### PR TITLE
chore: bump version to 0.2.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "c9watch",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "c9watch",
-      "version": "0.1.0",
+      "version": "0.2.0",
       "license": "MIT",
       "dependencies": {
         "@tauri-apps/api": "^2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "c9watch",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "Monitor and control all your Claude Code sessions from one place",
   "type": "module",
   "scripts": {

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -394,7 +394,7 @@ dependencies = [
 
 [[package]]
 name = "c9watch"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "anyhow",
  "axum",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "c9watch"
-version = "0.1.0"
+version = "0.2.0"
 description = "Monitor and control all your Claude Code sessions from one place"
 authors = ["minchenlee"]
 edition = "2021"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "c9watch",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "identifier": "com.minchenlee.c9watch",
   "build": {
     "beforeDevCommand": "npm run dev",


### PR DESCRIPTION
## Version Bump to 0.2.0

Updates all version numbers across the codebase for the 0.2.0 release.

### Files Updated:
- ✅ `package.json`
- ✅ `package-lock.json`  
- ✅ `src-tauri/Cargo.toml`
- ✅ `src-tauri/Cargo.lock`
- ✅ `src-tauri/tauri.conf.json`

### Related:
- Draft release: https://github.com/minchenlee/c9watch/releases
- Tag: v0.2.0

### Checklist:
- [x] All version files updated
- [x] Lock files regenerated
- [x] Tag created locally
- [ ] Ready to merge and push tag