### PR TITLE
chore: bump version to 0.2.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "c9watch",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "Monitor and control all your Claude Code sessions from one place",
   "type": "module",
   "scripts": {

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -394,7 +394,7 @@ dependencies = [
 
 [[package]]
 name = "c9watch"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "anyhow",
  "axum",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "c9watch"
-version = "0.2.0"
+version = "0.2.1"
 description = "Monitor and control all your Claude Code sessions from one place"
 authors = ["minchenlee"]
 edition = "2021"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "c9watch",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "identifier": "com.minchenlee.c9watch",
   "build": {
     "beforeDevCommand": "npm run dev",


### PR DESCRIPTION
Bump version to 0.2.1 for release.

## Changes
- Updated version in package.json, tauri.conf.json, Cargo.toml
- Auto-updated Cargo.lock

## Next Steps
After merging, tag with:
```bash
git checkout main
git pull origin main
git tag -a v0.2.1 -m "Release v0.2.1"
git push origin v0.2.1
```