### PR TITLE
feat: add Linux support

### DIFF
--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -29,7 +29,7 @@
   },
   "bundle": {
     "active": true,
-    "targets": ["dmg", "app"],
+    "targets": ["dmg", "app", "deb", "appimage"],
     "icon": [
       "icons/32x32.png",
       "icons/128x128.png",


### PR DESCRIPTION
Add Linux build targets (deb, AppImage) to tauri.conf.json
Add platform-conditional code in actions.rs using `#[cfg(target_os)]`
No changes to core session detection logic (already cross-platform)