### PR TITLE
fix: strip 'v' prefix from version in latest.json for updater compatibility

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -106,6 +106,8 @@ jobs:
       - name: Generate updater JSON manifest
         run: |
           VERSION="${{ github.ref_name }}"
+          # Strip 'v' prefix for semver compatibility (v0.2.0 -> 0.2.0)
+          VERSION_NO_V="${VERSION#v}"
           DATE=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
 
           # Read signatures if they exist
@@ -120,7 +122,7 @@ jobs:
 
           cat > artifacts/latest.json << MANIFEST
           {
-            "version": "${VERSION}",
+            "version": "${VERSION_NO_V}",
             "notes": "See the release notes on GitHub",
             "pub_date": "${DATE}",
             "platforms": {


### PR DESCRIPTION
## Problem

Auto-update is broken between v0.1.0 and v0.2.0 due to version format mismatch:

- **Installed app version** (from `Info.plist`): `0.1.0` (no "v" prefix)
- **latest.json version** (from git tag): `v0.2.0` (with "v" prefix)

The Tauri updater performs strict semver comparison and fails when one version has a "v" prefix and the other doesn't. This prevents the updater from recognizing v0.2.0 as newer than v0.1.0.

## Solution

Strip the "v" prefix from the version field in `latest.json` while keeping it in the download URLs (which reference the git tag).

**Before:**
```json
{
  "version": "v0.2.0",
  "platforms": {
    "darwin-aarch64": {
      "url": "https://github.com/.../releases/download/v0.2.0/c9watch_v0.2.0_aarch64.app.tar.gz"
    }
  }
}
```

**After:**
```json
{
  "version": "0.2.0",
  "platforms": {
    "darwin-aarch64": {
      "url": "https://github.com/.../releases/download/v0.2.0/c9watch_v0.2.0_aarch64.app.tar.gz"
    }
  }
}
```

## Changes

- Modified `.github/workflows/release.yml` to strip the "v" prefix using shell parameter expansion: `VERSION_NO_V="${VERSION#v}"`
- The download URLs still use `${VERSION}` (with "v") to match the git tag
- The version field uses `${VERSION_NO_V}` for semver compatibility

## Testing

After merging and releasing v0.2.1:
1. The v0.1.0 app should auto-update to v0.2.1
2. Future versions will continue to work correctly

## Impact

This will fix auto-update going forward. The v0.2.0 release will remain broken (users need to manually download), but v0.2.1+ will work.