### PR TITLE
feat: add Windows support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,8 +7,42 @@ on:
     branches: [main]
 
 jobs:
-  check:
+  check-macos:
     runs-on: macos-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Rust cache
+        uses: swatinem/rust-cache@v2
+        with:
+          workspaces: src-tauri -> target
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+
+      - name: Install frontend dependencies
+        run: npm ci
+
+      - name: Svelte check
+        run: npm run check
+
+      - name: Rust check
+        run: cargo check --manifest-path src-tauri/Cargo.toml
+
+      - name: Rust tests
+        run: cargo test --manifest-path src-tauri/Cargo.toml
+
+      - name: Build frontend
+        run: npm run build
+
+  check-windows:
+    runs-on: windows-latest
     steps:
       - uses: actions/checkout@v4
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -50,7 +50,7 @@ jobs:
           APPLE_ID: ${{ secrets.APPLE_ID }}
           APPLE_PASSWORD: ${{ secrets.APPLE_PASSWORD }}
           APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
-        run: npx tauri build --target ${{ matrix.target }}
+        run: npx tauri build --target ${{ matrix.target }} --bundles dmg,app,updater
 
       - name: Rename artifacts for clarity
         run: |
@@ -109,7 +109,7 @@ jobs:
         env:
           TAURI_SIGNING_PRIVATE_KEY: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY }}
           TAURI_SIGNING_PRIVATE_KEY_PASSWORD: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY_PASSWORD }}
-        run: npx tauri build --target ${{ matrix.target }}
+        run: npx tauri build --target ${{ matrix.target }} --bundles nsis,msi,updater
 
       - name: Upload NSIS installer
         uses: actions/upload-artifact@v4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -77,12 +77,62 @@ jobs:
         uses: actions/upload-artifact@v4
         if: always()
         with:
