### PR TITLE
fix: search highlight blink, wrong match, and nav scroll

### DIFF
--- a/src/lib/components/ExpandedCardOverlay.svelte
+++ b/src/lib/components/ExpandedCardOverlay.svelte
@@ -220,7 +220,9 @@
 					<div class="messages">
 						{#each conversation.messages as message, index (index)}
 							{#if (showTools || (message.messageType !== 'ToolUse' && message.messageType !== 'ToolResult')) && (showThinking || message.messageType !== 'Thinking')}
-								<MessageBubble {message} />
+								<div data-msg-index={index}>
+									<MessageBubble {message} />
+								</div>
 							{/if}
 						{/each}
 					</div>

--- a/src/lib/components/HistoryCardOverlay.svelte
+++ b/src/lib/components/HistoryCardOverlay.svelte
@@ -46,10 +46,13 @@
 			if (!hasScrolledToBottom) {
 				tick().then(() => {
 					if (searchQuery) {
-						// Find the first message whose content matches the search query
+						// Find the first user/assistant message whose content matches.
+						// Only search User and Assistant types to match what the Rust
+						// deep search scans (it skips Thinking, ToolUse, ToolResult).
 						const queryLower = searchQuery.toLowerCase();
 						const matchIndex = conversation!.messages.findIndex(
-							(m) => m.content.toLowerCase().includes(queryLower)
+							(m) => (m.messageType === 'User' || m.messageType === 'Assistant') &&
+								m.content.toLowerCase().includes(queryLower)
 						);
 						if (matchIndex >= 0) {
 							scrollToMessageIndex(matchIndex);
@@ -67,16 +70,13 @@
 
 	function scrollToMessageIndex(index: number) {
 		if (!messagesContainer) return;
-		const bubbles = messagesContainer.querySelectorAll('.message-bubble');
-		// Count only visible bubbles (tools/thinking may be hidden)
-		// The index is from the full messages array, so we need to find the
-		// corresponding visible element. We tag each bubble with data-msg-index.
 		const target = messagesContainer.querySelector(`[data-msg-index="${index}"]`) as HTMLElement | null;
 		if (target) {
 			target.scrollIntoView({ block: 'center' });
 			target.classList.add('search-highlight');
-			setTimeout(() => target.classList.remove('search-highlight'), 2000);
-		} else if (bubbles.length > 0) {
+			// Don't remove the class — animation-fill-mode: forwards holds the
+			// end state (no box-shadow), so removing it would cause a re-render blink.
+		} else {
 			// Fallback: the matched message might be hidden (tool/thinking toggle off)
 			messagesContainer.scrollTop = messagesContainer.scrollHeight;
 		}
@@ -451,9 +451,11 @@
 		flex-direction: column;
 	}
 
-	/* Flash highlight for the matched search result message */
+	/* Flash highlight for the matched search result message.
+	   animation-fill-mode: forwards keeps the end state (no box-shadow)
+	   so removing the class isn't needed and avoids a re-render blink. */
 	.messages :global([data-msg-index].search-highlight .message-bubble) {
-		animation: search-flash 2s ease-out;
+		animation: search-flash 2s ease-out forwards;
 	}
 
 	@keyframes search-flash {

--- a/src/lib/components/MessageNavMap.svelte
+++ b/src/lib/components/MessageNavMap.svelte
@@ -50,11 +50,11 @@
 
 	async function scrollToMessage(index: number) {
 		if (!scrollContainer) return;
-		
-		const messages = scrollContainer.querySelector('.messages');
-		if (!messages) return;
-		
-		const target = messages.children[index] as HTMLElement;
+
+		// Use data-msg-index attribute to find the right element.
+		// children[index] doesn't work because hidden messages (tools/thinking
+		// toggled off) create gaps between the array index and DOM position.
+		const target = scrollContainer.querySelector(`[data-msg-index="${index}"]`) as HTMLElement | null;
 		if (target) {
 			target.scrollIntoView({ behavior: 'smooth', block: 'start' });
 		}


### PR DESCRIPTION
## Summary

Fixes three related bugs in the history conversation viewer:

- **Highlight blink** — after the amber search-flash animation faded, the message would blink due to removing the `search-highlight` class causing a re-render. Fixed by using `animation-fill-mode: forwards` so the end state persists without class removal.
- **Wrong message highlighted** — `findIndex` searched ALL message types, but the Rust deep search only scans User and Assistant content. A keyword match in a ToolUse or Thinking block would highlight the wrong message. Fixed by filtering to only User/Assistant types.
- **NavMap scroll to wrong message** — `scrollToMessage()` used `messages.children[index]`, but hidden messages (tools/thinking toggled off) create index gaps. Fixed by using `[data-msg-index]` attribute selector. Also added `data-msg-index` wrappers to `ExpandedCardOverlay` for consistency.

## Test plan

- [ ] Search a keyword in History tab, click result → correct message highlighted, no blink after fade
- [ ] Verify the highlighted message actually contains the search keyword
- [ ] In conversation overlay, click nav items → scrolls to correct message
- [ ] Toggle tools/thinking off, click nav items → still scrolls correctly
- [ ] Monitor tab: expand a session, use nav sidebar → scrolls correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)