### PR TITLE
fix: register get_terminal_title command in Tauri handler

### DIFF
--- a/TESTING.md
+++ b/TESTING.md
@@ -1,0 +1,65 @@
+# Testing the Terminal Title Fix
+
+## Bug Description
+PR #9 added the `get_iterm2_session_title()` backend function and the `get_terminal_title` Tauri command, but forgot to register it in the invoke handler. This caused the terminal title placeholder feature to silently fail.
+
+## The Fix
+Added `get_terminal_title` to the Tauri command registration in `src-tauri/src/lib.rs` line 279.
+
+## Testing Steps
+
+### 1. Build Verification
+- ✅ Backend builds without warnings (no more "function is never used" warning)
+- ✅ Frontend builds successfully
+- ✅ Tauri app bundles successfully
+
+### 2. Manual Testing
+To test the terminal title placeholder feature:
+
+1. **Setup**:
+   - Open iTerm2
+   - Start a Claude Code session in a tab
+   - Set a custom tab title in iTerm2 (View → Edit Session → Name: "My Custom Title")
+
+2. **Test in c9watch**:
+   - Launch the newly built c9watch app
+   - Find the session corresponding to your Claude Code instance
+   - **Double-click** on the session title to enter rename mode
+   - **Expected**: You should see "My Custom Title" as a placeholder (grayed out text)
+   - **Press Tab**: The placeholder text should fill the input field
+   - **Press Enter**: The session should be renamed to "My Custom Title"
+
+3. **Verify**:
+   - The session title in c9watch should now show "My Custom Title"
+   - The placeholder appeared correctly (not empty)
+   - Tab-to-fill worked properly
+
+### 3. Technical Verification
+
+You can verify the command is registered by checking the Tauri DevTools console:
+
+```javascript
+// In the browser DevTools console (when running in dev mode)
+await window.__TAURI__.core.invoke('get_terminal_title', { pid: 12345 })
+// Should return the iTerm2 tab title or null, not throw "command not found"
+```
+
+## Test Results
+
+### Build Results
+- Cargo build: ✅ Success (no warnings)
+- Frontend build: ✅ Success
+- Tauri bundle: ✅ Success (app bundle created)
+
+### Runtime Testing
+**To be completed by running the app and following steps above.**
+
+Expected:
+- [ ] Placeholder shows iTerm2 tab title when renaming
+- [ ] Tab key fills the title
+- [ ] No console errors about missing command
+
+## Related Files
+- `src-tauri/src/lib.rs` - Command registration
+- `src-tauri/src/actions.rs` - Backend function `get_iterm2_session_title()`
+- `src/lib/components/SessionCard.svelte` - Frontend rename UI

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -277,6 +277,7 @@ pub fn run() {
             stop_session,
             open_session,
             rename_session,
+            get_terminal_title,
             show_main_window,
             get_server_info
         ]);


### PR DESCRIPTION
## Summary
Fixes the iTerm2 tab title placeholder feature from PR #9 by registering the `get_terminal_title` command in the Tauri invoke handler.

## Problem
PR #9 added the backend function `get_iterm2_session_title()` and the Tauri command `get_terminal_title`, but forgot to register it in the invoke handler at `src-tauri/src/lib.rs`. This caused the feature to silently fail - when double-clicking to rename a session, no placeholder would appear.

The Rust compiler warned about this:
```
warning: function `get_terminal_title` is never used
```

## Changes
- Added `get_terminal_title` to the `invoke_handler` registration list in `src-tauri/src/lib.rs`
- Added `TESTING.md` with verification steps

## Testing
✅ Cargo build completes without warnings  
✅ Frontend builds successfully  
✅ Tauri app bundles successfully  

### Manual Testing Steps
1. Open iTerm2 with a Claude Code session
2. Set a custom tab title (e.g., "Intro (claude)")
3. In c9watch, double-click the session title to rename
4. **Expected**: iTerm2 tab title appears as placeholder
5. Press Tab to fill, Enter to save

## Related
- Completes PR #9 implementation
- Fixes issue where terminal title hint feature was not working

🤖 Generated with [Claude Code](https://claude.com/claude-code)