### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix path traversal in session handling

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2026-01-08 - Path Traversal via Unvalidated Session IDs
+**Vulnerability:** The application used user-provided `session_id` directly in file path construction (`format!("{}.jsonl", session_id)`), allowing path traversal (e.g., `../secret`) to access arbitrary files ending in `.jsonl`.
+**Learning:** Even when appending a fixed extension, path traversal is possible if the base identifier is not validated. `Path::join` resolves `..` components.
+**Prevention:** Validate all user-provided identifiers against a strict allowlist (e.g., alphanumeric only) before using them in file system operations.

--- a/src-tauri/src/web_server.rs
+++ b/src-tauri/src/web_server.rs
@@ -277,6 +277,10 @@ async fn handle_message(msg: ClientMsg) -> ServerMsg {
             session_id,
             new_name,
         } => {
+            if let Err(e) = crate::validate_session_id(&session_id) {
+                return ServerMsg::Error { message: e };
+            }
+
             let mut custom_titles = crate::session::CustomTitles::load();
             custom_titles.set(session_id, new_name);
             match custom_titles.save() {


### PR DESCRIPTION
This PR fixes a path traversal vulnerability where an attacker could supply a malicious session ID (e.g., `../secret`) to access arbitrary files ending in `.jsonl`. 

I introduced a `validate_session_id` function that strictly enforces an allowlist of characters (alphanumeric, hyphens, and underscores). This validation is now applied in:
1. `get_conversation_data` (used by both Tauri command and WebSocket `getConversation`).
2. `rename_session` (Tauri command).
3. `ClientMsg::RenameSession` handler in the WebSocket server.

I also added a test module `security_tests` in `src-tauri/src/lib.rs` to verify the validation logic. A journal entry was added to `.jules/sentinel.md` documenting the vulnerability and prevention strategy.

---
*PR created automatically by Jules for task [9636075218532736977](https://jules.google.com/task/9636075218532736977) started by @minchenlee*