### PR TITLE
feat: improve notification UX

### DIFF
--- a/src-tauri/src/polling.rs
+++ b/src-tauri/src/polling.rs
@@ -437,10 +437,10 @@ fn fire_notification(
     let body = match status {
         SessionStatus::NeedsPermission => {
             let tool_name = pending_tool_name.unwrap_or("unknown tool");
-            format!("{}: Needs permission for {}", session_name, tool_name)
+            format!("🔐 {}: Needs permission for {}", session_name, tool_name)
         }
         SessionStatus::WaitingForInput => {
-            format!("{}: Finished working", session_name)
+            format!("✅ {}: Finished working", session_name)
         }
         _ => return, // Should not happen based on the caller's logic
     };

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -8,8 +8,7 @@
 		sortedSessions,
 		expandedSessionId,
 		currentConversation,
-		statusSummary,
-		checkNotificationPermission
+		statusSummary
 	} from '$lib/stores/sessions';
 	import { getConversation, stopSession, openSession } from '$lib/api';
 	import { isDemoMode, toggleDemoMode } from '$lib/demo';
@@ -17,7 +16,6 @@
 	import StatusBar from '$lib/components/StatusBar.svelte';
 	import SessionCard from '$lib/components/SessionCard.svelte';
 	import ExpandedCardOverlay from '$lib/components/ExpandedCardOverlay.svelte';
-	import NotificationPermissionBanner from '$lib/components/NotificationPermissionBanner.svelte';
 	import ToastNotifications from '$lib/components/ToastNotifications.svelte';
 	import QRCodeModal from '$lib/components/QRCodeModal.svelte';
 	import ConnectionScreen from '$lib/components/ConnectionScreen.svelte';
@@ -48,8 +46,6 @@
 			if (savedCompact === 'true') {
 				isCompact = true;
 			}
-
-			checkNotificationPermission();
 		}
 	});
 
@@ -318,9 +314,6 @@
 					</div>
 				{/if}
 			</section>
-
-			<!-- Notification Permission Banner -->
-			<NotificationPermissionBanner />
 
 			{#if sessions.length === 0}
 				<div class="empty-state">


### PR DESCRIPTION
## Summary
- Remove the notification permission banner from the main page (Tauri handles permissions natively)
- Add emoji indicators to notification messages for quick visual distinction:
  - 🔐 for permission requests (e.g. "🔐 project: Needs permission for Bash")
  - ✅ for task completion (e.g. "✅ project: Finished working")

## Changes
- `src/routes/+page.svelte`: Remove `NotificationPermissionBanner` component and `checkNotificationPermission` call
- `src-tauri/src/polling.rs`: Add emoji prefixes to notification body text