### PR TITLE
fix(website): add wrangler.toml for Cloudflare Workers deploy

### DIFF
--- a/website/wrangler.toml
+++ b/website/wrangler.toml
@@ -1,0 +1,5 @@
+name = "c9watch"
+compatibility_date = "2025-04-01"
+
+[assets]
+directory = "./dist"


### PR DESCRIPTION
## Summary

- Add `wrangler.toml` to `website/` for Cloudflare Workers static asset deployment
- Cloudflare merged Pages into Workers — the old `wrangler pages deploy` flow no longer works with auto-generated API tokens

## Cloudflare dashboard settings

- **Build command**: `npm run build`
- **Deploy command**: `npx wrangler deploy`
- **Path**: `website`

## Test plan

- [ ] Cloudflare build and deploy succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)