### PR TITLE
feat: add list item numbers to history session rows

### DIFF
--- a/src/lib/components/SessionHistory.svelte
+++ b/src/lib/components/SessionHistory.svelte
@@ -557,7 +557,6 @@
 		min-width: 1.5em;
 		text-align: right;
 		user-select: none;
-		opacity: 0.5;
 	}
 
 	.row-content {


### PR DESCRIPTION
## Summary

- Add sequential list item numbers on the left side of each session row in the History tab
- Numbers help users quickly locate and reference specific sessions
- In flat view: continuous numbering across all results
- In grouped (BY PROJECT) view: numbers restart at 1 per group
- Numbers reflect the visible/filtered order (after search and sorting)

## Screenshot Test proof 

<img width="482" height="486" alt="截圖 2026-03-08 凌晨1 23 37" src="https://github.com/user-attachments/assets/6a507bb1-efb7-4acc-b909-0757e8fb88ec" />

## Test plan

- [x] Open History tab → verify numbers appear on the left of each row
- [x] Switch sort order (NEWEST/OLDEST) → verify numbers update correctly
- [x] Search for a term → verify numbers restart from 1 on filtered results
- [x] Switch to BY PROJECT view → verify numbers restart at 1 per group
- [x] Resize window → verify layout doesn't break

_🤖 On behalf of @grimmerk — generated with Claude Code_
