### PR TITLE
feat: restore minimized terminal windows on Open click

### DIFF
--- a/src-tauri/src/actions.rs
+++ b/src-tauri/src/actions.rs
@@ -215,20 +215,22 @@ fn activate_app_fallback(app_name: &str) -> Result<(), String> {
     //
     // Notes:
     // - Unminimizes ALL windows of the app, not just the target one.
-    // - Requires Accessibility permission; if denied, falls back to activate-only
-    //   (same behavior as before this change).
+    // - AXMinimized requires Accessibility permission and may throw;
+    //   wrapped in try/end try so `activate` always succeeds regardless.
     let script = format!(
         r#"
         tell application "{app}" to activate
-        tell application "System Events"
-            tell process "{app}"
-                repeat with w in windows
-                    if value of attribute "AXMinimized" of w is true then
-                        set value of attribute "AXMinimized" of w to false
-                    end if
-                end repeat
+        try
+            tell application "System Events"
+                tell process "{app}"
+                    repeat with w in windows
+                        if value of attribute "AXMinimized" of w is true then
+                            set value of attribute "AXMinimized" of w to false
+                        end if
+                    end repeat
+                end tell
             end tell
-        end tell
+        end try
         "#,
         app = app_name
     );


### PR DESCRIPTION
## Summary

- Fix minimized terminal windows not restoring when clicking OPEN in c9watch
- Use System Events `AXMinimized` attribute to unminimize windows in `activate_app_fallback`
- Affects all terminals without a dedicated code path: Ghostty, Alacritty, kitty, Warp, Hyper, WezTerm, macOS Terminal, etc.
- Also add Ghostty `.app` bundle path detection in `get_app_name`

## Notes

- iTerm2 is unaffected (has its own `focus_iterm2_session` with tty matching)
- VS Code / Cursor / Zed / JetBrains are unaffected (use CLI path, only fall through on CLI failure)
- Requires macOS Accessibility permission; if not granted, gracefully falls back to activate-only (same as before)

## Test plan

- [x] Click OPEN on a Ghostty session while Ghostty is minimized → verify it restores
- [x] Click OPEN on a Ghostty session while Ghostty is visible → verify it focuses normally
- [x] Click OPEN on an iTerm2 session → verify no regression
- [ ] Click OPEN on a VS Code session → verify no regression

_🤖 On behalf of @grimmerk — generated with Claude Code_

## Test proof about while Ghostty is minimized

https://github.com/user-attachments/assets/e914af1d-e199-41cf-b95e-cedc74e95032

