### PR TITLE
feat: add subagent visibility support

### DIFF
--- a/src-tauri/src/polling.rs
+++ b/src-tauri/src/polling.rs
@@ -201,6 +201,50 @@ pub fn detect_and_enrich_sessions() -> Result<Vec<Session>, String> {
     detect_and_enrich_sessions_with_detector(&mut detector)
 }
 
+/// Convert tracked subagents into virtual Session entries
+fn subagent_sessions() -> Vec<Session> {
+    let subagents = crate::session::read_active_subagents();
+    let now_ms = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|d| d.as_millis() as u64)
+        .unwrap_or(0);
+
+    subagents
+        .into_iter()
+        .map(|sa| {
+            let age_secs = (now_ms.saturating_sub(sa.started_at)) / 1000;
+            let status_label = if age_secs < 5 {
+                SessionStatus::Connecting
+            } else {
+                SessionStatus::Working
+            };
+
+            let started_dt: DateTime<Utc> = DateTime::from_timestamp_millis(sa.started_at as i64)
+                .unwrap_or_default();
+
+            Session {
+                id: sa.id.clone(),
+                pid: sa.parent_pid,
+                session_name: format!("⚡ {}", sa.name),
+                custom_title: None,
+                project_path: format!("subagent:{}", sa.agent_type),
+                git_branch: None,
+                first_prompt: if sa.description.is_empty() {
+                    sa.prompt.clone()
+                } else {
+                    sa.description.clone()
+                },
+                summary: Some(format!("Type: {} | Parent: {}", sa.agent_type, sa.parent_session_id)),
+                message_count: 1,
+                modified: started_dt.to_rfc3339(),
+                status: status_label,
+                latest_message: format!("Running for {}s", age_secs),
+                pending_tool_name: None,
+            }
+        })
+        .collect()
+}
+
 /// Detect sessions using an existing detector (avoids recreating System each call)
 fn detect_and_enrich_sessions_with_detector(
     detector: &mut SessionDetector,
@@ -341,6 +385,10 @@ fn detect_and_enrich_sessions_with_detector(
             pending_tool_name,
         });
     }
+
+    // Merge in subagent virtual sessions
+    let mut subagent_list = subagent_sessions();
+    sessions.append(&mut subagent_list);
 
     Ok(sessions)
 }

--- a/src-tauri/src/session/mod.rs
+++ b/src-tauri/src/session/mod.rs
@@ -20,3 +20,6 @@ pub use history::{deep_search, get_history, DeepSearchHit, HistoryEntry};
 
 pub mod cost;
 pub use cost::{get_cost_data, CostData};
+
+pub mod subagents;
+pub use subagents::{read_active_subagents, TrackedSubagent};

--- a/src-tauri/src/session/subagents.rs
+++ b/src-tauri/src/session/subagents.rs
@@ -1,0 +1,90 @@
+use serde::{Deserialize, Serialize};
+use std::fs;
+use std::path::PathBuf;
+
+const MAX_AGE_SECS: u64 = 600; // 10 minutes
+
+/// A tracked subagent from ~/.claude/active-subagents.json
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct TrackedSubagent {
+    pub id: String,
+    pub name: String,
+    #[serde(rename = "type")]
+    pub agent_type: String,
+    pub description: String,
+    pub prompt: String,
+    pub parent_session_id: String,
+    pub parent_pid: u32,
+    pub started_at: u64, // milliseconds since epoch
+}
+
+/// Read active subagents from the JSON file, filtering out expired entries
+pub fn read_active_subagents() -> Vec<TrackedSubagent> {
+    let home = match dirs::home_dir() {
+        Some(h) => h,
+        None => return Vec::new(),
+    };
+
+    let file_path: PathBuf = home.join(".claude").join("active-subagents.json");
+
+    if !file_path.exists() {
+        return Vec::new();
+    }
+
+    let content = match fs::read_to_string(&file_path) {
+        Ok(c) => c,
+        Err(_) => return Vec::new(),
+    };
+
+    let subagents: Vec<TrackedSubagent> = match serde_json::from_str(&content) {
+        Ok(s) => s,
+        Err(_) => return Vec::new(),
+    };
+
+    // Filter out expired entries
+    let now_ms = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|d| d.as_millis() as u64)
+        .unwrap_or(0);
+
+    subagents
+        .into_iter()
+        .filter(|s| {
+            let age_ms = now_ms.saturating_sub(s.started_at);
+            age_ms < (MAX_AGE_SECS * 1000)
+        })
+        .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_read_active_subagents_no_file() {
+        // Should return empty vec when file doesn't exist
+        let result = read_active_subagents();
+        // May or may not be empty depending on machine state
+        println!("Found {} subagents", result.len());
+    }
+
+    #[test]
+    fn test_parse_subagent_json() {
+        let json = r#"[{
+            "id": "sa-123",
+            "name": "test-agent",
+            "type": "general-purpose",
+            "description": "Test",
+            "prompt": "Do something",
+            "parentSessionId": "abc",
+            "parentPid": 1234,
+            "startedAt": 1709312345678
+        }]"#;
+
+        let parsed: Vec<TrackedSubagent> = serde_json::from_str(json).unwrap();
+        assert_eq!(parsed.len(), 1);
+        assert_eq!(parsed[0].name, "test-agent");
+        assert_eq!(parsed[0].agent_type, "general-purpose");
+    }
+}


