### PR TITLE
ci: add Linux build support to release workflow and installer

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -81,8 +81,55 @@ jobs:
           path: src-tauri/target/${{ matrix.target }}/release/bundle/macos/*.app.tar.gz*
           if-no-files-found: ignore
 
+  build-linux:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+
+      - name: Install system dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y libwebkit2gtk-4.1-dev \
+            build-essential \
+            curl \
+            wget \
+            file \
+            libssl-dev \
+            libayatana-appindicator3-dev \
+            librsvg2-dev
+
+      - name: Install frontend dependencies
+        run: npm ci
+
+      - name: Install Tauri CLI
+        run: npm install -g @tauri-apps/cli@2
+
+      - name: Build Tauri app
+        run: npx tauri build
+
+      - name: Upload DEB
+        uses: actions/upload-artifact@v4
+        with:
+          name: linux-deb
+          path: src-tauri/target/release/bundle/deb/*.deb
+
+      - name: Upload AppImage
+        uses: actions/upload-artifact@v4
+        with:
+          name: linux-appimage
+          path: src-tauri/target/release/bundle/appimage/*.AppImage
+
   create-release:
-    needs: build-macos
+    needs: [build-macos, build-linux]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -144,4 +191,6 @@ jobs:
           files: |
             artifacts/macos-dmg-*/*.dmg
             artifacts/*.app.tar.gz
+            artifacts/linux-deb/*.deb
+            artifacts/linux-appimage/*.AppImage
             artifacts/latest.json

--- a/install.sh
+++ b/install.sh
@@ -6,9 +6,9 @@
 #   curl -fsSL https://raw.githubusercontent.com/minchenlee/c9watch/main/install.sh | bash
 #
 # This script:
-#   1. Detects your Mac's architecture (Apple Silicon or Intel)
-#   2. Downloads the latest signed DMG from GitHub
-#   3. Installs c9watch.app to /Applications
+#   1. Detects your OS and architecture
+#   2. Downloads the latest release from GitHub
+#   3. Installs c9watch (macOS: to /Applications, Linux: via package manager)
 #
 set -euo pipefail
 
@@ -21,21 +21,30 @@ INSTALL_DIR="/Applications"
 info()  { printf '\033[1;34m=>\033[0m %s\n' "$*"; }
 error() { printf '\033[1;31mError:\033[0m %s\n' "$*" >&2; exit 1; }
 
-# --- Detect architecture ---
+# --- Detect OS and architecture ---
 
+OS=$(uname -s)
 ARCH=$(uname -m)
+
 case "$ARCH" in
   arm64|aarch64) ARCH_LABEL="aarch64" ;;
   x86_64)        ARCH_LABEL="x86_64" ;;
   *)             error "Unsupported architecture: $ARCH" ;;
 esac
 
-OS=$(uname -s)
-if [ "$OS" != "Darwin" ]; then
-  error "c9watch is currently macOS-only. Detected OS: $OS"
-fi
-
-info "Detected macOS ($ARCH_LABEL)"
+case "$OS" in
+  Darwin)
+    PLATFORM="macos"
+    info "Detected macOS ($ARCH_LABEL)"
+    ;;
+  Linux)
+    PLATFORM="linux"
+    info "Detected Linux ($ARCH_LABEL)"
+    ;;
+  *)
+    error "Unsupported operating system: $OS"
+    ;;
+esac
 
 # --- Find latest release ---
 
@@ -52,49 +61,116 @@ fi
 
 info "Latest version: ${LATEST_TAG}"
 
-# --- Download ---
+# --- Platform-specific installation ---
 
-DOWNLOAD_URL="https://github.com/${REPO}/releases/download/${LATEST_TAG}/${APP_NAME}_${LATEST_TAG}_${ARCH_LABEL}.dmg"
-TMPDIR=$(mktemp -d)
-trap 'rm -rf "$TMPDIR"' EXIT
+if [ "$PLATFORM" = "macos" ]; then
+  # --- macOS: Download and install DMG ---
 
-info "Downloading ${APP_NAME} for ${ARCH_LABEL}..."
-curl -fSL --progress-bar "$DOWNLOAD_URL" -o "$TMPDIR/${APP_NAME}.dmg"
+  DOWNLOAD_URL="https://github.com/${REPO}/releases/download/${LATEST_TAG}/${APP_NAME}_${LATEST_TAG}_${ARCH_LABEL}.dmg"
+  TMPDIR=$(mktemp -d)
+  trap 'rm -rf "$TMPDIR"' EXIT
 
-# --- Mount and install ---
+  info "Downloading ${APP_NAME} for ${ARCH_LABEL}..."
+  curl -fSL --progress-bar "$DOWNLOAD_URL" -o "$TMPDIR/${APP_NAME}.dmg"
 
-info "Mounting DMG..."
-MOUNT_POINT=$(hdiutil attach "$TMPDIR/${APP_NAME}.dmg" -nobrowse -noverify | grep "/Volumes/" | tail -1 | awk '{print $3}')
+  info "Mounting DMG..."
+  MOUNT_POINT=$(hdiutil attach "$TMPDIR/${APP_NAME}.dmg" -nobrowse -noverify | grep "/Volumes/" | tail -1 | awk '{print $3}')
 
-if [ -z "$MOUNT_POINT" ]; then
-  error "Failed to mount DMG"
+  if [ -z "$MOUNT_POINT" ]; then
+    error "Failed to mount DMG"
+  fi
+
+  # Ensure we unmount on exit
+  trap 'hdiutil detach "$MOUNT_POINT" -quiet 2>/dev/null || true; rm -rf "$TMPDIR"' EXIT
+
+  # Find the .app bundle
+  APP_BUNDLE=$(find "$MOUNT_POINT" -maxdepth 1 -name "*.app" -type d | head -1)
+  if [ -z "$APP_BUNDLE" ]; then
+    error "No .app bundle found in DMG"
+  fi
+
+  APP_BASENAME=$(basename "$APP_BUNDLE")
+
+  # Remove old version if it exists
+  if [ -d "${INSTALL_DIR}/${APP_BASENAME}" ]; then
+    info "Removing previous installation..."
+    rm -rf "${INSTALL_DIR}/${APP_BASENAME}"
+  fi
+
+  info "Installing to ${INSTALL_DIR}/${APP_BASENAME}..."
+  cp -R "$APP_BUNDLE" "${INSTALL_DIR}/"
+
+  echo ""
+  info "c9watch has been installed to ${INSTALL_DIR}/${APP_BASENAME}"
+  info "You can launch it from Spotlight or by running:"
+  echo ""
+  echo "    open '${INSTALL_DIR}/${APP_BASENAME}'"
+  echo ""
+
+elif [ "$PLATFORM" = "linux" ]; then
+  # --- Linux: Download and install package ---
+
+  # Detect package format preference
+  if command -v dpkg &> /dev/null; then
+    PKG_FORMAT="deb"
+    PKG_EXT="deb"
+  else
+    PKG_FORMAT="appimage"
+    PKG_EXT="AppImage"
+  fi
+
+  # Construct download URL
+  if [ "$PKG_FORMAT" = "deb" ]; then
+    # DEB packages are usually named: c9watch_<version>_<arch>.deb
+    # But Tauri might generate different naming, so we'll try to fetch it
+    DOWNLOAD_URL="https://github.com/${REPO}/releases/download/${LATEST_TAG}/${APP_NAME}_${LATEST_TAG#v}_amd64.deb"
+  else
+    DOWNLOAD_URL="https://github.com/${REPO}/releases/download/${LATEST_TAG}/${APP_NAME}_${LATEST_TAG#v}_amd64.${PKG_EXT}"
+  fi
+
+  TMPDIR=$(mktemp -d)
+  trap 'rm -rf "$TMPDIR"' EXIT
+
+  info "Downloading ${APP_NAME} (${PKG_FORMAT})..."
+  PKG_FILE="$TMPDIR/${APP_NAME}.${PKG_EXT}"
+
+  if ! curl -fSL --progress-bar "$DOWNLOAD_URL" -o "$PKG_FILE"; then
+    error "Failed to download ${PKG_FORMAT} package. URL: ${DOWNLOAD_URL}"
+  fi
+
+  # Install based on package format
+  if [ "$PKG_FORMAT" = "deb" ]; then
+    info "Installing DEB package (requires sudo)..."
+    sudo dpkg -i "$PKG_FILE" || {
+      info "Fixing dependencies..."
+      sudo apt-get install -f -y
+    }
+    echo ""
+    info "c9watch has been installed successfully!"
+    info "Launch it with: c9watch"
+    echo ""
+  else
+    # AppImage installation
+    INSTALL_DIR="$HOME/.local/bin"
+    mkdir -p "$INSTALL_DIR"
+
+    INSTALL_PATH="$INSTALL_DIR/${APP_NAME}"
+
+    info "Installing AppImage to ${INSTALL_PATH}..."
+    cp "$PKG_FILE" "$INSTALL_PATH"
+    chmod +x "$INSTALL_PATH"
+
+    echo ""
+    info "c9watch has been installed to ${INSTALL_PATH}"
+    info "Make sure ${INSTALL_DIR} is in your PATH, then launch with: c9watch"
+    echo ""
+
+    # Check if in PATH
+    if [[ ":$PATH:" != *":$INSTALL_DIR:"* ]]; then
+      echo "To add ${INSTALL_DIR} to your PATH, add this to your shell rc file (~/.bashrc or ~/.zshrc):"
+      echo ""
+      echo "    export PATH=\"\$PATH:${INSTALL_DIR}\""
+      echo ""
+    fi
+  fi
 fi
-
-# Ensure we unmount on exit
-trap 'hdiutil detach "$MOUNT_POINT" -quiet 2>/dev/null || true; rm -rf "$TMPDIR"' EXIT
-
-# Find the .app bundle
-APP_BUNDLE=$(find "$MOUNT_POINT" -maxdepth 1 -name "*.app" -type d | head -1)
-if [ -z "$APP_BUNDLE" ]; then
-  error "No .app bundle found in DMG"
-fi
-
-APP_BASENAME=$(basename "$APP_BUNDLE")
-
-# Remove old version if it exists
-if [ -d "${INSTALL_DIR}/${APP_BASENAME}" ]; then
-  info "Removing previous installation..."
-  rm -rf "${INSTALL_DIR}/${APP_BASENAME}"
-fi
-
-info "Installing to ${INSTALL_DIR}/${APP_BASENAME}..."
-cp -R "$APP_BUNDLE" "${INSTALL_DIR}/"
-
-# --- Done ---
-
-echo ""
-info "c9watch has been installed to ${INSTALL_DIR}/${APP_BASENAME}"
-info "You can launch it from Spotlight or by running:"
-echo ""
-echo "    open '${INSTALL_DIR}/${APP_BASENAME}'"
-echo ""


### PR DESCRIPTION
## Summary

This PR adds comprehensive Linux support to the CI/CD pipeline and installation process, complementing the Linux runtime support added in #2 (commit c7dc27f).

## Changes

### GitHub Actions Workflow (`.github/workflows/release.yml`)
- Added `build-linux` job that runs on `ubuntu-latest`
- Installs required Tauri system dependencies:
  - `libwebkit2gtk-4.1-dev` (WebKit rendering)
  - `libayatana-appindicator3-dev` (system tray support)
  - `librsvg2-dev` (SVG support)
  - Other build essentials
- Builds both DEB and AppImage packages
- Uploads Linux artifacts alongside macOS builds
- Updates `create-release` job to include Linux packages

### Install Script (`install.sh`)
- Added cross-platform OS detection (macOS and Linux)
- **Linux support:**
  - Auto-detects package format (DEB if `dpkg` available, otherwise AppImage)
  - **DEB**: Installs via `dpkg` with automatic dependency resolution (`apt-get install -f`)
  - **AppImage**: Installs to `~/.local/bin` with PATH setup instructions
- Maintains existing macOS DMG installation flow unchanged
- Provides clear user feedback for each platform

## Test Plan

- [ ] Verify GitHub Actions workflow builds successfully on push to tag
- [ ] Test DEB package installation on Ubuntu/Debian
- [ ] Test AppImage installation on non-Debian Linux distributions
- [ ] Verify macOS installation remains unchanged
- [ ] Check that release artifacts include both Linux packages

## Related

- Closes/Related to #2 (Linux runtime support)
- Builds on commit c7dc27f

🤖 Generated with [Claude Code](https://claude.com/claude-code)