### PR TITLE
feat: restore thinking toggle in conversation preview

### DIFF
--- a/src/lib/components/ExpandedCardOverlay.svelte
+++ b/src/lib/components/ExpandedCardOverlay.svelte
@@ -21,6 +21,7 @@
 	let isInitialLoad = $state(true);
 	let hasScrolledToBottom = $state(false);
 	let showTools = $state(true);
+	let showThinking = $state(true);
 	let navSheetOpen = $state(false);
 
 	function handleNavItemClick() {
@@ -172,6 +173,15 @@
 					<div class="header-divider"></div>
 					<button
 						type="button"
+						class="header-button toggle-thinking"
+						class:active={showThinking}
+						onclick={() => showThinking = !showThinking}
+						title={showThinking ? "Hide Thinking" : "Show Thinking"}
+					>
+						<span>◇</span>
+					</button>
+					<button
+						type="button"
 						class="header-button toggle-tools"
 						class:active={showTools}
 						onclick={() => showTools = !showTools}
@@ -209,7 +219,7 @@
 				{:else}
 					<div class="messages">
 						{#each conversation.messages as message, index (index)}
-							{#if showTools || (message.messageType !== 'ToolUse' && message.messageType !== 'ToolResult')}
+							{#if (showTools || (message.messageType !== 'ToolUse' && message.messageType !== 'ToolResult')) && (showThinking || message.messageType !== 'Thinking')}
 								<div data-msg-index={index}>
 									<MessageBubble {message} />
 								</div>
@@ -237,7 +247,7 @@
 
 		<!-- Desktop: sidebar nav -->
 		<div class="nav-map-side nav-desktop" in:scale={{ start: 0.95, duration: 300, easing: quintOut }}>
-			<MessageNavMap {conversation} scrollContainer={messagesContainer} bind:showTools />
+			<MessageNavMap {conversation} scrollContainer={messagesContainer} bind:showTools bind:showThinking />
 		</div>
 
 		<!-- Mobile: bottom sheet nav -->
@@ -250,7 +260,7 @@
 			<div class="nav-sheet-handle">
 				<div class="handle-bar"></div>
 			</div>
-			<MessageNavMap {conversation} scrollContainer={messagesContainer} bind:showTools />
+			<MessageNavMap {conversation} scrollContainer={messagesContainer} bind:showTools bind:showThinking />
 		</div>
 	</div>
 </div>
@@ -421,6 +431,11 @@
 	.header-button span {
 		font-family: var(--font-mono);
 		font-size: 14px;
+	}
+
+	.header-button.active.toggle-thinking {
+		color: var(--status-permission);
+		opacity: 1;
 	}
 
 	.header-button.active.toggle-tools {

--- a/src/lib/components/HistoryCardOverlay.svelte
+++ b/src/lib/components/HistoryCardOverlay.svelte
@@ -18,6 +18,7 @@
 	let messagesContainer = $state<HTMLDivElement>(undefined!);
 	let hasScrolledToBottom = $state(false);
 	let showTools = $state(true);
+	let showThinking = $state(true);
 	let navSheetOpen = $state(false);
 	let copied = $state(false);
 
@@ -143,6 +144,15 @@
 				<div class="header-actions">
 					<button
 						type="button"
+						class="header-button toggle-thinking"
+						class:active={showThinking}
+						onclick={() => showThinking = !showThinking}
+						title={showThinking ? "Hide Thinking" : "Show Thinking"}
+					>
+						<span>◇</span>
+					</button>
+					<button
+						type="button"
 						class="header-button toggle-tools"
 						class:active={showTools}
 						onclick={() => showTools = !showTools}
@@ -178,7 +188,7 @@
 				{:else}
 					<div class="messages">
 						{#each conversation.messages as message, index (index)}
-							{#if showTools || (message.messageType !== 'ToolUse' && message.messageType !== 'ToolResult')}
+							{#if (showTools || (message.messageType !== 'ToolUse' && message.messageType !== 'ToolResult')) && (showThinking || message.messageType !== 'Thinking')}
 								<div data-msg-index={index}>
 									<MessageBubble {message} />
 								</div>
@@ -206,7 +216,7 @@
 
 		<!-- Desktop: sidebar nav -->
 		<div class="nav-map-side nav-desktop" in:scale={{ start: 0.95, duration: 300, easing: quintOut }}>
-			<MessageNavMap {conversation} scrollContainer={messagesContainer} bind:showTools />
+			<MessageNavMap {conversation} scrollContainer={messagesContainer} bind:showTools bind:showThinking />
 		</div>
 
 		<!-- Mobile: bottom sheet nav -->
@@ -219,7 +229,7 @@
 			<div class="nav-sheet-handle">
 				<div class="handle-bar"></div>
 			</div>
-			<MessageNavMap {conversation} scrollContainer={messagesContainer} bind:showTools />
+			<MessageNavMap {conversation} scrollContainer={messagesContainer} bind:showTools bind:showThinking />
 		</div>
 	</div>
 </div>
@@ -397,6 +407,11 @@
 	.header-button span {
 		font-family: var(--font-mono);
 		font-size: 14px;
+	}
+
+	.header-button.active.toggle-thinking {
+		color: var(--status-permission);
+		opacity: 1;
 	}
 
 	.header-button.active.toggle-tools {

--- a/src/lib/components/MessageNavMap.svelte
+++ b/src/lib/components/MessageNavMap.svelte
@@ -5,17 +5,19 @@
 		conversation: Conversation | null;
 		scrollContainer: HTMLDivElement | null;
 		showTools?: boolean;
+		showThinking?: boolean;
 	}
 
-	let { conversation, scrollContainer, showTools = $bindable(true) }: Props = $props();
+	let { conversation, scrollContainer, showTools = $bindable(true), showThinking = $bindable(true) }: Props = $props();
 
-	// Filter for "milestone" messages - user messages and tool blocks
+	// Filter for "milestone" messages - user messages, tool blocks, and thinking steps
 	let items = $derived.by(() => {
 		if (!conversation) return [];
 		return conversation.messages
 			.map((msg, index) => ({ msg, index }))
 			.filter(({ msg }) =>
 				msg.messageType === 'User' ||
+				(showThinking && msg.messageType === 'Thinking') ||
 				(showTools && msg.messageType === 'ToolUse' && msg.content?.length > 0)
 			);
 	});
@@ -24,6 +26,8 @@
 		switch (message.messageType) {
 			case 'User':
 				return '→';
+			case 'Thinking':
+				return '◇';
 			case 'ToolUse':
 				return '⚙';
 			default:
@@ -35,6 +39,8 @@
 		switch (message.messageType) {
 			case 'User':
 				return 'var(--text-primary)';
+			case 'Thinking':
+				return 'var(--status-permission)';
 			case 'ToolUse':
 				return 'var(--status-input)';
 			default:
@@ -70,9 +76,10 @@
 		{#each items as { msg, index }}
 			<!-- svelte-ignore a11y_click_events_have_key_events -->
 			<!-- svelte-ignore a11y_no_static_element_interactions -->
-			<div 
-				class="nav-item-descriptive" 
+			<div
+				class="nav-item-descriptive"
 				class:is-user={msg.messageType === 'User'}
+				class:is-thinking={msg.messageType === 'Thinking'}
 				style="--item-color: {getMessageColor(msg)}"
 				onclick={() => scrollToMessage(index)}
 			>
@@ -187,6 +194,15 @@
 
 	.is-user {
 		margin-bottom: 4px;
+	}
+
+	.is-thinking {
+		opacity: 0.8;
+		padding-left: calc(var(--space-lg) + var(--space-sm));
+	}
+
+	.is-thinking .nav-text {
+		font-style: italic;
 	}
 
 	/* Scrollbar for nav list */


### PR DESCRIPTION
## Summary

- Restore the thinking block toggle (◇) removed in #38
- The original removal assumed JSONL files never contain thinking blocks, but they do when Claude Code has extended thinking mode enabled
- Adds toggle to both live session overlay and history session overlay
- Restores thinking entries (indented, italic) in the sidebar navigation map

## Changes

- **ExpandedCardOverlay.svelte**: Add `showThinking` state, ◇ toggle button, message filter, NavMap binding
- **HistoryCardOverlay.svelte**: Same changes as above
- **MessageNavMap.svelte**: Add `showThinking` bindable prop, Thinking filter/icon/color, `.is-thinking` styling

## Test plan

- [x] Open a session that used extended thinking — thinking blocks should appear with dashed orange border
- [x] Click the ◇ toggle — thinking blocks should hide/show
- [x] Sidebar nav should show/hide thinking entries in sync with the toggle
- [x] Sessions without thinking blocks should be unaffected (toggle present but no thinking messages to filter)
- [x] `npm run check` passes with 0 errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)