### PR DESCRIPTION
## Summary

This PR adds support for displaying **Claude Code subagents** (spawned via the Agent tool) alongside regular sessions in c9watch.

### Problem

Claude Code's Agent tool spawns subagents that run as nested API calls within the parent session — they don't create separate OS processes. This means c9watch's process-based detection (`sysinfo` process scan) cannot see them, and they remain invisible in the UI.

### Solution

Instead of trying to detect subagents via OS processes, this uses a **file-based approach**:

1. A Claude Code `SubagentStart` hook writes subagent metadata to `~/.claude/active-subagents.json`
2. c9watch reads this file and merges subagent entries into the session list as virtual sessions

### Changes

- **New: `src-tauri/src/session/subagents.rs`** — Reads and parses `~/.claude/active-subagents.json`, with automatic expiry filtering (entries older than 10 minutes are ignored)
- **Modified: `src-tauri/src/session/mod.rs`** — Registers the new `subagents` module
- **Modified: `src-tauri/src/polling.rs`** — Adds `subagent_sessions()` function that converts tracked subagents into virtual `Session` entries, merged into the main session list

### How subagents appear in the UI

- Session name: `⚡ {agent_type}` (e.g., "⚡ general-purpose")
- Project path: `subagent:{agent_type}`
- Status: "Connecting" for first 5 seconds, then "Working"
- Summary: Shows agent type and parent session ID
- Latest message: "Running for Xs" (live age counter)

### JSON file format

The companion hook (not included in this PR — it's a user-side Claude Code hook) writes entries like:

```json
[
  {
    "id": "a283f405b3f4854be",
    "name": "general-purpose",
    "type": "general-purpose",
    "description": "Subagent in my-project",
    "prompt": "",
    "parentSessionId": "6aa3fc2c-3137-4801-86ce-93733a254e2f",
    "parentPid": 42974,
    "transcriptPath": "/Users/.../.claude/projects/.../session.jsonl",
    "startedAt": 1772338545341
  }
]
```

### Example hook setup

Users add this to their `.claude/settings.json`:

```json
{
  "hooks": {
    "SubagentStart": [{
      "hooks": [{
        "type": "command",
        "command": "node .claude/helpers/subagent-tracker.cjs",
        "timeout": 3000
      }]
    }]
  }
}
```

The `SubagentStart` hook receives JSON via stdin with `agent_id`, `agent_type`, `session_id`, and `transcript_path`.

### Testing

- Verified with real Claude Code Agent tool spawns
- Hook correctly captures agent_id, agent_type, parent session, parent PID
- Entries appear in c9watch UI with ⚡ prefix
- Auto-expiry works (entries disappear after 10 minutes)
- No impact on existing session detection — subagents are appended after regular sessions
- `cargo check` and full `tauri build` pass with no errors

### Backwards compatibility

- If `~/.claude/active-subagents.json` doesn't exist, the feature is a no-op
- No changes to existing session detection logic
- No new dependencies added