### PR TITLE
fix: prevent status flickering during active work

### DIFF
--- a/src-tauri/src/polling.rs
+++ b/src-tauri/src/polling.rs
@@ -235,9 +235,13 @@ pub fn detect_and_enrich_sessions() -> Result<Vec<Session>, String> {
             SessionStatus::Connecting
         } else {
             let raw_status = determine_status(&entries);
-            // Override WaitingForInput if the JSONL file was recently modified
+            // Override WaitingForInput if the JSONL file was recently modified.
             // This catches progress entries (bash_progress, thinking updates) that
-            // don't get parsed as meaningful entries but indicate active work
+            // don't get parsed as meaningful entries but indicate active work.
+            //
+            // Why 8 seconds? Polling runs every 2s, Claude writes progress every 1-3s
+            // during active work. 8s provides buffer for gaps without delaying "Ready"
+            // transition when work truly finishes.
             if raw_status == SessionStatus::WaitingForInput
                 && is_file_recently_modified(&session_file_path, 8)
             {

--- a/src-tauri/src/session/status.rs
+++ b/src-tauri/src/session/status.rs
@@ -68,8 +68,9 @@ pub fn determine_status(entries: &[SessionEntry]) -> SessionStatus {
             // Check if this is a tool_result or an actual user prompt.
             // Tool results mean Claude is still processing.
             if message.is_tool_result {
-                // This is a tool result - Claude should be generating its next response
-                // But if it's old, the session might be idle (process died, etc.)
+                // This is a tool result - Claude should be generating its next response.
+                // But if it's old, the session might be idle (process died, etc.).
+                // 30s threshold (increased from 15s) accommodates API latency and longer operations.
                 if is_entry_recent(&base.timestamp, 30) {
                     SessionStatus::Working
                 } else {
@@ -97,7 +98,8 @@ pub fn determine_status(entries: &[SessionEntry]) -> SessionStatus {
                     let has_pending_tools = has_pending_tool_uses(&message.content);
 
                     if has_pending_tools {
-                        // Tool is pending - check if there's active progress or recent activity
+                        // Tool is pending - check if there's active progress or recent activity.
+                        // 20s threshold (increased from 10s) accommodates tool execution time.
                         if has_trailing_progress || is_entry_recent(&base.timestamp, 20) {
                             SessionStatus::Working
                         } else {
@@ -109,6 +111,7 @@ pub fn determine_status(entries: &[SessionEntry]) -> SessionStatus {
                         // Since stop_reason is always None in JSONL, we use recency:
                         // if the entry was written recently, Claude is likely still
                         // streaming or about to write more. If old, session is idle.
+                        // 20s threshold (increased from 10s) accommodates streaming and thinking pauses.
                         if is_entry_recent(&base.timestamp, 20) {
                             SessionStatus::Working
                         } else {


### PR DESCRIPTION
## Summary

Fixes #10 - The status indicator was incorrectly showing "Ready" (WaitingForInput) when Claude was actively working, causing flickering during extended operations.

## Problem

The status determination logic relied solely on parsing JSONL entries with tight time windows (10-15s). This caused flickering because:
- Claude Code writes frequent progress entries (`bash_progress`, thinking updates) that update the file modification time
- These progress entries are parsed as `Unknown` and ignored for status determination
- When Claude thinks for 15+ seconds between parsed actions, timestamps age out and status incorrectly switches to "Ready"

## Solution

### 1. File Modification Time Check (`polling.rs`)

Added `is_file_recently_modified()` helper that checks filesystem modification time as a fallback signal:

```rust
if raw_status == SessionStatus::WaitingForInput
    && is_file_recently_modified(&session_file_path, 8)
{
    SessionStatus::Working
}
```

**Why 8 seconds?** Polling runs every 2s, Claude writes progress every 1-3s during active work. 8s provides buffer for gaps without delaying "Ready" transition when work truly finishes.

### 2. Widened Recency Windows (`session/status.rs`)

Increased hardcoded time thresholds to accommodate API latency and longer operations:

| Check Type | Before | After |
|------------|--------|-------|
| Tool results | 15s | **30s** |
| Pending tools | 10s | **20s** |
| Assistant text (no stop_reason) | 10s | **20s** |

### 3. Fixed Flaky Tests

Changed test commands from `cargo build`/`npm install` to `rm -rf /dangerous` to prevent failures when common commands are in user's auto-approved permission list.

## Testing

- ✅ All unit tests pass (`cargo test`)
- ✅ Builds successfully (`cargo build`)
- ⏳ Ready for manual testing with live Claude Code sessions

## Expected Behavior

**Before:** Status flickers between "Working" ↔️ "Ready" during:
- Multi-step research tasks
- Extended tool chains (reads, greps, searches)
- Thinking pauses between actions

**After:** Status remains "Working" throughout active sessions, only transitioning to "Ready" when Claude truly finishes.

## Implementation Details

The two fixes work together as defense-in-depth:
1. **Wider windows** reduce false "Ready" transitions from parsed entry timestamps
2. **File mtime check** catches activity that happens between parsed entries (progress updates)

Only overrides `WaitingForInput` → `Working`, never affects `NeedsPermission` status.