### PR TITLE
fix: solve clippy warnings and apply rustfmt

### DIFF
--- a/src-tauri/examples/test_parser.rs
+++ b/src-tauri/examples/test_parser.rs
@@ -2,9 +2,7 @@ use std::env;
 use std::path::PathBuf;
 
 // Import from the library
-use c9watch_lib::session::{
-    parse_sessions_index, parse_last_n_entries, extract_messages,
-};
+use c9watch_lib::session::{extract_messages, parse_last_n_entries, parse_sessions_index};
 
 fn main() {
     let home = env::var("HOME").expect("HOME env var not set");

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -4,8 +4,8 @@ pub mod session;
 
 use actions::{open_session as open_session_action, stop_session as stop_session_action};
 use polling::{detect_and_enrich_sessions, start_polling, Session};
-use session::{extract_messages, parse_all_entries, MessageType};
 use serde::Serialize;
+use session::{extract_messages, parse_all_entries, MessageType};
 use std::time::Duration;
 use tauri::{
     tray::{MouseButton, MouseButtonState, TrayIconBuilder, TrayIconEvent},
@@ -70,7 +70,10 @@ async fn get_conversation(session_id: String) -> Result<Conversation, String> {
         }
     }
 
-    Err(format!("Session {} not found in any project directory", session_id))
+    Err(format!(
+        "Session {} not found in any project directory",
+        session_id
+    ))
 }
 
 /// Stop a session by process ID
