### PR TITLE
🛡️ Sentinel: Fix Path Traversal in Session Handling

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2024-05-22 - Path Traversal in Session IDs
+**Vulnerability:** `get_conversation_data` constructed file paths using unvalidated `session_id` inputs, allowing traversal out of the project directory.
+**Learning:** The application assumes session IDs are safe because they are often generated internally, but they can be supplied by the user/frontend via WebSocket or Tauri commands.
+**Prevention:** Always validate `session_id` using `validate_session_id` (alphanumeric whitelist) before using it in file system operations.

--- a/src-tauri/src/web_server.rs
+++ b/src-tauri/src/web_server.rs
@@ -277,6 +277,10 @@ async fn handle_message(msg: ClientMsg) -> ServerMsg {
             session_id,
             new_name,
         } => {
+            if let Err(e) = crate::validate_session_id(&session_id) {
+                return ServerMsg::Error { message: e };
+            }
+
             let mut custom_titles = crate::session::CustomTitles::load();
             custom_titles.set(session_id, new_name);
             match custom_titles.save() {


### PR DESCRIPTION
Add `validate_session_id` to sanitise inputs and prevent path traversal vulnerabilities.
Update `get_conversation_data` and `rename_session` to use the validation.
Update `web_server.rs` to validate session IDs in WebSocket messages.
Create `.jules/sentinel.md` to record the security learning.

---
*PR created automatically by Jules for task [5032840958340051346](https://jules.google.com/task/5032840958340051346) started by @minchenlee*