-          name: updater-sig-${{ matrix.arch }}
+          name: updater-sig-macos-${{ matrix.arch }}
           path: src-tauri/target/${{ matrix.target }}/release/bundle/macos/*.app.tar.gz*
           if-no-files-found: ignore
 
+  build-windows:
+    runs-on: windows-latest
+    strategy:
+      matrix:
+        include:
+          - target: x86_64-pc-windows-msvc
+            arch: x64
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: ${{ matrix.target }}
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+
+      - name: Install frontend dependencies
+        run: npm ci
+
+      - name: Build Tauri app
+        env:
+          TAURI_SIGNING_PRIVATE_KEY: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY }}
+          TAURI_SIGNING_PRIVATE_KEY_PASSWORD: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY_PASSWORD }}
+        run: npx tauri build --target ${{ matrix.target }}
+
+      - name: Upload NSIS installer
+        uses: actions/upload-artifact@v4
+        with:
+          name: windows-nsis-${{ matrix.arch }}
+          path: src-tauri/target/${{ matrix.target }}/release/bundle/nsis/*.exe
+
+      - name: Upload MSI installer
+        uses: actions/upload-artifact@v4
+        with:
+          name: windows-msi-${{ matrix.arch }}
+          path: src-tauri/target/${{ matrix.target }}/release/bundle/msi/*.msi
+
+      - name: Upload updater signature (if exists)
+        uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: updater-sig-windows-${{ matrix.arch }}
+          path: src-tauri/target/${{ matrix.target }}/release/bundle/nsis/*.nsis.zip*
+          if-no-files-found: ignore
+
   create-release:
-    needs: build-macos
+    needs: [build-macos, build-windows]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -113,11 +163,15 @@ jobs:
           # Read signatures if they exist
           AARCH64_SIG=""
           X86_64_SIG=""
-          if [ -f "artifacts/updater-sig-aarch64/"*.sig ]; then
-            AARCH64_SIG=$(cat artifacts/updater-sig-aarch64/*.sig 2>/dev/null || echo "")
+          WINDOWS_X64_SIG=""
+          if [ -f "artifacts/updater-sig-macos-aarch64/"*.sig ]; then
+            AARCH64_SIG=$(cat artifacts/updater-sig-macos-aarch64/*.sig 2>/dev/null || echo "")
           fi
-          if [ -f "artifacts/updater-sig-x86_64/"*.sig ]; then
-            X86_64_SIG=$(cat artifacts/updater-sig-x86_64/*.sig 2>/dev/null || echo "")
+          if [ -f "artifacts/updater-sig-macos-x86_64/"*.sig ]; then
+            X86_64_SIG=$(cat artifacts/updater-sig-macos-x86_64/*.sig 2>/dev/null || echo "")
+          fi
+          if [ -f "artifacts/updater-sig-windows-x64/"*.sig ]; then
+            WINDOWS_X64_SIG=$(cat artifacts/updater-sig-windows-x64/*.sig 2>/dev/null || echo "")
           fi
 
           cat > artifacts/latest.json << MANIFEST
@@ -133,6 +187,10 @@ jobs:
               "darwin-x86_64": {
                 "signature": "${X86_64_SIG}",
                 "url": "https://github.com/${{ github.repository }}/releases/download/${VERSION}/c9watch_${VERSION}_x86_64.app.tar.gz"
+              },
+              "windows-x86_64": {
+                "signature": "${WINDOWS_X64_SIG}",
+                "url": "https://github.com/${{ github.repository }}/releases/download/${VERSION}/c9watch_${VERSION}_x64-setup.nsis.zip"
               }
             }
           }
@@ -146,4 +204,6 @@ jobs:
           files: |
             artifacts/macos-dmg-*/*.dmg
             artifacts/*.app.tar.gz
+            artifacts/windows-nsis-*/*.exe
+            artifacts/windows-msi-*/*.msi
             artifacts/latest.json

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 <p align="center">Monitor and control all your Claude Code sessions from one place.</p>
 
-**c9watch** (short for **c**laude cod**e** watch, like k8s for Kubernetes) is a macOS desktop app that gives you a real-time dashboard of every Claude Code session running on your machine. No more switching between terminals to check which agent needs permission, which one is working, and which one is idle.
+**c9watch** (short for **c**laude cod**e** watch, like k8s for Kubernetes) is a desktop app for **macOS** and **Windows** that gives you a real-time dashboard of every Claude Code session running on your machine. No more switching between terminals to check which agent needs permission, which one is working, and which one is idle.
 
 ## Demo
 
@@ -16,7 +16,7 @@
 
 Unlike other Claude Code management tools that require you to launch sessions from within their app, **c9watch doesn't care where you start your sessions**. It discovers them automatically by scanning running processes at the OS level.
 
-Start Claude Code from any terminal or IDE you already use -- VS Code, Zed, iTerm2, Antigravity, you name it -- and c9watch picks them all up. No plugins to install. No workflows to change. No vendor lock-in.
+Start Claude Code from any terminal or IDE you already use -- VS Code, Zed, Cursor, Windows Terminal, iTerm2, you name it -- and c9watch picks them all up. No plugins to install. No workflows to change. No vendor lock-in.
 
 Just open c9watch and see everything.
 
@@ -26,19 +26,42 @@ Built with **Tauri**, **Rust**, and **Svelte** -- not Electron. The app binary i
 
 ## Install
 
-### Quick install
+### macOS
+
+#### Quick install
 
 ```bash
 curl -fsSL https://raw.githubusercontent.com/minchenlee/c9watch/main/install.sh | bash
 ```
 
-### Download
+#### Download
 
 Grab the latest `.dmg` from the [Releases](https://github.com/minchenlee/c9watch/releases) page.
+
+### Windows
+
+#### Quick install (PowerShell)
+
+```powershell
+irm https://raw.githubusercontent.com/minchenlee/c9watch/main/install.ps1 | iex
+```
+
+This downloads and runs the latest NSIS or MSI installer.
+
+#### Download
+
+Grab the latest `.exe` (NSIS installer) or `.msi` from the [Releases](https://github.com/minchenlee/c9watch/releases) page.
+
+#### System requirements
+
+- Windows 10 (1803+) or Windows 11
+- [WebView2 Runtime](https://developer.microsoft.com/en-us/microsoft-edge/webview2/) (pre-installed on Windows 11; the NSIS installer will prompt to install it if missing)
 
 ### Build from source
 
 Prerequisites: [Rust](https://rustup.rs/), [Node.js](https://nodejs.org/) (v18+), and the [Tauri CLI](https://v2.tauri.app/start/prerequisites/).
+
+**Windows additional prerequisites:** [Visual Studio Build Tools](https://visualstudio.microsoft.com/visual-cpp-build-tools/) with the "Desktop development with C++" workload, and [WebView2](https://developer.microsoft.com/en-us/microsoft-edge/webview2/).
 
 ```bash
 git clone https://github.com/minchenlee/c9watch.git
@@ -47,7 +70,9 @@ npm install
 npm run tauri build
 ```
 
-The built `.app` will be in `src-tauri/target/release/bundle/macos/`.
+Build output:
+- **macOS:** `src-tauri/target/release/bundle/macos/`
+- **Windows:** `src-tauri/target/release/bundle/nsis/` and `src-tauri/target/release/bundle/msi/`
 
 ## Screenshots
 
@@ -95,20 +120,41 @@ See your total token usage as a rice stack towering past real-world landmarks. S
 
 ## Features
 
+- **Cross-platform** -- Runs natively on macOS and Windows
 - **Zero-integration setup** -- Works with any terminal or IDE, no plugins or extensions required
 - **Auto-discovery** -- Detects all running Claude Code sessions by scanning processes at the OS level
 - **Real-time status** -- See at a glance which sessions are Working, Need Permission, or Idle
 - **Conversation viewer** -- Expand any session to view the full conversation with formatted markdown, code blocks, and inline images
 - **Session control** -- Stop sessions, open their parent terminal/IDE, or rename them for easier tracking
 - **Multi-project view** -- Sessions grouped by project with git branch info
-- **Tray popover** -- Click the menu bar icon for a quick-glance overlay with session status indicators and latest messages
-- **Status notifications** -- Get a native macOS notification when a session needs your attention
+- **System tray integration** -- Click the tray icon for a quick-glance overlay with session status indicators and latest messages
+- **Status notifications** -- Get a native notification when a session needs your attention
 - **Mobile/Web client** -- Connect from any browser or mobile device via WebSocket; scan the QR code to monitor sessions remotely
 - **Session history** -- Browse and search all past sessions with instant metadata filter and deep content search; click a result to scroll to and highlight the matching message
 - **Memory viewer** -- Browse and inspect Claude Code memory files with a two-panel layout and quick Claude command access
 - **Cost tracker** -- Track Claude Code spending with daily, per-project, and per-model breakdowns using cached JSONL scanning
 - **Token distance visualizer** -- See your token usage as a rice stack towering past 17 real-world landmarks, with animated stacking, native share sheet, and Instagram-ready PNG export
 - **Debug console** -- Hidden diagnostic panel (`Cmd+Shift+D`) for troubleshooting session detection issues
+
+### Supported terminals and IDEs
+
+| Application | macOS | Windows |
+|-------------|-------|---------|
+| VS Code | Yes | Yes |
+| Cursor | Yes | Yes |
+| Windsurf | Yes | Yes |
+| Zed | Yes | Yes |
+| Terminal.app | Yes | -- |
+| iTerm2 | Yes | -- |
+| Windows Terminal | -- | Yes |
+| PowerShell | -- | Yes |
+| Command Prompt | -- | Yes |
+| Alacritty | Yes | Yes |
+| kitty | Yes | Yes |
+| WezTerm | Yes | Yes |
+| Warp | Yes | -- |
+| Ghostty | Yes | -- |
+| Hyper | Yes | Yes |
 
 ## How it works
 
@@ -123,6 +169,12 @@ Status updates are pushed to the Svelte frontend via Tauri events. The UI reacti
 
 **Cost tracking** -- Parses assistant message metadata from JSONL files to extract model usage and token counts. Costs are computed using per-model pricing tables and cached by file mtime to avoid re-scanning unchanged sessions.
 
+### Platform-specific details
+
+- **macOS:** Process tree walking via `ps`, window activation via AppleScript, IDE CLI detection in `/Applications/`
+- **Windows:** Process tree walking via PowerShell CIM, window activation via Win32 APIs, IDE CLI detection in `%LOCALAPPDATA%` and `%PROGRAMFILES%`
+- **Process termination:** `SIGTERM` on Unix, `taskkill` on Windows (graceful first, then force)
+
 ## Tech stack
 
 | Layer | Technology |
@@ -131,6 +183,7 @@ Status updates are pushed to the Svelte frontend via Tauri events. The UI reacti
 | Frontend | [SvelteKit](https://svelte.dev/) + [Svelte 5](https://svelte.dev/docs/svelte/overview) |
 | Backend | Rust |
 | Process discovery | [sysinfo](https://crates.io/crates/sysinfo) |
+| Windows APIs | [windows-sys](https://crates.io/crates/windows-sys) |
 | Design system | Vercel Noir (true black, [Geist](https://vercel.com/font) fonts) |
 
 ## Development
@@ -162,9 +215,10 @@ c9watch/
 │   │   ├── api.ts              # Tauri command wrappers
 │   │   └── types.ts            # TypeScript type definitions
 │   └── app.css                 # Global styles (Vercel Noir theme)
+├── install.ps1                 # Windows PowerShell installer
 ├── src-tauri/                  # Rust backend (Tauri)
 │   └── src/
-│       ├── lib.rs              # App setup, tray icon, NSPanel popover
+│       ├── lib.rs              # App setup, tray icon, system tray popover
 │       ├── polling.rs          # Background session detection loop
 │       ├── actions.rs          # Stop/open session, IDE detection
 │       ├── web_server.rs       # WebSocket server for mobile clients
@@ -181,7 +235,7 @@ c9watch/
 
 ## Demo mode
 
-Press `Cmd+D` to toggle demo mode, which loads simulated sessions with animated status transitions. Useful for testing the UI without running real Claude Code sessions.
+Press `Cmd+D` (macOS) / `Ctrl+D` (Windows) to toggle demo mode, which loads simulated sessions with animated status transitions. Useful for testing the UI without running real Claude Code sessions.
 
 ## Contributing
 

--- a/install.ps1
+++ b/install.ps1
@@ -1,0 +1,126 @@
+#Requires -Version 5.1
+<#
+.SYNOPSIS
+    c9watch installer for Windows
+
+.DESCRIPTION
+    Downloads and installs the latest c9watch release for Windows.
+
+.EXAMPLE
+    # Run directly from PowerShell:
+    irm https://raw.githubusercontent.com/minchenlee/c9watch/main/install.ps1 | iex
+
+    # Or download and run:
+    .\install.ps1
+#>
+
+$ErrorActionPreference = 'Stop'
+
+$REPO = "minchenlee/c9watch"
+$APP_NAME = "c9watch"
+
+function Write-Info { param([string]$Message) Write-Host "=> $Message" -ForegroundColor Cyan }
+function Write-Err  { param([string]$Message) Write-Host "Error: $Message" -ForegroundColor Red; exit 1 }
+
+# --- Check OS ---
+if ($env:OS -ne 'Windows_NT') {
+    Write-Err "This installer is for Windows only. Detected OS: $($env:OS)"
+}
+
+$osVersion = [System.Environment]::OSVersion.Version
+if ($osVersion.Build -lt 17134) {
+    Write-Err "c9watch requires Windows 10 (1803) or later. Current build: $($osVersion.Build)"
+}
+
+# --- Only x64 supported ---
+$arch = $env:PROCESSOR_ARCHITECTURE
+if ($arch -ne 'AMD64') {
+    Write-Err "c9watch currently only supports x64 architecture. Detected: $arch"
+}
+
+Write-Info "Detected Windows x64 (build $($osVersion.Build))"
+
+# --- Find latest release ---
+Write-Info "Fetching latest release..."
+
+try {
+    $releaseInfo = Invoke-RestMethod -Uri "https://api.github.com/repos/$REPO/releases/latest" -UseBasicParsing
+    $latestTag = $releaseInfo.tag_name
+} catch {
+    Write-Err "Could not determine the latest release. Check https://github.com/$REPO/releases"
+}
+
+if (-not $latestTag) {
+    Write-Err "Could not determine the latest release tag."
+}
+
+$version = $latestTag.TrimStart('v')
+Write-Info "Latest version: $latestTag"
+
+# --- Look for NSIS installer first, then MSI ---
+$nsisPattern = "${APP_NAME}_${version}_x64-setup.exe"
+$msiPattern  = "${APP_NAME}_${version}_x64_en-US.msi"
+
+$downloadAsset = $null
+$installerType = $null
+
+foreach ($asset in $releaseInfo.assets) {
+    if ($asset.name -eq $nsisPattern) {
+        $downloadAsset = $asset
+        $installerType = 'nsis'
+        break
+    }
+    if ($asset.name -eq $msiPattern) {
+        $downloadAsset = $asset
+        $installerType = 'msi'
+    }
+}
+
+if (-not $downloadAsset) {
+    Write-Err "No installer found for x64 in release $latestTag.`nLooked for: $nsisPattern or $msiPattern"
+}
+
+$downloadUrl = $downloadAsset.browser_download_url
+$fileName = $downloadAsset.name
+
+Write-Info "Downloading $fileName..."
+
+# --- Download ---
+$tempDir = Join-Path $env:TEMP "c9watch-install-$(Get-Random)"
+New-Item -ItemType Directory -Path $tempDir -Force | Out-Null
+$installerPath = Join-Path $tempDir $fileName
+
+try {
+    $ProgressPreference = 'SilentlyContinue'
+    Invoke-WebRequest -Uri $downloadUrl -OutFile $installerPath -UseBasicParsing
+    $ProgressPreference = 'Continue'
+} catch {
+    Write-Err "Failed to download installer: $_"
+}
+
+Write-Info "Downloaded to $installerPath"
+
+# --- Install ---
+Write-Info "Running installer..."
+
+try {
+    if ($installerType -eq 'nsis') {
+        $process = Start-Process -FilePath $installerPath -Wait -PassThru
+    } else {
+        $process = Start-Process -FilePath 'msiexec.exe' -ArgumentList "/i `"$installerPath`"" -Wait -PassThru
+    }
+    if ($process.ExitCode -ne 0) {
+        Write-Err "Installer exited with code $($process.ExitCode)"
+    }
+} catch {
+    Write-Err "Installation failed: $_"
+}
+
+# --- Cleanup ---
+Remove-Item -Path $tempDir -Recurse -Force -ErrorAction SilentlyContinue
+
+# --- Done ---
+Write-Host ""
+Write-Info "$APP_NAME has been installed successfully!"
+Write-Info "You can launch it from the Start Menu or by searching for '$APP_NAME'."
+Write-Host ""

--- a/install.sh
+++ b/install.sh
@@ -31,9 +31,21 @@ case "$ARCH" in
 esac
 
 OS=$(uname -s)
-if [ "$OS" != "Darwin" ]; then
-  error "c9watch is currently macOS-only. Detected OS: $OS"
-fi
+case "$OS" in
+  MINGW*|MSYS*|CYGWIN*)
+    info "Windows detected. Please use the PowerShell installer instead:"
+    echo ""
+    echo "    irm https://raw.githubusercontent.com/${REPO}/main/install.ps1 | iex"
+    echo ""
+    exit 0
+    ;;
+  Darwin)
+    # macOS - continue installation
+    ;;
+  *)
+    error "This installer supports macOS only. For Windows, use install.ps1. Detected OS: $OS"
+    ;;
+esac
 
 info "Detected macOS ($ARCH_LABEL)"
 

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -413,6 +413,7 @@ dependencies = [
  "tauri-plugin-updater",
  "thiserror 1.0.69",
  "tokio",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -42,3 +42,11 @@ base64 = "0.22"
 
 [target."cfg(target_os = \"macos\")".dependencies]
 tauri-nspanel = { git = "https://github.com/ahkohd/tauri-nspanel", rev = "da9c9a8d4eb7f0524a2508988df1a7d9585b4904" }
+
+[target."cfg(target_os = \"windows\")".dependencies]
+windows-sys = { version = "0.59", features = [
+    "Win32_Foundation",
+    "Win32_System_Threading",
+    "Win32_System_Diagnostics_ToolHelp",
+    "Win32_UI_WindowsAndMessaging",
+] }

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -46,7 +46,5 @@ tauri-nspanel = { git = "https://github.com/ahkohd/tauri-nspanel", rev = "da9c9a
 [target."cfg(target_os = \"windows\")".dependencies]
 windows-sys = { version = "0.59", features = [
     "Win32_Foundation",
-    "Win32_System_Threading",
-    "Win32_System_Diagnostics_ToolHelp",
     "Win32_UI_WindowsAndMessaging",
 ] }

--- a/src-tauri/src/actions.rs
+++ b/src-tauri/src/actions.rs
@@ -1374,4 +1374,66 @@ mod tests {
             Some("iTerm")
         );
     }
+
+    #[test]
+    fn test_get_app_name_windows_exe_suffix() {
+        // .exe stripping is cross-platform safe — these tests run everywhere
+        assert_eq!(get_app_name("Code.exe"), Some("Visual Studio Code"));
+        assert_eq!(get_app_name("Cursor.exe"), Some("Cursor"));
+        assert_eq!(get_app_name("Windsurf.exe"), Some("Windsurf"));
+        assert_eq!(get_app_name("WindowsTerminal.exe"), Some("Windows Terminal"));
+        assert_eq!(get_app_name("pwsh.exe"), Some("PowerShell"));
+        assert_eq!(get_app_name("powershell.exe"), Some("PowerShell"));
+        assert_eq!(get_app_name("cmd.exe"), Some("Command Prompt"));
+        assert_eq!(get_app_name("alacritty.exe"), Some("Alacritty"));
+        assert_eq!(get_app_name("kitty.exe"), Some("kitty"));
+        assert_eq!(get_app_name("zed.exe"), Some("Zed"));
+    }
+
+    #[test]
+    fn test_get_app_name_windows_backslash_paths() {
+        // Windows-style paths with backslashes
+        assert_eq!(
+            get_app_name(r"C:\Program Files\Microsoft VS Code\Code.exe"),
+            Some("Visual Studio Code")
+        );
+        assert_eq!(
+            get_app_name(r"C:\Users\user\AppData\Local\Programs\cursor\Cursor.exe"),
+            Some("Cursor")
+        );
+        assert_eq!(
+            get_app_name(r"C:\Program Files\WindowsApps\WindowsTerminal.exe"),
+            Some("Windows Terminal")
+        );
+    }
+
+    #[test]
+    fn test_get_app_name_windows_terminals() {
+        // Windows terminal process names without .exe
+        assert_eq!(get_app_name("windowsterminal"), Some("Windows Terminal"));
+        assert_eq!(get_app_name("pwsh"), Some("PowerShell"));
+        assert_eq!(get_app_name("powershell"), Some("PowerShell"));
+        assert_eq!(get_app_name("cmd"), Some("Command Prompt"));
+    }
+
+    #[test]
+    fn test_windows_path_encoding() {
+        // Verify the path encoding logic matches what detector.rs does
+        let windows_path = r"C:\Users\Name\My_Project";
+        let encoded = windows_path
+            .replace('\\', "-")
+            .replace('/', "-")
+            .replace('_', "-")
+            .replace(':', "");
+        assert_eq!(encoded, "C-Users-Name-My-Project");
+
+        // Unix path for comparison
+        let unix_path = "/Users/Name/My_Project";
+        let encoded = unix_path
+            .replace('\\', "-")
+            .replace('/', "-")
+            .replace('_', "-")
+            .replace(':', "");
+        assert_eq!(encoded, "-Users-Name-My-Project");
+    }
 }

--- a/src-tauri/src/actions.rs
+++ b/src-tauri/src/actions.rs
@@ -342,7 +342,45 @@ fn activate_app_fallback(app_name: &str) -> Result<(), String> {
     Ok(())
 }
 
-#[cfg(not(any(target_os = "macos", target_os = "linux")))]
+/// Windows fallback: use Win32 APIs to find and activate a window
+#[cfg(target_os = "windows")]
+fn activate_app_fallback(app_name: &str) -> Result<(), String> {
+    use std::ffi::OsStr;
+    use std::os::windows::ffi::OsStrExt;
+    use windows_sys::Win32::UI::WindowsAndMessaging::*;
+
+    // Map app names to window title patterns
+    let search_title: &str = match app_name {
+        "Visual Studio Code" => "Visual Studio Code",
+        "Cursor" => "Cursor",
+        "Windsurf" => "Windsurf",
+        "Windows Terminal" => "Windows Terminal",
+        "PowerShell" => "PowerShell",
+        "Command Prompt" => "Command Prompt",
+        _ => app_name,
+    };
+
+    // Use FindWindowW to find the window by title
+    let title_wide: Vec<u16> = OsStr::new(search_title)
+        .encode_wide()
+        .chain(Some(0))
+        .collect();
+
+    unsafe {
+        let hwnd = FindWindowW(std::ptr::null(), title_wide.as_ptr());
+        if hwnd != 0 {
+            ShowWindow(hwnd, SW_RESTORE);
+            SetForegroundWindow(hwnd);
+            eprintln!("[open_session] Activated window for: {}", app_name);
+        } else {
+            eprintln!("[open_session] Window not found for: {}", app_name);
+        }
+    }
+
+    Ok(())
+}
+
+#[cfg(not(any(target_os = "macos", target_os = "linux", target_os = "windows")))]
 fn activate_app_fallback(_app_name: &str) -> Result<(), String> {
     Ok(())
 }
@@ -624,12 +662,69 @@ fn get_app_cli(app_name: &str) -> Option<String> {
     None
 }
 
-#[cfg(not(any(target_os = "macos", target_os = "linux")))]
+/// Get the CLI path for an application on Windows
+#[cfg(target_os = "windows")]
+fn get_app_cli(app_name: &str) -> Option<String> {
+    let local_app_data = std::env::var("LOCALAPPDATA").ok()?;
+    let program_files = std::env::var("PROGRAMFILES").ok()?;
+
+    let cli_paths: Vec<(&str, Vec<String>)> = vec![
+        (
+            "Visual Studio Code",
+            vec![
+                format!(
+                    r"{}\Programs\Microsoft VS Code\bin\code.cmd",
+                    local_app_data
+                ),
+                format!(r"{}\Microsoft VS Code\bin\code.cmd", program_files),
+            ],
+        ),
+        (
+            "Cursor",
+            vec![
+                format!(
+                    r"{}\Programs\cursor\resources\app\bin\cursor.cmd",
+                    local_app_data
+                ),
+                format!(r"{}\Cursor\resources\app\bin\cursor.cmd", local_app_data),
+            ],
+        ),
+        (
+            "Windsurf",
+            vec![
+                format!(r"{}\Programs\Windsurf\bin\windsurf.cmd", local_app_data),
+                format!(r"{}\Windsurf\bin\windsurf.cmd", program_files),
+            ],
+        ),
+        (
+            "Zed",
+            vec![
+                format!(r"{}\Zed\zed.exe", local_app_data),
+                format!(r"{}\Programs\Zed\zed.exe", local_app_data),
+            ],
+        ),
+    ];
+
+    for (name, paths) in &cli_paths {
+        if *name == app_name {
+            for path in paths {
+                if std::path::Path::new(path).exists() {
+                    return Some(path.clone());
+                }
+            }
+        }
+    }
+
+    None
+}
+
+#[cfg(not(any(target_os = "macos", target_os = "linux", target_os = "windows")))]
 fn get_app_cli(_app_name: &str) -> Option<String> {
     None
 }
 
-/// Find the parent GUI application for a given process ID
+/// Find the parent GUI application for a given process ID (Unix: macOS/Linux)
+#[cfg(unix)]
 fn find_parent_app(pid: u32) -> Result<String, String> {
     let mut current_pid = pid;
 
@@ -699,10 +794,64 @@ fn find_parent_app(pid: u32) -> Result<String, String> {
         crate::debug_log::log_warn("[open_session] Falling back to xterm");
         Ok("xterm".to_string())
     }
-    #[cfg(not(any(target_os = "macos", target_os = "linux")))]
-    {
-        Ok("Terminal".to_string())
+}
+
+/// Find the parent GUI application for a given process ID (Windows)
+#[cfg(target_os = "windows")]
+fn find_parent_app(pid: u32) -> Result<String, String> {
+    let mut current_pid = pid;
+
+    eprintln!("[open_session] Starting with PID: {}", pid);
+
+    for i in 0..20 {
+        let output = Command::new("powershell")
+            .arg("-NoProfile")
+            .arg("-NonInteractive")
+            .arg("-Command")
+            .arg(format!(
+                "Get-CimInstance -ClassName Win32_Process -Filter 'ProcessId={}' | Select-Object Name,ParentProcessId | ConvertTo-Json",
+                current_pid
+            ))
+            .output()
+            .map_err(|e| format!("Failed to execute PowerShell: {}", e))?;
+
+        let stdout = String::from_utf8_lossy(&output.stdout);
+        eprintln!(
+            "[open_session] Step {}: PID {} -> output: {}",
+            i,
+            current_pid,
+            stdout.trim()
+        );
+
+        // Parse JSON output
+        let json: serde_json::Value = serde_json::from_str(stdout.trim())
+            .map_err(|e| format!("Failed to parse process info: {}", e))?;
+
+        let process_name = json["Name"].as_str().unwrap_or("").to_string();
+        let parent_pid = json["ParentProcessId"].as_u64().unwrap_or(0) as u32;
+
+        if process_name.is_empty() {
+            break;
+        }
+
+        eprintln!(
+            "[open_session] Process: {} (PPID: {})",
+            process_name, parent_pid
+        );
+
+        if let Some(app_name) = get_app_name(&process_name) {
+            eprintln!("[open_session] Found app: {}", app_name);
+            return Ok(app_name.to_string());
+        }
+
+        if parent_pid <= 1 || parent_pid == current_pid {
+            break;
+        }
+        current_pid = parent_pid;
     }
+
+    eprintln!("[open_session] Falling back to Windows Terminal");
+    Ok("Windows Terminal".to_string())
 }
 
 /// Map process command names to application names
@@ -807,8 +956,17 @@ fn get_app_name(comm: &str) -> Option<&'static str> {
         }
     }
 
-    // Extract the base name from the path
-    let base_name = comm.rsplit('/').next().unwrap_or(comm);
+    // Extract the base name from the path (handle both Unix / and Windows \)
+    let base_name = comm
+        .rsplit('/')
+        .next()
+        .unwrap_or(comm)
+        .rsplit('\\')
+        .next()
+        .unwrap_or(comm);
+
+    // Strip .exe suffix for Windows process names (safe on all platforms)
+    let base_name = base_name.strip_suffix(".exe").unwrap_or(base_name);
 
     match base_name.to_lowercase().as_str() {
         // Terminals (cross-platform names)
@@ -853,6 +1011,11 @@ fn get_app_name(comm: &str) -> Option<&'static str> {
         "sublime_text" | "subl" => Some("Sublime Text"),
         "atom" => Some("Atom"),
 
+        // Windows-specific process names
+        "windowsterminal" => Some("Windows Terminal"),
+        "pwsh" | "powershell" => Some("PowerShell"),
+        "cmd" => Some("Command Prompt"),
+
         _ => None,
     }
 }
@@ -862,10 +1025,11 @@ fn is_jetbrains_ide(app_name: &str) -> bool {
     jetbrains_url_scheme(app_name).is_some()
 }
 
-/// Stop a session by sending SIGTERM to the process
+/// Stop a session by sending SIGTERM to the process (Unix: macOS/Linux)
 ///
 /// This gracefully terminates the Claude process by sending a SIGTERM signal.
 /// SIGTERM is preferred over SIGINT as Claude Code may trap SIGINT for its own use.
+#[cfg(unix)]
 pub fn stop_session(pid: u32) -> Result<(), String> {
     crate::debug_log::log_info(&format!("[stop_session] Stopping PID: {}", pid));
 
@@ -885,6 +1049,45 @@ pub fn stop_session(pid: u32) -> Result<(), String> {
     }
 
     crate::debug_log::log_info("[stop_session] SIGTERM sent successfully");
+    Ok(())
+}
+
+/// Stop a session by terminating the process (Windows)
+///
+/// Uses taskkill to terminate the Claude process. First tries graceful termination,
+/// then falls back to force kill if needed.
+#[cfg(target_os = "windows")]
+pub fn stop_session(pid: u32) -> Result<(), String> {
+    eprintln!("[stop_session] Stopping PID: {} on Windows", pid);
+
+    // First try graceful termination with taskkill (sends WM_CLOSE)
+    let output = Command::new("taskkill")
+        .arg("/PID")
+        .arg(pid.to_string())
+        .output()
+        .map_err(|e| format!("Failed to execute taskkill: {}", e))?;
+
+    if output.status.success() {
+        eprintln!("[stop_session] Graceful termination succeeded");
+        return Ok(());
+    }
+
+    // If graceful fails, try force kill
+    eprintln!("[stop_session] Graceful termination failed, trying force kill");
+    let output = Command::new("taskkill")
+        .arg("/F")
+        .arg("/PID")
+        .arg(pid.to_string())
+        .output()
+        .map_err(|e| format!("Failed to execute taskkill /F: {}", e))?;
+
+    if !output.status.success() {
+        let error = String::from_utf8_lossy(&output.stderr);
+        eprintln!("[stop_session] Force kill failed: {}", error);
+        return Err(format!("Failed to stop process {}: {}", pid, error));
+    }
+
+    eprintln!("[stop_session] Force kill succeeded");
     Ok(())
 }
 

--- a/src-tauri/src/actions.rs
+++ b/src-tauri/src/actions.rs
@@ -342,35 +342,52 @@ fn activate_app_fallback(app_name: &str) -> Result<(), String> {
     Ok(())
 }
 
-/// Windows fallback: use Win32 APIs to find and activate a window
+/// Windows fallback: use Win32 APIs to find and activate a window by substring title match
 #[cfg(target_os = "windows")]
 fn activate_app_fallback(app_name: &str) -> Result<(), String> {
-    use std::ffi::OsStr;
-    use std::os::windows::ffi::OsStrExt;
+    use std::ffi::OsString;
+    use std::os::windows::ffi::OsStringExt;
+    use windows_sys::Win32::Foundation::*;
     use windows_sys::Win32::UI::WindowsAndMessaging::*;
 
-    // Map app names to window title patterns
-    let search_title: &str = match app_name {
-        "Visual Studio Code" => "Visual Studio Code",
-        "Cursor" => "Cursor",
-        "Windsurf" => "Windsurf",
-        "Windows Terminal" => "Windows Terminal",
-        "PowerShell" => "PowerShell",
-        "Command Prompt" => "Command Prompt",
-        _ => app_name,
+    // The search substring to look for in window titles
+    let search_title: &str = app_name;
+
+    // EnumWindows callback data
+    struct FindData {
+        needle: String,
+        found_hwnd: isize, // HWND is isize on windows-sys
+    }
+
+    unsafe extern "system" fn enum_callback(hwnd: HWND, lparam: LPARAM) -> BOOL {
+        let data = &mut *(lparam as *mut FindData);
+        let mut buf = [0u16; 512];
+        let len = GetWindowTextW(hwnd, buf.as_mut_ptr(), buf.len() as i32);
+        if len > 0 {
+            let title = OsString::from_wide(&buf[..len as usize])
+                .to_string_lossy()
+                .to_lowercase();
+            if title.contains(&data.needle) {
+                // Check window is visible
+                if IsWindowVisible(hwnd) != 0 {
+                    data.found_hwnd = hwnd;
+                    return 0; // Stop enumeration
+                }
+            }
+        }
+        1 // Continue enumeration
+    }
+
+    let mut data = FindData {
+        needle: search_title.to_lowercase(),
+        found_hwnd: 0,
     };
 
-    // Use FindWindowW to find the window by title
-    let title_wide: Vec<u16> = OsStr::new(search_title)
-        .encode_wide()
-        .chain(Some(0))
-        .collect();
-
     unsafe {
-        let hwnd = FindWindowW(std::ptr::null(), title_wide.as_ptr());
-        if hwnd != 0 {
-            ShowWindow(hwnd, SW_RESTORE);
-            SetForegroundWindow(hwnd);
+        EnumWindows(Some(enum_callback), &mut data as *mut FindData as LPARAM);
+        if data.found_hwnd != 0 {
+            ShowWindow(data.found_hwnd, SW_RESTORE);
+            SetForegroundWindow(data.found_hwnd);
             eprintln!("[open_session] Activated window for: {}", app_name);
         } else {
             eprintln!("[open_session] Window not found for: {}", app_name);
@@ -668,54 +685,30 @@ fn get_app_cli(app_name: &str) -> Option<String> {
     let local_app_data = std::env::var("LOCALAPPDATA").ok()?;
     let program_files = std::env::var("PROGRAMFILES").ok()?;
 
-    let cli_paths: Vec<(&str, Vec<String>)> = vec![
-        (
-            "Visual Studio Code",
-            vec![
-                format!(
-                    r"{}\Programs\Microsoft VS Code\bin\code.cmd",
-                    local_app_data
-                ),
-                format!(r"{}\Microsoft VS Code\bin\code.cmd", program_files),
-            ],
-        ),
-        (
-            "Cursor",
-            vec![
-                format!(
-                    r"{}\Programs\cursor\resources\app\bin\cursor.cmd",
-                    local_app_data
-                ),
-                format!(r"{}\Cursor\resources\app\bin\cursor.cmd", local_app_data),
-            ],
-        ),
-        (
-            "Windsurf",
-            vec![
-                format!(r"{}\Programs\Windsurf\bin\windsurf.cmd", local_app_data),
-                format!(r"{}\Windsurf\bin\windsurf.cmd", program_files),
-            ],
-        ),
-        (
-            "Zed",
-            vec![
-                format!(r"{}\Zed\zed.exe", local_app_data),
-                format!(r"{}\Programs\Zed\zed.exe", local_app_data),
-            ],
-        ),
-    ];
+    // Only build candidate paths for the matched app (avoids allocating all paths)
+    let candidates: Vec<String> = match app_name {
+        "Visual Studio Code" => vec![
+            format!(r"{}\Programs\Microsoft VS Code\bin\code.cmd", local_app_data),
+            format!(r"{}\Microsoft VS Code\bin\code.cmd", program_files),
+        ],
+        "Cursor" => vec![
+            format!(r"{}\Programs\cursor\resources\app\bin\cursor.cmd", local_app_data),
+            format!(r"{}\Cursor\resources\app\bin\cursor.cmd", local_app_data),
+        ],
+        "Windsurf" => vec![
+            format!(r"{}\Programs\Windsurf\bin\windsurf.cmd", local_app_data),
+            format!(r"{}\Windsurf\bin\windsurf.cmd", program_files),
+        ],
+        "Zed" => vec![
+            format!(r"{}\Zed\zed.exe", local_app_data),
+            format!(r"{}\Programs\Zed\zed.exe", local_app_data),
+        ],
+        _ => return None,
+    };
 
-    for (name, paths) in &cli_paths {
-        if *name == app_name {
-            for path in paths {
-                if std::path::Path::new(path).exists() {
-                    return Some(path.clone());
-                }
-            }
-        }
-    }
-
-    None
+    candidates
+        .into_iter()
+        .find(|path| std::path::Path::new(path).exists())
 }
 
 #[cfg(not(any(target_os = "macos", target_os = "linux", target_os = "windows")))]
@@ -823,9 +816,12 @@ fn find_parent_app(pid: u32) -> Result<String, String> {
             stdout.trim()
         );
 
-        // Parse JSON output
-        let json: serde_json::Value = serde_json::from_str(stdout.trim())
-            .map_err(|e| format!("Failed to parse process info: {}", e))?;
+        // Parse JSON output — treat parse failures as a loop-break, not a hard error,
+        // since transient CIM query failures for intermediate PIDs shouldn't abort the walk
+        let Ok(json) = serde_json::from_str::<serde_json::Value>(stdout.trim()) else {
+            eprintln!("[open_session] Failed to parse JSON for PID {}, stopping walk", current_pid);
+            break;
+        };
 
         let process_name = json["Name"].as_str().unwrap_or("").to_string();
         let parent_pid = json["ParentProcessId"].as_u64().unwrap_or(0) as u32;
@@ -1418,22 +1414,13 @@ mod tests {
 
     #[test]
     fn test_windows_path_encoding() {
-        // Verify the path encoding logic matches what detector.rs does
-        let windows_path = r"C:\Users\Name\My_Project";
-        let encoded = windows_path
-            .replace('\\', "-")
-            .replace('/', "-")
-            .replace('_', "-")
-            .replace(':', "");
-        assert_eq!(encoded, "C-Users-Name-My-Project");
+        // Verify the encoding logic used by detector.rs for session matching
+        // This uses the same replace chain as detector.rs: replace(\, /, _ with -) then strip :
+        let encode = |s: &str| -> String {
+            s.replace(['\\', '/', '_'], "-").replace(':', "")
+        };
 
-        // Unix path for comparison
-        let unix_path = "/Users/Name/My_Project";
-        let encoded = unix_path
-            .replace('\\', "-")
-            .replace('/', "-")
-            .replace('_', "-")
-            .replace(':', "");
-        assert_eq!(encoded, "-Users-Name-My-Project");
+        assert_eq!(encode(r"C:\Users\Name\My_Project"), "C-Users-Name-My-Project");
+        assert_eq!(encode("/Users/Name/My_Project"), "-Users-Name-My-Project");
     }
 }

--- a/src-tauri/src/actions.rs
+++ b/src-tauri/src/actions.rs
@@ -353,10 +353,10 @@ fn activate_app_fallback(app_name: &str) -> Result<(), String> {
     // The search substring to look for in window titles
     let search_title: &str = app_name;
 
-    // EnumWindows callback data
+    // EnumWindows callback data — HWND is *mut c_void on windows-sys 0.59
     struct FindData {
         needle: String,
-        found_hwnd: isize, // HWND is isize on windows-sys
+        found_hwnd: HWND,
     }
 
     unsafe extern "system" fn enum_callback(hwnd: HWND, lparam: LPARAM) -> BOOL {
@@ -380,12 +380,12 @@ fn activate_app_fallback(app_name: &str) -> Result<(), String> {
 
     let mut data = FindData {
         needle: search_title.to_lowercase(),
-        found_hwnd: 0,
+        found_hwnd: std::ptr::null_mut(),
     };
 
     unsafe {
         EnumWindows(Some(enum_callback), &mut data as *mut FindData as LPARAM);
-        if data.found_hwnd != 0 {
+        if !data.found_hwnd.is_null() {
             ShowWindow(data.found_hwnd, SW_RESTORE);
             SetForegroundWindow(data.found_hwnd);
             eprintln!("[open_session] Activated window for: {}", app_name);

--- a/src-tauri/src/actions.rs
+++ b/src-tauri/src/actions.rs
@@ -1411,16 +1411,4 @@ mod tests {
         assert_eq!(get_app_name("powershell"), Some("PowerShell"));
         assert_eq!(get_app_name("cmd"), Some("Command Prompt"));
     }
-
-    #[test]
-    fn test_windows_path_encoding() {
-        // Verify the encoding logic used by detector.rs for session matching
-        // This uses the same replace chain as detector.rs: replace(\, /, _ with -) then strip :
-        let encode = |s: &str| -> String {
-            s.replace(['\\', '/', '_'], "-").replace(':', "")
-        };
-
-        assert_eq!(encode(r"C:\Users\Name\My_Project"), "C-Users-Name-My-Project");
-        assert_eq!(encode("/Users/Name/My_Project"), "-Users-Name-My-Project");
-    }
 }

--- a/src-tauri/src/debug_log.rs
+++ b/src-tauri/src/debug_log.rs
@@ -85,8 +85,7 @@ mod tests {
 
     #[test]
     fn test_log_and_retrieve() {
-        // Use unique messages to avoid interference from parallel tests
-        // sharing the global buffer.
+        clear_buffer();
         log_info("test_lar_hello");
         log_error("test_lar_broke");
 

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -180,11 +180,18 @@ async fn save_temp_image(data: String) -> Result<String, String> {
     Ok(file_path.to_string_lossy().to_string())
 }
 
-/// Open a directory in the system file manager (Finder on macOS)
+/// Open a directory in the system file manager
 #[cfg(not(mobile))]
 #[tauri::command]
 async fn reveal_in_file_manager(path: String) -> Result<(), String> {
-    std::process::Command::new("open")
+    #[cfg(target_os = "macos")]
+    let cmd = "open";
+    #[cfg(target_os = "windows")]
+    let cmd = "explorer";
+    #[cfg(target_os = "linux")]
+    let cmd = "xdg-open";
+
+    std::process::Command::new(cmd)
         .arg(&path)
         .spawn()
         .map_err(|e| format!("Failed to open directory: {}", e))?;

--- a/src-tauri/src/session/detector.rs
+++ b/src-tauri/src/session/detector.rs
@@ -346,11 +346,8 @@ impl SessionDetector {
             let name = process.name().to_string_lossy();
             let name_lower = name.to_lowercase();
 
-            // Match "claude" on Unix and "claude.exe" on Windows
-            // Exclude c9watch's own process
-            let is_claude = name_lower == "claude"
-                || name_lower == "claude.exe"
-                || (name_lower.contains("claude") && !name_lower.contains("c9watch"));
+            // Match processes with "claude" in the name, excluding c9watch itself
+            let is_claude = name_lower.contains("claude") && !name_lower.contains("c9watch");
 
             if is_claude {
                 // Get the current working directory of the process

--- a/src-tauri/src/session/detector.rs
+++ b/src-tauri/src/session/detector.rs
@@ -204,7 +204,13 @@ impl SessionDetector {
         for proc in sorted_processes {
             let proc_cwd = match &proc.cwd {
                 Some(cwd) => cwd,
-                None => continue, // Skip processes without cwd
+                None => {
+                    eprintln!(
+                        "[c9watch] Skipping claude process pid={}: cwd unavailable",
+                        proc.pid
+                    );
+                    continue;
+                }
             };
 
             // Encode the process cwd for matching against Claude's project directory names.
@@ -473,6 +479,12 @@ mod tests {
     #[test]
     fn test_encode_path_for_matching() {
         // Must match Claude Code's encoding: replace every non-alphanumeric char with '-'.
+        // Windows: colon AND backslash each become a dash → double dash after drive letter
+        assert_eq!(
+            encode_path_for_matching(r"C:\Users\Name\My_Project"),
+            "C--Users-Name-My-Project"
+        );
+        // macOS/Linux: leading slash becomes a dash
         assert_eq!(
             encode_path_for_matching("/Users/Name/My_Project"),
             "-Users-Name-My-Project"
@@ -491,6 +503,16 @@ mod tests {
         assert_eq!(
             encode_path_for_matching("/Users/Name/project.v2"),
             "-Users-Name-project-v2"
+        );
+        // Windows spaces
+        assert_eq!(
+            encode_path_for_matching(r"C:\Users\Name\My Project"),
+            "C--Users-Name-My-Project"
+        );
+        // UNC paths (Windows network shares)
+        assert_eq!(
+            encode_path_for_matching(r"\\server\share\project"),
+            "--server-share-project"
         );
     }
 }

--- a/src-tauri/src/session/detector.rs
+++ b/src-tauri/src/session/detector.rs
@@ -57,13 +57,20 @@ impl SessionDetector {
 
         let claude_projects_dir = home_dir.join(".claude").join("projects");
 
+        #[allow(unused_mut)]
+        let mut process_refresh = ProcessRefreshKind::new()
+            .with_exe(UpdateKind::OnlyIfNotSet)
+            .with_cwd(UpdateKind::OnlyIfNotSet);
+
+        // On Windows, also fetch command-line args to filter out Claude Desktop processes
+        #[cfg(target_os = "windows")]
+        {
+            process_refresh = process_refresh.with_cmd(UpdateKind::OnlyIfNotSet);
+        }
+
         Ok(Self {
             system: System::new_with_specifics(
-                RefreshKind::new().with_processes(
-                    ProcessRefreshKind::new()
-                        .with_exe(UpdateKind::OnlyIfNotSet)
-                        .with_cwd(UpdateKind::OnlyIfNotSet),
-                ),
+                RefreshKind::new().with_processes(process_refresh),
             ),
             claude_projects_dir,
         })
@@ -72,12 +79,20 @@ impl SessionDetector {
     /// Detects all active Claude Code sessions
     pub fn detect_sessions(&mut self) -> Result<(Vec<DetectedSession>, DetectionDiagnostics), SessionDetectorError> {
         // Refresh process information (only what we need: name, cwd, start_time)
+        #[allow(unused_mut)]
+        let mut process_refresh = ProcessRefreshKind::new()
+            .with_exe(UpdateKind::OnlyIfNotSet)
+            .with_cwd(UpdateKind::OnlyIfNotSet);
+
+        #[cfg(target_os = "windows")]
+        {
+            process_refresh = process_refresh.with_cmd(UpdateKind::OnlyIfNotSet);
+        }
+
         self.system.refresh_processes_specifics(
             ProcessesToUpdate::All,
             true,
-            ProcessRefreshKind::new()
-                .with_exe(UpdateKind::OnlyIfNotSet)
-                .with_cwd(UpdateKind::OnlyIfNotSet),
+            process_refresh,
         );
 
         // Find all running Claude processes
@@ -214,8 +229,10 @@ impl SessionDetector {
             };
 
             // Encode the process cwd for matching against Claude's project directory names.
+            // Trim trailing separators first — Windows sysinfo often includes trailing '\'.
             let cwd_str = proc_cwd.to_string_lossy();
-            let encoded_cwd = encode_path_for_matching(&cwd_str);
+            let trimmed = cwd_str.trim_end_matches(['/', '\\']);
+            let encoded_cwd = encode_path_for_matching(trimmed);
 
             // Helper closure to check if a session matches the process path
             let path_matches =
@@ -343,29 +360,49 @@ impl SessionDetector {
         None
     }
 
-    /// Finds all processes with name "claude"
+    /// Finds all running Claude Code CLI processes.
+    /// Filters out Claude Desktop (Electron) subprocesses on Windows.
     fn find_claude_processes(&self) -> Vec<ClaudeProcess> {
         let mut processes = Vec::new();
 
         for (pid, process) in self.system.processes() {
-            // Check if the process name is "claude"
             let name = process.name().to_string_lossy();
             let name_lower = name.to_lowercase();
 
             // Match processes with "claude" in the name, excluding c9watch itself
-            let is_claude = name_lower.contains("claude") && !name_lower.contains("c9watch");
-
-            if is_claude {
-                // Get the current working directory of the process
-                let cwd = process.cwd().map(|p| p.to_path_buf());
-                let start_time = process.start_time();
-
-                processes.push(ClaudeProcess {
-                    pid: pid.as_u32(),
-                    cwd,
-                    start_time,
-                });
+            if !name_lower.contains("claude") || name_lower.contains("c9watch") {
+                continue;
             }
+
+            // On Windows, filter out Claude Desktop (Electron) subprocesses.
+            // These have --type= flags (renderer, GPU, utility) or --startup,
+            // or their exe path contains "AnthropicClaude".
+            #[cfg(target_os = "windows")]
+            {
+                let exe_path = process.exe().map(|p| p.to_string_lossy().to_string());
+                let cmd_args = process.cmd();
+
+                let is_desktop = exe_path
+                    .as_ref()
+                    .map_or(false, |p| p.contains("AnthropicClaude"));
+
+                let has_electron_flags = cmd_args
+                    .iter()
+                    .any(|arg| arg.to_string_lossy().starts_with("--type="));
+
+                if is_desktop || has_electron_flags {
+                    continue;
+                }
+            }
+
+            let cwd = process.cwd().map(|p| p.to_path_buf());
+            let start_time = process.start_time();
+
+            processes.push(ClaudeProcess {
+                pid: pid.as_u32(),
+                cwd,
+                start_time,
+            });
         }
 
         processes
@@ -513,6 +550,24 @@ mod tests {
         assert_eq!(
             encode_path_for_matching(r"\\server\share\project"),
             "--server-share-project"
+        );
+        // Trailing separators should be trimmed BEFORE calling this function,
+        // so encoding itself does not handle them — test the trim + encode combo:
+        let trim_and_encode = |s: &str| {
+            encode_path_for_matching(s.trim_end_matches(['/', '\\']))
+        };
+        assert_eq!(
+            trim_and_encode(r"C:\Users\Name\project\"),
+            "C--Users-Name-project"
+        );
+        assert_eq!(
+            trim_and_encode("/Users/Name/project/"),
+            "-Users-Name-project"
+        );
+        // Without trailing separator, result is the same
+        assert_eq!(
+            trim_and_encode(r"C:\Users\Name\project"),
+            "C--Users-Name-project"
         );
     }
 }

--- a/src-tauri/src/session/detector.rs
+++ b/src-tauri/src/session/detector.rs
@@ -344,8 +344,15 @@ impl SessionDetector {
         for (pid, process) in self.system.processes() {
             // Check if the process name is "claude"
             let name = process.name().to_string_lossy();
+            let name_lower = name.to_lowercase();
 
-            if name.contains("claude") && !name.contains("c9watch") {
+            // Match "claude" on Unix and "claude.exe" on Windows
+            // Exclude c9watch's own process
+            let is_claude = name_lower == "claude"
+                || name_lower == "claude.exe"
+                || (name_lower.contains("claude") && !name_lower.contains("c9watch"));
+
+            if is_claude {
                 // Get the current working directory of the process
                 let cwd = process.cwd().map(|p| p.to_path_buf());
                 let start_time = process.start_time();

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -44,7 +44,7 @@
   },
   "bundle": {
     "active": true,
-    "targets": ["dmg", "app", "deb", "appimage"],
+    "targets": ["dmg", "app", "nsis", "msi", "deb", "appimage"],
     "icon": [
       "icons/32x32.png",
       "icons/128x128.png",
@@ -57,6 +57,16 @@
       "minimumSystemVersion": "10.15",
       "signingIdentity": "-",
       "entitlements": "entitlements.plist"
+    },
+    "windows": {
+      "certificateThumbprint": null,
+      "digestAlgorithm": "sha256",
+      "timestampUrl": "",
+      "nsis": {
+        "displayLanguageSelector": false,
+        "installerIcon": "icons/icon.ico",
+        "languages": ["English"]
+      }
     },
     "createUpdaterArtifacts": "v1Compatible"
   },

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -37,7 +37,9 @@ export async function getConversation(sessionId: string): Promise<Conversation> 
 }
 
 /**
- * Stop a running session by sending SIGTERM
+ * Stop a running session by terminating the process
+ * On Unix: Sends SIGTERM for graceful termination
+ * On Windows: Uses taskkill for process termination
  */
 export async function stopSession(pid: number): Promise<void> {
 	if (get(isDemoMode)) return;

--- a/src/routes/(app)/+page.svelte
+++ b/src/routes/(app)/+page.svelte
@@ -326,7 +326,7 @@
 		     centered in the whole tab bar so they appear at the window midpoint.
 		     Hidden in fullscreen where window dragging is unavailable. -->
 		<div class="tab-drag-region" data-tauri-drag-region>
-			{#if !isFullscreen}
+			{#if isMacOS && !isFullscreen}
 				<span class="drag-dots" transition:fade={{ duration: 250 }}>⠿ ⠿ ⠿</span>
 			{/if}
 		</div>

--- a/src/routes/(app)/+page.svelte
+++ b/src/routes/(app)/+page.svelte
@@ -53,9 +53,11 @@
 	// We use Tauri's window resize event + a short delay so isFullscreen()
 	// is queried after the transition has settled (avoids stale values).
 	let isFullscreen = $state(false);
+	let isMacOS = $state(false);
 
 	onMount(() => {
 		if (browser) {
+			isMacOS = /Mac/.test(navigator.platform);
 			const saved = localStorage.getItem('sessionViewMode');
 			if (saved === 'project' || saved === 'all') {
 				viewMode = saved;
@@ -287,7 +289,7 @@
 {:else}
 <div class="dashboard">
 	<FdaBanner {fdaLikelyNeeded} />
-	<div class="tab-bar" class:fullscreen={isFullscreen} data-tauri-drag-region>
+	<div class="tab-bar" class:fullscreen={isFullscreen} class:macos={isMacOS} data-tauri-drag-region>
 		<button
 			class="tab-btn"
 			class:active={activeTab === 'monitor'}
@@ -645,9 +647,7 @@
 		background: transparent;
 		z-index: 1000;
 		position: relative;
-		/* Left padding clears the macOS traffic light buttons (~80px) on
-		   titleBarStyle: Overlay windows. Right padding matches. */
-		padding: 0 var(--space-md) 0 80px;
+		padding: 0 var(--space-md);
 		transition: padding-left 0.35s ease;
 		/* Make the whole bar draggable (including the 80px padding over the
 		   traffic lights). Child buttons opt out via -webkit-app-region: no-drag. */
@@ -1071,6 +1071,15 @@
 
 	.empty-header-row :global(.status-bar) {
 		flex: 1;
+	}
+
+	/* ── macOS: clear traffic light buttons ────────────────────── */
+	/* On macOS the titleBarStyle: Overlay places traffic lights at top-left.
+	   80px left padding prevents tabs from sitting underneath them.
+	   On Windows the overlay controls are on the right, so no extra left
+	   padding is needed — the base rule already uses var(--space-md). */
+	.tab-bar.macos {
+		padding-left: 80px;
 	}
 
 	/* ── Fullscreen: align tab padding with content padding ────── */


### PR DESCRIPTION
## Summary

Add Windows support to c9watch, building on the work from PR #1 by @ntuee10 (closed). This is a fresh implementation on current main (v0.4.0) that addresses all 6 review issues from the original PR.

- Add Windows-specific session actions: process tree walking (PowerShell CIM), window activation (Win32 EnumWindows), app CLI detection, and taskkill-based termination
- Add Windows CI job and release pipeline (x64 NSIS + MSI)
- Add `install.ps1` PowerShell installer (Windows 10 1803+, x64)
- Update session detector for Windows path encoding and `claude.exe` matching
- Update README with Windows install/run docs and terminal/IDE compatibility table
- Fix `reveal_in_file_manager` to work cross-platform (was macOS-only)

### Issues addressed from PR #1 review

| Issue | Resolution |
|-------|------------|
| WMIC deprecated | Use PowerShell `Get-CimInstance` with JSON output |
| Win10/11 requirement inconsistency | Check build 17134 (Win10 1803), not 22000 |
| ARM64 mismatch | x64 only — no ARM64 detection in installer |
| No Windows tests | 4 new cross-platform tests for `.exe` suffix, backslash paths, terminals, path encoding |
| PowerShell+C# perf overhead | Use Win32 `EnumWindows`/`SetForegroundWindow` via windows-sys |
| Fragile CSV parsing | JSON output from CIM, parsed with serde_json |

## Test plan

- [x] All 104 Rust tests pass (macOS)
- [ ] Windows CI check passes
- [ ] macOS CI check passes (no regressions)
- [ ] `install.ps1` downloads and runs installer on Windows
- [ ] Session detection works on Windows

Closes #1 (supersedes)
cc @jrgcubano @ntuee10

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Eric <ntuee10@users.noreply.github.com>