@@ -98,7 +101,11 @@ async fn open_session(pid: u32, project_path: String) -> Result<(), String> {
 
 /// Rename a session title
 #[tauri::command]
-async fn rename_session(app: AppHandle, session_id: String, new_name: String) -> Result<(), String> {
+async fn rename_session(
+    app: AppHandle,
+    session_id: String,
+    new_name: String,
+) -> Result<(), String> {
     let mut custom_titles = session::CustomTitles::load();
     custom_titles.set(session_id, new_name);
     custom_titles.save()?;

--- a/src-tauri/src/session/detector.rs
+++ b/src-tauri/src/session/detector.rs
@@ -44,8 +44,7 @@ pub struct SessionDetector {
 impl SessionDetector {
     /// Creates a new SessionDetector
     pub fn new() -> Result<Self, SessionDetectorError> {
-        let home_dir = dirs::home_dir()
-            .ok_or(SessionDetectorError::HomeDirectoryNotFound)?;
+        let home_dir = dirs::home_dir().ok_or(SessionDetectorError::HomeDirectoryNotFound)?;
 
         let claude_projects_dir = home_dir.join(".claude").join("projects");
 
@@ -86,7 +85,14 @@ impl SessionDetector {
     ) -> Vec<DetectedSession> {
         // Collect all session files with their modification times and project path
         // Tuple: (modified_time, jsonl_path, project_dir, project_path, project_name, has_reliable_path)
-        let mut session_files: Vec<(std::time::SystemTime, PathBuf, PathBuf, PathBuf, String, bool)> = Vec::new();
+        let mut session_files: Vec<(
+            std::time::SystemTime,
+            PathBuf,
+            PathBuf,
+            PathBuf,
+            String,
+            bool,
+        )> = Vec::new();
 
         for project_dir in project_dirs {
             if let Ok(entries) = fs::read_dir(project_dir) {
@@ -94,9 +100,7 @@ impl SessionDetector {
                     let path = entry.path();
 
                     // Check if it's a JSONL file (UUID format, not subagent files)
-                    if path.is_file()
-                        && path.extension().map_or(false, |ext| ext == "jsonl")
-                    {
+                    if path.is_file() && path.extension().is_some_and(|ext| ext == "jsonl") {
                         // Skip files that don't look like UUIDs (e.g., agent-*.jsonl)
                         if let Some(stem) = path.file_stem().and_then(|s| s.to_str()) {
                             if stem.starts_with("agent-") {
@@ -107,31 +111,37 @@ impl SessionDetector {
                         if let Ok(metadata) = fs::metadata(&path) {
                             if let Ok(modified) = metadata.modified() {
                                 // Get session ID and project info
-                                if let Some(session_id) = path.file_stem()
+                                if let Some(session_id) = path
+                                    .file_stem()
                                     .and_then(|s| s.to_str())
                                     .map(|s| s.to_string())
                                 {
                                     // Try to get project info from sessions-index.json
                                     // This is the ONLY reliable source of project path
-                                    let (project_path, project_name, has_reliable_path) =
-                                        match self.get_project_info_from_index(project_dir, &session_id) {
-                                            Some((path, name)) => (path, name, true),
-                                            None => {
-                                                // No reliable path available - use directory name as display only
-                                                // Don't try to decode it (decoding is ambiguous due to dashes)
-                                                let dir_name = project_dir
-                                                    .file_name()
-                                                    .and_then(|n| n.to_str())
-                                                    .unwrap_or("unknown");
+                                    let (project_path, project_name, has_reliable_path) = match self
+                                        .get_project_info_from_index(project_dir, &session_id)
+                                    {
+                                        Some((path, name)) => (path, name, true),
+                                        None => {
+                                            // No reliable path available - use directory name as display only
+                                            // Don't try to decode it (decoding is ambiguous due to dashes)
+                                            let dir_name = project_dir
+                                                .file_name()
+                                                .and_then(|n| n.to_str())
+                                                .unwrap_or("unknown");
 
-                                                // Just use the last segment after splitting on dash as a rough name
-                                                // This is for display only, not for matching
-                                                let name = dir_name.rsplit('-').next().unwrap_or("unknown").to_string();
+                                            // Just use the last segment after splitting on dash as a rough name
+                                            // This is for display only, not for matching
+                                            let name = dir_name
+                                                .rsplit('-')
+                                                .next()
+                                                .unwrap_or("unknown")
+                                                .to_string();
 
-                                                // Use the project_dir as a placeholder (will use fallback PID assignment)
-                                                (project_dir.clone(), name, false)
-                                            }
-                                        };
+                                            // Use the project_dir as a placeholder (will use fallback PID assignment)
+                                            (project_dir.clone(), name, false)
+                                        }
+                                    };
 
                                     session_files.push((
                                         modified,
@@ -155,7 +165,8 @@ impl SessionDetector {
         // Process-centric approach: for each process, find its matching session
         // This ensures we only show sessions that have actual running processes
         let mut sessions = Vec::new();
-        let mut used_session_ids: std::collections::HashSet<String> = std::collections::HashSet::new();
+        let mut used_session_ids: std::collections::HashSet<String> =
+            std::collections::HashSet::new();
 
         // Sort processes by start_time (newest first) to match newest processes first
         let mut sorted_processes: Vec<&ClaudeProcess> = processes.iter().collect();
@@ -169,28 +180,28 @@ impl SessionDetector {
 
             // Encode the process cwd for matching
             let cwd_str = proc_cwd.to_string_lossy();
-            let encoded_cwd = cwd_str.replace('/', "-").replace('_', "-");
+            let encoded_cwd = cwd_str.replace(['/', '_'], "-");
 
             // Helper closure to check if a session matches the process path
-            let path_matches = |project_dir: &Path, project_path: &Path, has_reliable_path: bool| -> bool {
-                let dir_name = project_dir
-                    .file_name()
-                    .and_then(|n| n.to_str())
-                    .unwrap_or("");
+            let path_matches =
+                |project_dir: &Path, project_path: &Path, has_reliable_path: bool| -> bool {
+                    let dir_name = project_dir
+                        .file_name()
+                        .and_then(|n| n.to_str())
+                        .unwrap_or("");
 
-                // Method 1: Direct path comparison (exact or subdirectory match)
-                let direct_match = if has_reliable_path {
-                    proc_cwd == project_path
-                        || proc_cwd.starts_with(project_path)
-                } else {
-                    false
+                    // Method 1: Direct path comparison (exact or subdirectory match)
+                    let direct_match = if has_reliable_path {
+                        proc_cwd == project_path || proc_cwd.starts_with(project_path)
+                    } else {
+                        false
+                    };
+
+                    // Method 2: Encoded path comparison
+                    let encoded_match = dir_name == encoded_cwd;
+
+                    direct_match || encoded_match
                 };
-
-                // Method 2: Encoded path comparison
-                let encoded_match = dir_name == encoded_cwd;
-
-                direct_match || encoded_match
-            };
 
             // Helper closure to check if session is not already used
             let session_available = |path: &Path| -> bool {
@@ -204,26 +215,31 @@ impl SessionDetector {
             // Only match sessions that were modified AFTER the process started
             // This prevents matching a new Claude instance (with no session file yet)
             // to an older session from the same project directory
-            let matching_session = session_files.iter().find(|(modified, path, project_dir, project_path, _, has_reliable_path)| {
-                if !session_available(path) {
-                    return false;
-                }
-
-                // Check if the session was modified after the process started
-                let session_active_after_proc_start = match modified.duration_since(std::time::UNIX_EPOCH) {
-                    Ok(duration) => {
-                        let session_modified_secs = duration.as_secs();
-                        // Session must have been modified at or after process start (with 5s buffer)
-                        session_modified_secs + 5 >= proc.start_time
+            let matching_session = session_files.iter().find(
+                |(modified, path, project_dir, project_path, _, has_reliable_path)| {
+                    if !session_available(path) {
+                        return false;
                     }
-                    Err(_) => false,
-                };
 
-                session_active_after_proc_start && path_matches(project_dir, project_path, *has_reliable_path)
-            });
+                    // Check if the session was modified after the process started
+                    let session_active_after_proc_start =
+                        match modified.duration_since(std::time::UNIX_EPOCH) {
+                            Ok(duration) => {
+                                let session_modified_secs = duration.as_secs();
+                                // Session must have been modified at or after process start (with 5s buffer)
+                                session_modified_secs + 5 >= proc.start_time
+                            }
+                            Err(_) => false,
+                        };
+
+                    session_active_after_proc_start
+                        && path_matches(project_dir, project_path, *has_reliable_path)
+                },
+            );
 
             if let Some((_, path, project_dir, _, project_name, _)) = matching_session {
-                if let Some(session_id) = path.file_stem()
+                if let Some(session_id) = path
+                    .file_stem()
                     .and_then(|s| s.to_str())
                     .map(|s| s.to_string())
                 {
@@ -335,7 +351,6 @@ impl SessionDetector {
 
         Ok(project_dirs)
     }
-
 }
 
 impl Default for SessionDetector {

--- a/src-tauri/src/session/status.rs
+++ b/src-tauri/src/session/status.rs
@@ -1,8 +1,8 @@
-use serde::{Deserialize, Serialize};
-use chrono::{DateTime, Utc};
-use std::sync::OnceLock;
-use super::parser::{SessionEntry, MessageContent, AssistantMessage};
+use super::parser::{AssistantMessage, MessageContent, SessionEntry};
 use super::permissions::PermissionChecker;
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
+use std::sync::OnceLock;
 
 /// Global permission checker (loaded once from settings)
 static PERMISSION_CHECKER: OnceLock<PermissionChecker> = OnceLock::new();
@@ -46,7 +46,10 @@ pub fn determine_status(entries: &[SessionEntry]) -> SessionStatus {
     // Claude Code writes "progress" entries during tool execution (e.g., bash_progress)
     // which must not override the actual session status.
     let last_meaningful = entries.iter().rev().find(|entry| {
-        matches!(entry, SessionEntry::User { .. } | SessionEntry::Assistant { .. })
+        matches!(
+            entry,
+            SessionEntry::User { .. } | SessionEntry::Assistant { .. }
+        )
     });
 
     let last_entry = match last_meaningful {
@@ -56,12 +59,18 @@ pub fn determine_status(entries: &[SessionEntry]) -> SessionStatus {
 
     // Also check if there are any recent progress entries AFTER the last meaningful entry.
     // Progress entries (e.g., bash_progress) indicate active tool execution.
-    let last_meaningful_idx = entries.iter().rposition(|entry| {
-        matches!(entry, SessionEntry::User { .. } | SessionEntry::Assistant { .. })
-    }).unwrap_or(0);
-    let has_trailing_progress = entries[last_meaningful_idx + 1..].iter().any(|entry| {
-        matches!(entry, SessionEntry::Unknown)
-    });
+    let last_meaningful_idx = entries
+        .iter()
+        .rposition(|entry| {
+            matches!(
+                entry,
+                SessionEntry::User { .. } | SessionEntry::Assistant { .. }
+            )
+        })
+        .unwrap_or(0);
+    let has_trailing_progress = entries[last_meaningful_idx + 1..]
+        .iter()
+        .any(|entry| matches!(entry, SessionEntry::Unknown));
 
     match last_entry {
         SessionEntry::User { base, message } => {
@@ -145,9 +154,10 @@ fn is_entry_recent(timestamp: &str, seconds: i64) -> bool {
 /// Analyzes an assistant message to determine status
 fn analyze_assistant_message(message: &AssistantMessage) -> SessionStatus {
     // Check if the message contains any tool uses
-    let has_tool_use = message.content.iter().any(|content| {
-        matches!(content, MessageContent::ToolUse { .. })
-    });
+    let has_tool_use = message
+        .content
+        .iter()
+        .any(|content| matches!(content, MessageContent::ToolUse { .. }));
 
     if has_tool_use {
         // Check if all tool uses have corresponding results
@@ -254,7 +264,8 @@ pub fn get_pending_tool_name(entries: &[SessionEntry]) -> Option<String> {
     let checker = get_permission_checker();
 
     // Get IDs of tools that have results
-    let completed_ids: Vec<&str> = last_assistant.content
+    let completed_ids: Vec<&str> = last_assistant
+        .content
         .iter()
         .filter_map(|c| {
             if let MessageContent::ToolResult { tool_use_id, .. } = c {
@@ -348,14 +359,18 @@ pub fn determine_status_with_context(entries: &[SessionEntry]) -> SessionStatus 
         let prev_entry = &entries[entries.len() - 2];
 
         if let (
-            SessionEntry::Assistant { message: last_msg, .. },
+            SessionEntry::Assistant {
+                message: last_msg, ..
+            },
             SessionEntry::Assistant { .. },
-        ) = (last_entry, prev_entry) {
+        ) = (last_entry, prev_entry)
+        {
             // If both are assistant messages and last one has no tool use,
             // might be waiting for input
-            let last_has_tools = last_msg.content.iter().any(|c| {
-                matches!(c, MessageContent::ToolUse { .. })
-            });
+            let last_has_tools = last_msg
+                .content
+                .iter()
+                .any(|c| matches!(c, MessageContent::ToolUse { .. }));
 
             if !last_has_tools && last_msg.stop_reason.is_some() {
                 return SessionStatus::WaitingForInput;
@@ -410,257 +425,231 @@ mod tests {
 
     #[test]
     fn test_user_message_means_working() {
-        let entries = vec![
-            SessionEntry::User {
-                base: create_base(),
-                message: UserMessage {
-                    role: "user".to_string(),
-                    content: "Hello".to_string(),
-                    is_tool_result: false,
-                },
-            }
-        ];
+        let entries = vec![SessionEntry::User {
+            base: create_base(),
+            message: UserMessage {
+                role: "user".to_string(),
+                content: "Hello".to_string(),
+                is_tool_result: false,
+            },
+        }];
         assert_eq!(determine_status(&entries), SessionStatus::Working);
     }
 
     #[test]
     fn test_assistant_text_completed() {
         // Old entry with end_turn should be WaitingForInput
-        let entries = vec![
-            SessionEntry::Assistant {
-                base: create_old_base(),
-                message: AssistantMessage {
-                    model: "claude-opus-4-5-20251101".to_string(),
-                    id: "msg_test".to_string(),
-                    role: "assistant".to_string(),
-                    content: vec![
-                        MessageContent::Text {
-                            text: "Hello there!".to_string(),
-                        }
-                    ],
-                    stop_reason: Some("end_turn".to_string()),
-                    stop_sequence: None,
-                    usage: None,
-                },
-            }
-        ];
+        let entries = vec![SessionEntry::Assistant {
+            base: create_old_base(),
+            message: AssistantMessage {
+                model: "claude-opus-4-5-20251101".to_string(),
+                id: "msg_test".to_string(),
+                role: "assistant".to_string(),
+                content: vec![MessageContent::Text {
+                    text: "Hello there!".to_string(),
+                }],
+                stop_reason: Some("end_turn".to_string()),
+                stop_sequence: None,
+                usage: None,
+            },
+        }];
         assert_eq!(determine_status(&entries), SessionStatus::WaitingForInput);
     }
 
     #[test]
     fn test_assistant_generating() {
-        let entries = vec![
-            SessionEntry::Assistant {
-                base: create_base(),
-                message: AssistantMessage {
-                    model: "claude-opus-4-5-20251101".to_string(),
-                    id: "msg_test".to_string(),
-                    role: "assistant".to_string(),
-                    content: vec![
-                        MessageContent::Text {
-                            text: "Thinking...".to_string(),
-                        }
-                    ],
-                    stop_reason: None,
-                    stop_sequence: None,
-                    usage: None,
-                },
-            }
-        ];
+        let entries = vec![SessionEntry::Assistant {
+            base: create_base(),
+            message: AssistantMessage {
+                model: "claude-opus-4-5-20251101".to_string(),
+                id: "msg_test".to_string(),
+                role: "assistant".to_string(),
+                content: vec![MessageContent::Text {
+                    text: "Thinking...".to_string(),
+                }],
+                stop_reason: None,
+                stop_sequence: None,
+                usage: None,
+            },
+        }];
         assert_eq!(determine_status(&entries), SessionStatus::Working);
     }
 
     #[test]
     fn test_tool_use_pending_auto_approved() {
         // Read is auto-approved, so pending Read should be Working
-        let entries = vec![
-            SessionEntry::Assistant {
-                base: create_base(),
-                message: AssistantMessage {
-                    model: "claude-opus-4-5-20251101".to_string(),
-                    id: "msg_test".to_string(),
-                    role: "assistant".to_string(),
-                    content: vec![
-                        MessageContent::ToolUse {
-                            id: "toolu_123".to_string(),
-                            name: "Read".to_string(),
-                            input: serde_json::json!({"file_path": "/test/file.txt"}),
-                        }
-                    ],
-                    stop_reason: Some("tool_use".to_string()),
-                    stop_sequence: None,
-                    usage: None,
-                },
-            }
-        ];
+        let entries = vec![SessionEntry::Assistant {
+            base: create_base(),
+            message: AssistantMessage {
+                model: "claude-opus-4-5-20251101".to_string(),
+                id: "msg_test".to_string(),
+                role: "assistant".to_string(),
+                content: vec![MessageContent::ToolUse {
+                    id: "toolu_123".to_string(),
+                    name: "Read".to_string(),
+                    input: serde_json::json!({"file_path": "/test/file.txt"}),
+                }],
+                stop_reason: Some("tool_use".to_string()),
+                stop_sequence: None,
+                usage: None,
+            },
+        }];
         assert_eq!(determine_status(&entries), SessionStatus::Working);
     }
 
     #[test]
     fn test_tool_use_pending_needs_permission() {
         // Bash with unknown command needs permission
-        let entries = vec![
-            SessionEntry::Assistant {
-                base: create_base(),
-                message: AssistantMessage {
-                    model: "claude-opus-4-5-20251101".to_string(),
-                    id: "msg_test".to_string(),
-                    role: "assistant".to_string(),
-                    content: vec![
-                        MessageContent::ToolUse {
-                            id: "toolu_123".to_string(),
-                            name: "Bash".to_string(),
-                            input: serde_json::json!({"command": "rm -rf /some/path"}),
-                        }
-                    ],
-                    stop_reason: Some("tool_use".to_string()),
-                    stop_sequence: None,
-                    usage: None,
-                },
-            }
-        ];
+        let entries = vec![SessionEntry::Assistant {
+            base: create_base(),
+            message: AssistantMessage {
+                model: "claude-opus-4-5-20251101".to_string(),
+                id: "msg_test".to_string(),
+                role: "assistant".to_string(),
+                content: vec![MessageContent::ToolUse {
+                    id: "toolu_123".to_string(),
+                    name: "Bash".to_string(),
+                    input: serde_json::json!({"command": "rm -rf /some/path"}),
+                }],
+                stop_reason: Some("tool_use".to_string()),
+                stop_sequence: None,
+                usage: None,
+            },
+        }];
         assert_eq!(determine_status(&entries), SessionStatus::NeedsPermission);
     }
 
     #[test]
     fn test_tool_use_completed() {
-        let entries = vec![
-            SessionEntry::Assistant {
-                base: create_base(),
-                message: AssistantMessage {
-                    model: "claude-opus-4-5-20251101".to_string(),
-                    id: "msg_test".to_string(),
-                    role: "assistant".to_string(),
-                    content: vec![
-                        MessageContent::ToolUse {
-                            id: "toolu_123".to_string(),
-                            name: "Read".to_string(),
-                            input: serde_json::json!({"file_path": "/test/file.txt"}),
-                        },
-                        MessageContent::ToolResult {
-                            tool_use_id: "toolu_123".to_string(),
-                            content: "File content here".to_string(),
-                            is_error: Some(false),
-                        }
-                    ],
-                    stop_reason: Some("end_turn".to_string()),
-                    stop_sequence: None,
-                    usage: None,
-                },
-            }
-        ];
+        let entries = vec![SessionEntry::Assistant {
+            base: create_base(),
+            message: AssistantMessage {
+                model: "claude-opus-4-5-20251101".to_string(),
+                id: "msg_test".to_string(),
+                role: "assistant".to_string(),
+                content: vec![
+                    MessageContent::ToolUse {
+                        id: "toolu_123".to_string(),
+                        name: "Read".to_string(),
+                        input: serde_json::json!({"file_path": "/test/file.txt"}),
+                    },
+                    MessageContent::ToolResult {
+                        tool_use_id: "toolu_123".to_string(),
+                        content: "File content here".to_string(),
+                        is_error: Some(false),
+                    },
+                ],
+                stop_reason: Some("end_turn".to_string()),
+                stop_sequence: None,
+                usage: None,
+            },
+        }];
         assert_eq!(determine_status(&entries), SessionStatus::WaitingForInput);
     }
 
     #[test]
     fn test_multiple_tools_partially_completed_auto_approved() {
         // Both tools are Read (auto-approved), so even partial = Working
-        let entries = vec![
-            SessionEntry::Assistant {
-                base: create_base(),
-                message: AssistantMessage {
-                    model: "claude-opus-4-5-20251101".to_string(),
-                    id: "msg_test".to_string(),
-                    role: "assistant".to_string(),
-                    content: vec![
-                        MessageContent::ToolUse {
-                            id: "toolu_123".to_string(),
-                            name: "Read".to_string(),
-                            input: serde_json::json!({"file_path": "/test/file1.txt"}),
-                        },
-                        MessageContent::ToolUse {
-                            id: "toolu_456".to_string(),
-                            name: "Read".to_string(),
-                            input: serde_json::json!({"file_path": "/test/file2.txt"}),
-                        },
-                        MessageContent::ToolResult {
-                            tool_use_id: "toolu_123".to_string(),
-                            content: "File 1 content".to_string(),
-                            is_error: Some(false),
-                        }
-                    ],
-                    stop_reason: Some("tool_use".to_string()),
-                    stop_sequence: None,
-                    usage: None,
-                },
-            }
-        ];
+        let entries = vec![SessionEntry::Assistant {
+            base: create_base(),
+            message: AssistantMessage {
+                model: "claude-opus-4-5-20251101".to_string(),
+                id: "msg_test".to_string(),
+                role: "assistant".to_string(),
+                content: vec![
+                    MessageContent::ToolUse {
+                        id: "toolu_123".to_string(),
+                        name: "Read".to_string(),
+                        input: serde_json::json!({"file_path": "/test/file1.txt"}),
+                    },
+                    MessageContent::ToolUse {
+                        id: "toolu_456".to_string(),
+                        name: "Read".to_string(),
+                        input: serde_json::json!({"file_path": "/test/file2.txt"}),
+                    },
+                    MessageContent::ToolResult {
+                        tool_use_id: "toolu_123".to_string(),
+                        content: "File 1 content".to_string(),
+                        is_error: Some(false),
+                    },
+                ],
+                stop_reason: Some("tool_use".to_string()),
+                stop_sequence: None,
+                usage: None,
+            },
+        }];
         assert_eq!(determine_status(&entries), SessionStatus::Working);
     }
 
     #[test]
     fn test_multiple_tools_partially_completed_needs_permission() {
         // One Read (auto) completed, one Bash (needs permission) pending
-        let entries = vec![
-            SessionEntry::Assistant {
-                base: create_base(),
-                message: AssistantMessage {
-                    model: "claude-opus-4-5-20251101".to_string(),
-                    id: "msg_test".to_string(),
-                    role: "assistant".to_string(),
-                    content: vec![
-                        MessageContent::ToolUse {
-                            id: "toolu_123".to_string(),
-                            name: "Read".to_string(),
-                            input: serde_json::json!({"file_path": "/test/file1.txt"}),
-                        },
-                        MessageContent::ToolUse {
-                            id: "toolu_456".to_string(),
-                            name: "Bash".to_string(),
-                            input: serde_json::json!({"command": "make build"}),
-                        },
-                        MessageContent::ToolResult {
-                            tool_use_id: "toolu_123".to_string(),
-                            content: "File 1 content".to_string(),
-                            is_error: Some(false),
-                        }
-                    ],
-                    stop_reason: Some("tool_use".to_string()),
-                    stop_sequence: None,
-                    usage: None,
-                },
-            }
-        ];
+        let entries = vec![SessionEntry::Assistant {
+            base: create_base(),
+            message: AssistantMessage {
+                model: "claude-opus-4-5-20251101".to_string(),
+                id: "msg_test".to_string(),
+                role: "assistant".to_string(),
+                content: vec![
+                    MessageContent::ToolUse {
+                        id: "toolu_123".to_string(),
+                        name: "Read".to_string(),
+                        input: serde_json::json!({"file_path": "/test/file1.txt"}),
+                    },
+                    MessageContent::ToolUse {
+                        id: "toolu_456".to_string(),
+                        name: "Bash".to_string(),
+                        input: serde_json::json!({"command": "make build"}),
+                    },
+                    MessageContent::ToolResult {
+                        tool_use_id: "toolu_123".to_string(),
+                        content: "File 1 content".to_string(),
+                        is_error: Some(false),
+                    },
+                ],
+                stop_reason: Some("tool_use".to_string()),
+                stop_sequence: None,
+                usage: None,
+            },
+        }];
         assert_eq!(determine_status(&entries), SessionStatus::NeedsPermission);
     }
 
     #[test]
     fn test_multiple_tools_all_completed() {
-        let entries = vec![
-            SessionEntry::Assistant {
-                base: create_base(),
-                message: AssistantMessage {
-                    model: "claude-opus-4-5-20251101".to_string(),
-                    id: "msg_test".to_string(),
-                    role: "assistant".to_string(),
-                    content: vec![
-                        MessageContent::ToolUse {
-                            id: "toolu_123".to_string(),
-                            name: "Read".to_string(),
-                            input: serde_json::json!({"file_path": "/test/file1.txt"}),
-                        },
-                        MessageContent::ToolUse {
-                            id: "toolu_456".to_string(),
-                            name: "Read".to_string(),
-                            input: serde_json::json!({"file_path": "/test/file2.txt"}),
-                        },
-                        MessageContent::ToolResult {
-                            tool_use_id: "toolu_123".to_string(),
-                            content: "File 1 content".to_string(),
-                            is_error: Some(false),
-                        },
-                        MessageContent::ToolResult {
-                            tool_use_id: "toolu_456".to_string(),
-                            content: "File 2 content".to_string(),
-                            is_error: Some(false),
-                        }
-                    ],
-                    stop_reason: Some("end_turn".to_string()),
-                    stop_sequence: None,
-                    usage: None,
-                },
-            }
-        ];
+        let entries = vec![SessionEntry::Assistant {
+            base: create_base(),
+            message: AssistantMessage {
+                model: "claude-opus-4-5-20251101".to_string(),
+                id: "msg_test".to_string(),
+                role: "assistant".to_string(),
+                content: vec![
+                    MessageContent::ToolUse {
+                        id: "toolu_123".to_string(),
+                        name: "Read".to_string(),
+                        input: serde_json::json!({"file_path": "/test/file1.txt"}),
+                    },
+                    MessageContent::ToolUse {
+                        id: "toolu_456".to_string(),
+                        name: "Read".to_string(),
+                        input: serde_json::json!({"file_path": "/test/file2.txt"}),
+                    },
+                    MessageContent::ToolResult {
+                        tool_use_id: "toolu_123".to_string(),
+                        content: "File 1 content".to_string(),
+                        is_error: Some(false),
+                    },
+                    MessageContent::ToolResult {
+                        tool_use_id: "toolu_456".to_string(),
+                        content: "File 2 content".to_string(),
+                        is_error: Some(false),
+                    },
+                ],
+                stop_reason: Some("end_turn".to_string()),
+                stop_sequence: None,
+                usage: None,
+            },
+        }];
         assert_eq!(determine_status(&entries), SessionStatus::WaitingForInput);
     }
 
@@ -676,17 +665,15 @@ mod tests {
                 tool_use_id: "toolu_1".to_string(),
                 content: "result".to_string(),
                 is_error: None,
-            }
+            },
         ];
         assert!(check_all_tools_completed(&content));
 
-        let incomplete_content = vec![
-            MessageContent::ToolUse {
-                id: "toolu_1".to_string(),
-                name: "Read".to_string(),
-                input: serde_json::json!({}),
-            }
-        ];
+        let incomplete_content = vec![MessageContent::ToolUse {
+            id: "toolu_1".to_string(),
+            name: "Read".to_string(),
+            input: serde_json::json!({}),
+        }];
         assert!(!check_all_tools_completed(&incomplete_content));
     }
 
@@ -701,13 +688,11 @@ mod tests {
                     model: "claude-opus-4-5-20251101".to_string(),
                     id: "msg_test".to_string(),
                     role: "assistant".to_string(),
-                    content: vec![
-                        MessageContent::ToolUse {
-                            id: "toolu_123".to_string(),
-                            name: "Bash".to_string(),
-                            input: serde_json::json!({"command": "rm -rf /dangerous"}),
-                        }
-                    ],
+                    content: vec![MessageContent::ToolUse {
+                        id: "toolu_123".to_string(),
+                        name: "Bash".to_string(),
+                        input: serde_json::json!({"command": "rm -rf /dangerous"}),
+                    }],
                     stop_reason: Some("tool_use".to_string()),
                     stop_sequence: None,
                     usage: None,
@@ -745,10 +730,7 @@ mod tests {
     #[test]
     fn test_only_unknown_entries_means_connecting() {
         // If all entries are Unknown (e.g., all progress), treat as Connecting
-        let entries = vec![
-            SessionEntry::Unknown,
-            SessionEntry::Unknown,
-        ];
+        let entries = vec![SessionEntry::Unknown, SessionEntry::Unknown];
         assert_eq!(determine_status(&entries), SessionStatus::Connecting);
     }
 
@@ -756,24 +738,20 @@ mod tests {
     fn test_old_assistant_text_no_stop_reason_is_idle() {
         // Realistic scenario: stop_reason is always None in Claude Code JSONL.
         // An old text-only assistant message with no stop_reason should be idle.
-        let entries = vec![
-            SessionEntry::Assistant {
-                base: create_old_base(),
-                message: AssistantMessage {
-                    model: "claude-opus-4-5-20251101".to_string(),
-                    id: "msg_test".to_string(),
-                    role: "assistant".to_string(),
-                    content: vec![
-                        MessageContent::Text {
-                            text: "Here's my response.".to_string(),
-                        }
-                    ],
-                    stop_reason: None,
-                    stop_sequence: None,
-                    usage: None,
-                },
-            }
-        ];
+        let entries = vec![SessionEntry::Assistant {
+            base: create_old_base(),
+            message: AssistantMessage {
+                model: "claude-opus-4-5-20251101".to_string(),
+                id: "msg_test".to_string(),
+                role: "assistant".to_string(),
+                content: vec![MessageContent::Text {
+                    text: "Here's my response.".to_string(),
+                }],
+                stop_reason: None,
+                stop_sequence: None,
+                usage: None,
+            },
+        }];
         assert_eq!(determine_status(&entries), SessionStatus::WaitingForInput);
     }
 
@@ -781,147 +759,127 @@ mod tests {
     fn test_recent_assistant_text_no_stop_reason_is_working() {
         // Recent text-only assistant message with no stop_reason means
         // Claude is still actively streaming / generating
-        let entries = vec![
-            SessionEntry::Assistant {
-                base: create_base(),
-                message: AssistantMessage {
-                    model: "claude-opus-4-5-20251101".to_string(),
-                    id: "msg_test".to_string(),
-                    role: "assistant".to_string(),
-                    content: vec![
-                        MessageContent::Text {
-                            text: "Working on it...".to_string(),
-                        }
-                    ],
-                    stop_reason: None,
-                    stop_sequence: None,
-                    usage: None,
-                },
-            }
-        ];
+        let entries = vec![SessionEntry::Assistant {
+            base: create_base(),
+            message: AssistantMessage {
+                model: "claude-opus-4-5-20251101".to_string(),
+                id: "msg_test".to_string(),
+                role: "assistant".to_string(),
+                content: vec![MessageContent::Text {
+                    text: "Working on it...".to_string(),
+                }],
+                stop_reason: None,
+                stop_sequence: None,
+                usage: None,
+            },
+        }];
         assert_eq!(determine_status(&entries), SessionStatus::Working);
     }
 
     #[test]
     fn test_old_user_prompt_is_idle() {
         // A user prompt from long ago with no response should be idle
-        let entries = vec![
-            SessionEntry::User {
-                base: create_old_base(),
-                message: UserMessage {
-                    role: "user".to_string(),
-                    content: "Hello".to_string(),
-                    is_tool_result: false,
-                },
-            }
-        ];
+        let entries = vec![SessionEntry::User {
+            base: create_old_base(),
+            message: UserMessage {
+                role: "user".to_string(),
+                content: "Hello".to_string(),
+                is_tool_result: false,
+            },
+        }];
         assert_eq!(determine_status(&entries), SessionStatus::WaitingForInput);
     }
 
     #[test]
     fn test_get_pending_tool_name_needs_permission() {
         // Bash command that needs permission
-        let entries = vec![
-            SessionEntry::Assistant {
-                base: create_base(),
-                message: AssistantMessage {
-                    model: "claude-opus-4-5-20251101".to_string(),
-                    id: "msg_test".to_string(),
-                    role: "assistant".to_string(),
-                    content: vec![
-                        MessageContent::ToolUse {
-                            id: "toolu_123".to_string(),
-                            name: "Bash".to_string(),
-                            input: serde_json::json!({"command": "rm -rf /some/path"}),
-                        }
-                    ],
-                    stop_reason: Some("tool_use".to_string()),
-                    stop_sequence: None,
-                    usage: None,
-                },
-            }
-        ];
+        let entries = vec![SessionEntry::Assistant {
+            base: create_base(),
+            message: AssistantMessage {
+                model: "claude-opus-4-5-20251101".to_string(),
+                id: "msg_test".to_string(),
+                role: "assistant".to_string(),
+                content: vec![MessageContent::ToolUse {
+                    id: "toolu_123".to_string(),
+                    name: "Bash".to_string(),
+                    input: serde_json::json!({"command": "rm -rf /some/path"}),
+                }],
+                stop_reason: Some("tool_use".to_string()),
+                stop_sequence: None,
+                usage: None,
+            },
+        }];
         assert_eq!(get_pending_tool_name(&entries), Some("Bash".to_string()));
     }
 
     #[test]
     fn test_get_pending_tool_name_auto_approved() {
         // Read is auto-approved, should return None
-        let entries = vec![
-            SessionEntry::Assistant {
-                base: create_base(),
-                message: AssistantMessage {
-                    model: "claude-opus-4-5-20251101".to_string(),
-                    id: "msg_test".to_string(),
-                    role: "assistant".to_string(),
-                    content: vec![
-                        MessageContent::ToolUse {
-                            id: "toolu_123".to_string(),
-                            name: "Read".to_string(),
-                            input: serde_json::json!({"file_path": "/test/file.txt"}),
-                        }
-                    ],
-                    stop_reason: Some("tool_use".to_string()),
-                    stop_sequence: None,
-                    usage: None,
-                },
-            }
-        ];
+        let entries = vec![SessionEntry::Assistant {
+            base: create_base(),
+            message: AssistantMessage {
+                model: "claude-opus-4-5-20251101".to_string(),
+                id: "msg_test".to_string(),
+                role: "assistant".to_string(),
+                content: vec![MessageContent::ToolUse {
+                    id: "toolu_123".to_string(),
+                    name: "Read".to_string(),
+                    input: serde_json::json!({"file_path": "/test/file.txt"}),
+                }],
+                stop_reason: Some("tool_use".to_string()),
+                stop_sequence: None,
+                usage: None,
+            },
+        }];
         assert_eq!(get_pending_tool_name(&entries), None);
     }
 
     #[test]
     fn test_get_pending_tool_name_no_tools() {
         // No tools in the message
-        let entries = vec![
-            SessionEntry::Assistant {
-                base: create_base(),
-                message: AssistantMessage {
-                    model: "claude-opus-4-5-20251101".to_string(),
-                    id: "msg_test".to_string(),
-                    role: "assistant".to_string(),
-                    content: vec![
-                        MessageContent::Text {
-                            text: "Just text, no tools".to_string(),
-                        }
-                    ],
-                    stop_reason: Some("end_turn".to_string()),
-                    stop_sequence: None,
-                    usage: None,
-                },
-            }
-        ];
+        let entries = vec![SessionEntry::Assistant {
+            base: create_base(),
+            message: AssistantMessage {
+                model: "claude-opus-4-5-20251101".to_string(),
+                id: "msg_test".to_string(),
+                role: "assistant".to_string(),
+                content: vec![MessageContent::Text {
+                    text: "Just text, no tools".to_string(),
+                }],
+                stop_reason: Some("end_turn".to_string()),
+                stop_sequence: None,
+                usage: None,
+            },
+        }];
         assert_eq!(get_pending_tool_name(&entries), None);
     }
 
     #[test]
     fn test_get_pending_tool_name_all_completed() {
         // Tool has a result, so not pending
-        let entries = vec![
-            SessionEntry::Assistant {
-                base: create_base(),
-                message: AssistantMessage {
-                    model: "claude-opus-4-5-20251101".to_string(),
-                    id: "msg_test".to_string(),
-                    role: "assistant".to_string(),
-                    content: vec![
-                        MessageContent::ToolUse {
-                            id: "toolu_123".to_string(),
-                            name: "Bash".to_string(),
-                            input: serde_json::json!({"command": "ls"}),
-                        },
-                        MessageContent::ToolResult {
-                            tool_use_id: "toolu_123".to_string(),
-                            content: "file1.txt\nfile2.txt".to_string(),
-                            is_error: Some(false),
-                        }
-                    ],
-                    stop_reason: Some("end_turn".to_string()),
-                    stop_sequence: None,
-                    usage: None,
-                },
-            }
-        ];
+        let entries = vec![SessionEntry::Assistant {
+            base: create_base(),
+            message: AssistantMessage {
+                model: "claude-opus-4-5-20251101".to_string(),
+                id: "msg_test".to_string(),
+                role: "assistant".to_string(),
+                content: vec![
+                    MessageContent::ToolUse {
+                        id: "toolu_123".to_string(),
+                        name: "Bash".to_string(),
+                        input: serde_json::json!({"command": "ls"}),
+                    },
+                    MessageContent::ToolResult {
+                        tool_use_id: "toolu_123".to_string(),
+                        content: "file1.txt\nfile2.txt".to_string(),
+                        is_error: Some(false),
+                    },
+                ],
+                stop_reason: Some("end_turn".to_string()),
+                stop_sequence: None,
+                usage: None,
+            },
+        }];
         assert_eq!(get_pending_tool_name(&entries), None);
     }
 
@@ -929,47 +887,43 @@ mod tests {
     fn test_get_pending_tool_name_multiple_tools_first_needs_permission() {
         // First tool (Bash) needs permission, second (Read) auto-approved
         // Should return the first one that needs permission
-        let entries = vec![
-            SessionEntry::Assistant {
-                base: create_base(),
-                message: AssistantMessage {
-                    model: "claude-opus-4-5-20251101".to_string(),
-                    id: "msg_test".to_string(),
-                    role: "assistant".to_string(),
-                    content: vec![
-                        MessageContent::ToolUse {
-                            id: "toolu_123".to_string(),
-                            name: "Bash".to_string(),
-                            input: serde_json::json!({"command": "make build"}),
-                        },
-                        MessageContent::ToolUse {
-                            id: "toolu_456".to_string(),
-                            name: "Read".to_string(),
-                            input: serde_json::json!({"file_path": "/test/file.txt"}),
-                        }
-                    ],
-                    stop_reason: Some("tool_use".to_string()),
-                    stop_sequence: None,
-                    usage: None,
-                },
-            }
-        ];
+        let entries = vec![SessionEntry::Assistant {
+            base: create_base(),
+            message: AssistantMessage {
+                model: "claude-opus-4-5-20251101".to_string(),
+                id: "msg_test".to_string(),
+                role: "assistant".to_string(),
+                content: vec![
+                    MessageContent::ToolUse {
+                        id: "toolu_123".to_string(),
+                        name: "Bash".to_string(),
+                        input: serde_json::json!({"command": "make build"}),
+                    },
+                    MessageContent::ToolUse {
+                        id: "toolu_456".to_string(),
+                        name: "Read".to_string(),
+                        input: serde_json::json!({"file_path": "/test/file.txt"}),
+                    },
+                ],
+                stop_reason: Some("tool_use".to_string()),
+                stop_sequence: None,
+                usage: None,
+            },
+        }];
         assert_eq!(get_pending_tool_name(&entries), Some("Bash".to_string()));
     }
 
     #[test]
     fn test_get_pending_tool_name_no_assistant_message() {
         // Only user message, no assistant message
-        let entries = vec![
-            SessionEntry::User {
-                base: create_base(),
-                message: UserMessage {
-                    role: "user".to_string(),
-                    content: "Hello".to_string(),
-                    is_tool_result: false,
-                },
-            }
-        ];
+        let entries = vec![SessionEntry::User {
+            base: create_base(),
+            message: UserMessage {
+                role: "user".to_string(),
+                content: "Hello".to_string(),
+                is_tool_result: false,
+            },
+        }];
         assert_eq!(get_pending_tool_name(&entries), None);
     }
 
@@ -983,36 +937,34 @@ mod tests {
     #[test]
     fn test_get_pending_tool_name_mixed_completed_and_pending() {
         // First tool completed, second tool needs permission
-        let entries = vec![
-            SessionEntry::Assistant {
-                base: create_base(),
-                message: AssistantMessage {
-                    model: "claude-opus-4-5-20251101".to_string(),
-                    id: "msg_test".to_string(),
-                    role: "assistant".to_string(),
-                    content: vec![
-                        MessageContent::ToolUse {
-                            id: "toolu_123".to_string(),
-                            name: "Read".to_string(),
-                            input: serde_json::json!({"file_path": "/test/file.txt"}),
-                        },
-                        MessageContent::ToolResult {
-                            tool_use_id: "toolu_123".to_string(),
-                            content: "file content".to_string(),
-                            is_error: Some(false),
-                        },
-                        MessageContent::ToolUse {
-                            id: "toolu_456".to_string(),
-                            name: "Bash".to_string(),
-                            input: serde_json::json!({"command": "rm -rf /important"}),
-                        }
-                    ],
-                    stop_reason: Some("tool_use".to_string()),
-                    stop_sequence: None,
-                    usage: None,
-                },
-            }
-        ];
+        let entries = vec![SessionEntry::Assistant {
+            base: create_base(),
+            message: AssistantMessage {
+                model: "claude-opus-4-5-20251101".to_string(),
+                id: "msg_test".to_string(),
+                role: "assistant".to_string(),
+                content: vec![
+                    MessageContent::ToolUse {
+                        id: "toolu_123".to_string(),
+                        name: "Read".to_string(),
+                        input: serde_json::json!({"file_path": "/test/file.txt"}),
+                    },
+                    MessageContent::ToolResult {
+                        tool_use_id: "toolu_123".to_string(),
+                        content: "file content".to_string(),
+                        is_error: Some(false),
+                    },
+                    MessageContent::ToolUse {
+                        id: "toolu_456".to_string(),
+                        name: "Bash".to_string(),
+                        input: serde_json::json!({"command": "rm -rf /important"}),
+                    },
+                ],
+                stop_reason: Some("tool_use".to_string()),
+                stop_sequence: None,
+                usage: None,
+            },
+        }];
         assert_eq!(get_pending_tool_name(&entries), Some("Bash".to_string()));
     }
 }

--- a/src-tauri/tests/parser_integration_test.rs
+++ b/src-tauri/tests/parser_integration_test.rs
@@ -1,5 +1,5 @@
 use c9watch_lib::session::{
-    parse_sessions_index, parse_last_n_entries, extract_messages, MessageType,
+    extract_messages, parse_last_n_entries, parse_sessions_index, MessageType,
 };
 use std::env;
 use std::path::PathBuf;
@@ -19,16 +19,26 @@ fn test_parse_real_sessions_index() {
         .join(".claude/projects/-Users-vincent-m-lee--claude/sessions-index.json");
 
     if !index_path.exists() {
-        println!("Sessions index not found at {:?}, skipping test", index_path);
+        println!(
+            "Sessions index not found at {:?}, skipping test",
+            index_path
+        );
         return;
     }
 
     let result = parse_sessions_index(&index_path);
-    assert!(result.is_ok(), "Failed to parse sessions-index.json: {:?}", result.err());
+    assert!(
+        result.is_ok(),
+        "Failed to parse sessions-index.json: {:?}",
+        result.err()
+    );
 
     let index = result.unwrap();
     assert_eq!(index.version, 1);
-    assert!(!index.entries.is_empty(), "Sessions index should have entries");
+    assert!(
+        !index.entries.is_empty(),
+        "Sessions index should have entries"
+    );
 
     println!("Successfully parsed {} sessions", index.entries.len());
 }
@@ -86,7 +96,11 @@ fn test_parse_real_jsonl_file() {
     for (timestamp, msg_type, content) in messages.iter().take(3) {
         assert!(!timestamp.is_empty(), "Timestamp should not be empty");
         assert!(!content.is_empty(), "Content should not be empty");
-        println!("Message type: {:?}, content length: {}", msg_type, content.len());
+        println!(
+            "Message type: {:?}, content length: {}",
+            msg_type,
+            content.len()
+        );
     }
 }
 
@@ -123,14 +137,25 @@ fn test_message_type_extraction() {
                 let messages = extract_messages(&entries);
 
                 // Count message types
-                let user_count = messages.iter().filter(|(_, t, _)| t == &MessageType::User).count();
-                let assistant_count = messages.iter().filter(|(_, t, _)| t == &MessageType::Assistant).count();
+                let user_count = messages
+                    .iter()
+                    .filter(|(_, t, _)| t == &MessageType::User)
+                    .count();
+                let assistant_count = messages
+                    .iter()
+                    .filter(|(_, t, _)| t == &MessageType::Assistant)
+                    .count();
 
-                println!("Session {}: {} user messages, {} assistant messages",
-                    entry.session_id, user_count, assistant_count);
+                println!(
+                    "Session {}: {} user messages, {} assistant messages",
+                    entry.session_id, user_count, assistant_count
+                );
 
                 // There should be at least some messages
-                assert!(messages.len() > 0, "Should have extracted at least one message");
+                assert!(
+                    !messages.is_empty(),
+                    "Should have extracted at least one message"
+                );
             }
             Err(e) => {
                 println!("Could not parse session {}: {}", entry.session_id, e);


### PR DESCRIPTION
## Summary
- Fixed all 11 clippy warnings across the codebase
- Applied `rustfmt` for consistent code formatting
- All tests passing

## Changes

### Clippy Warning Fixes
1. **Pattern matching simplifications** - Used `matches!` macro instead of verbose match expressions (polling.rs:79)
2. **Iterator improvements** - Replaced `flatten()` with `map_while(Result::ok)` on `Lines` iterators to properly handle I/O errors (polling.rs:384, parser.rs:230,248,284)
3. **API improvements** - Used `is_some_and()` instead of `map_or()` for cleaner Option checking (detector.rs:98)
4. **String operations** - Replaced consecutive `str::replace()` calls with array parameter (detector.rs:172)
5. **Manual string stripping** - Used `strip_suffix()` instead of manual slicing (permissions.rs:84-85)
6. **Derive traits** - Added `#[derive(Default)]` instead of manual impl block (permissions.rs:17,206-212)
7. **Function parameters** - Refactored `fire_notification()` to use `NotificationParams` struct to reduce parameter count from 8 to 2 (polling.rs:397-418)
8. **Test assertions** - Replaced `len() > 0` with `!is_empty()` for idiomatic checks (parser_integration_test.rs:133)

### Formatting
- Applied `cargo fmt` to all modified files for consistent formatting

## Test plan
- [x] All unit tests pass (`cargo test`)
- [x] Clippy runs clean (`cargo clippy --all-targets --all-features`)
- [x] Code formatted (`cargo fmt`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)