### PR TITLE
fix: sliding window rendering for large conversations

### DIFF
--- a/src/lib/components/ExpandedCardOverlay.svelte
+++ b/src/lib/components/ExpandedCardOverlay.svelte
@@ -6,6 +6,7 @@
 	import { SessionStatus } from '$lib/types';
 	import MessageBubble from './MessageBubble.svelte';
 	import MessageNavMap from './MessageNavMap.svelte';
+	import { createSlidingWindow, BATCH_SIZE } from '$lib/slidingWindow.svelte';
 
 	interface Props {
 		session: Session;
@@ -23,6 +24,13 @@
 	let showTools = $state(true);
 	let showThinking = $state(true);
 	let navSheetOpen = $state(false);
+
+	const sw = createSlidingWindow();
+
+	let visibleMessages = $derived.by(() => {
+		if (!conversation) return [];
+		return sw.sliceMessages(conversation.messages);
+	});
 
 	function handleNavItemClick() {
 		// Close the bottom sheet on mobile after navigating
@@ -42,13 +50,19 @@
 	});
 
 	function handleScroll() {
-		// No longer persisting scroll position as we want to always show latest on open
+		if (!messagesContainer || !conversation) return;
+		sw.handleScroll(messagesContainer, conversation.messages.length);
+	}
+
+	async function onExpandToIndex(index: number) {
+		if (!messagesContainer || !conversation) return;
+		await sw.scrollToIndex(index, messagesContainer, conversation.messages.length);
 	}
 
 	$effect(() => {
 		if (conversation && conversation.messages.length > 0 && messagesContainer) {
 			if (!hasScrolledToBottom) {
-				// Initial scroll to bottom when opening
+				sw.reset(conversation.messages.length);
 				tick().then(() => {
 					messagesContainer.scrollTop = messagesContainer.scrollHeight;
 					hasScrolledToBottom = true;
@@ -100,7 +114,8 @@
 		}
 	}
 
-	function handleClose() {
+	async function handleClose() {
+		await sw.clearBeforeClose(conversation?.messages.length ?? 0);
 		onclose?.();
 	}
 
@@ -142,7 +157,7 @@
 							<span class="separator">·</span>
 							<span class="session-name-badge">{session.sessionName}</span>
 							<span class="separator">·</span>
-							<span class="message-count">{conversation?.messages.length ?? 0} messages</span>
+							<span class="message-count">{#if conversation && conversation.messages.length > BATCH_SIZE}{sw.startIndex + 1}–{sw.endIndex} / {/if}{conversation?.messages.length ?? 0} messages</span>
 							{#if session.gitBranch}
 								<span class="separator">·</span>
 								<div class="git-info">
@@ -218,9 +233,14 @@
 					</div>
 				{:else}
 					<div class="messages">
-						{#each conversation.messages as message, index (index)}
+						{#if sw.startIndex > 0}
+							<div class="load-more-indicator">
+								{sw.startIndex} earlier messages
+							</div>
+						{/if}
+						{#each visibleMessages as message, i (sw.startIndex + i)}
 							{#if (showTools || (message.messageType !== 'ToolUse' && message.messageType !== 'ToolResult')) && (showThinking || message.messageType !== 'Thinking')}
-								<div data-msg-index={index}>
+								<div data-msg-index={sw.startIndex + i}>
 									<MessageBubble {message} />
 								</div>
 							{/if}
@@ -247,7 +267,7 @@
 
 		<!-- Desktop: sidebar nav -->
 		<div class="nav-map-side nav-desktop" in:scale={{ start: 0.95, duration: 300, easing: quintOut }}>
-			<MessageNavMap {conversation} scrollContainer={messagesContainer} bind:showTools bind:showThinking />
+			<MessageNavMap {conversation} scrollContainer={messagesContainer} bind:showTools bind:showThinking {onExpandToIndex} />
 		</div>
 
 		<!-- Mobile: bottom sheet nav -->
@@ -260,7 +280,7 @@
 			<div class="nav-sheet-handle">
 				<div class="handle-bar"></div>
 			</div>
-			<MessageNavMap {conversation} scrollContainer={messagesContainer} bind:showTools bind:showThinking />
+			<MessageNavMap {conversation} scrollContainer={messagesContainer} bind:showTools bind:showThinking {onExpandToIndex} />
 		</div>
 	</div>
 </div>
@@ -473,6 +493,17 @@
 	.messages {
 		display: flex;
 		flex-direction: column;
+	}
+
+	.load-more-indicator {
+		text-align: center;
+		padding: var(--space-md) 0;
+		font-family: var(--font-mono);
+		font-size: 12px;
+		color: var(--text-muted);
+		text-transform: uppercase;
+		letter-spacing: 0.05em;
+		opacity: 0.6;
 	}
 
 	.loading-state,

--- a/src/lib/components/HistoryCardOverlay.svelte
+++ b/src/lib/components/HistoryCardOverlay.svelte
@@ -5,6 +5,7 @@
 	import type { HistoryEntry, Conversation } from '$lib/types';
 	import MessageBubble from './MessageBubble.svelte';
 	import MessageNavMap from './MessageNavMap.svelte';
+	import { createSlidingWindow, BATCH_SIZE, MAX_VISIBLE } from '$lib/slidingWindow.svelte';
 
 	interface Props {
 		entry: HistoryEntry;
@@ -22,6 +23,13 @@
 	let navSheetOpen = $state(false);
 	let copied = $state(false);
 
+	const sw = createSlidingWindow();
+
+	let visibleMessages = $derived.by(() => {
+		if (!conversation) return [];
+		return sw.sliceMessages(conversation.messages);
+	});
+
 	function handleNavItemClick() {
 		// Close the bottom sheet on mobile after navigating
 		navSheetOpen = false;
@@ -38,12 +46,32 @@
 	});
 
 	function handleScroll() {
-		// No scroll position persisting needed for history viewer
+		if (!messagesContainer || !conversation) return;
+		sw.handleScroll(messagesContainer, conversation.messages.length);
+	}
+
+	async function onExpandToIndex(index: number) {
+		if (!messagesContainer || !conversation) return;
+		await sw.scrollToIndex(index, messagesContainer, conversation.messages.length);
 	}
 
 	$effect(() => {
 		if (conversation && conversation.messages.length > 0 && messagesContainer) {
 			if (!hasScrolledToBottom) {
+				if (searchQuery) {
+					const queryLower = searchQuery.toLowerCase();
+					const matchIndex = conversation!.messages.findIndex(
+						(m) => (m.messageType === 'User' || m.messageType === 'Assistant') &&
+							m.content.toLowerCase().includes(queryLower)
+					);
+					if (matchIndex >= 0) {
+						sw.reset(conversation.messages.length, Math.max(0, matchIndex - 10));
+					} else {
+						sw.reset(conversation.messages.length);
+					}
+				} else {
+					sw.reset(conversation.messages.length);
+				}
 				tick().then(() => {
 					if (searchQuery) {
 						// Find the first user/assistant message matching all query words.
@@ -70,8 +98,10 @@
 		}
 	});
 
-	function scrollToMessageIndex(index: number) {
-		if (!messagesContainer) return;
+	async function scrollToMessageIndex(index: number) {
+		if (!messagesContainer || !conversation) return;
+		sw.expandToIndex(index, conversation.messages.length);
+		await tick();
 		const target = messagesContainer.querySelector(`[data-msg-index="${index}"]`) as HTMLElement | null;
 		if (target) {
 			target.scrollIntoView({ block: 'center' });
@@ -84,7 +114,8 @@
 		}
 	}
 
-	function handleClose() {
+	async function handleClose() {
+		await sw.clearBeforeClose(conversation?.messages.length ?? 0);
 		onclose();
 	}
 
@@ -127,7 +158,7 @@
 							<h2 id="overlay-title" class="project-name">{entry.projectName.toUpperCase()}</h2>
 						</div>
 						<div class="header-meta">
-							<span class="message-count">{conversation?.messages.length ?? 0} messages</span>
+							<span class="message-count">{#if conversation && conversation.messages.length > BATCH_SIZE}{sw.startIndex + 1}–{sw.endIndex} / {/if}{conversation?.messages.length ?? 0} messages</span>
 						</div>
 					</div>
 				</div>
@@ -189,9 +220,14 @@
 					</div>
 				{:else}
 					<div class="messages">
-						{#each conversation.messages as message, index (index)}
+						{#if sw.startIndex > 0}
+							<div class="load-more-indicator">
+								{sw.startIndex} earlier messages
+							</div>
+						{/if}
+						{#each visibleMessages as message, i (sw.startIndex + i)}
 							{#if (showTools || (message.messageType !== 'ToolUse' && message.messageType !== 'ToolResult')) && (showThinking || message.messageType !== 'Thinking')}
-								<div data-msg-index={index}>
+								<div data-msg-index={sw.startIndex + i}>
 									<MessageBubble {message} />
 								</div>
 							{/if}
@@ -218,7 +254,7 @@
 
 		<!-- Desktop: sidebar nav -->
 		<div class="nav-map-side nav-desktop" in:scale={{ start: 0.95, duration: 300, easing: quintOut }}>
-			<MessageNavMap {conversation} scrollContainer={messagesContainer} bind:showTools bind:showThinking />
+			<MessageNavMap {conversation} scrollContainer={messagesContainer} bind:showTools bind:showThinking {onExpandToIndex} />
 		</div>
 
 		<!-- Mobile: bottom sheet nav -->
@@ -231,7 +267,7 @@
 			<div class="nav-sheet-handle">
 				<div class="handle-bar"></div>
 			</div>
-			<MessageNavMap {conversation} scrollContainer={messagesContainer} bind:showTools bind:showThinking />
+			<MessageNavMap {conversation} scrollContainer={messagesContainer} bind:showTools bind:showThinking {onExpandToIndex} />
 		</div>
 	</div>
 </div>
@@ -451,6 +487,17 @@
 	.messages {
 		display: flex;
 		flex-direction: column;
+	}
+
+	.load-more-indicator {
+		text-align: center;
+		padding: var(--space-md) 0;
+		font-family: var(--font-mono);
+		font-size: 12px;
+		color: var(--text-muted);
+		text-transform: uppercase;
+		letter-spacing: 0.05em;
+		opacity: 0.6;
 	}
 
 	/* Flash highlight for the matched search result message.

--- a/src/lib/components/MessageNavMap.svelte
+++ b/src/lib/components/MessageNavMap.svelte
@@ -6,9 +6,10 @@
 		scrollContainer: HTMLDivElement | null;
 		showTools?: boolean;
 		showThinking?: boolean;
+		onExpandToIndex?: (index: number) => void;
 	}
 
-	let { conversation, scrollContainer, showTools = $bindable(true), showThinking = $bindable(true) }: Props = $props();
+	let { conversation, scrollContainer, showTools = $bindable(true), showThinking = $bindable(true), onExpandToIndex }: Props = $props();
 
 	// Filter for "milestone" messages - user messages, tool blocks, and thinking steps
 	let items = $derived.by(() => {
@@ -57,6 +58,8 @@
 		const target = scrollContainer.querySelector(`[data-msg-index="${index}"]`) as HTMLElement | null;
 		if (target) {
 			target.scrollIntoView({ behavior: 'smooth', block: 'start' });
+		} else if (onExpandToIndex) {
+			onExpandToIndex(index);
 		}
 	}
 
@@ -83,6 +86,7 @@
 				style="--item-color: {getMessageColor(msg)}"
 				onclick={() => scrollToMessage(index)}
 			>
+				<span class="nav-index">{index + 1}</span>
 				<span class="nav-icon">{getMessageIcon(msg)}</span>
 				<span class="nav-text">{truncateContent(msg.content)}</span>
 				<div class="nav-indicator"></div>
@@ -144,9 +148,9 @@
 	.nav-item-descriptive {
 		position: relative;
 		display: flex;
-		align-items: flex-start;
-		gap: var(--space-sm);
-		padding: 6px var(--space-lg);
+		align-items: baseline;
+		gap: 3px;
+		padding: 6px var(--space-sm) 6px var(--space-md);
 		cursor: pointer;
 		transition: all var(--transition-fast);
 		border: 1px solid transparent;
@@ -157,12 +161,21 @@
 		border-color: var(--border-muted);
 	}
 
+	.nav-index {
+		font-family: var(--font-mono);
+		font-size: 9px;
+		color: var(--text-muted);
+		opacity: 0.5;
+		flex-shrink: 0;
+		min-width: 1.8em;
+		text-align: right;
+	}
+
 	.nav-icon {
 		font-family: var(--font-mono);
 		font-size: 12px;
 		color: var(--item-color);
 		flex-shrink: 0;
-		margin-top: 1px;
 	}
 
 	.nav-text {

--- a/src/lib/slidingWindow.svelte.ts
+++ b/src/lib/slidingWindow.svelte.ts
@@ -1,0 +1,118 @@
+import { tick } from 'svelte';
+import type { Message } from '$lib/types';
+
+/** Tuning constants for the sliding window. */
+export const BATCH_SIZE = 200;
+export const MAX_VISIBLE = 400;
+const SCROLL_THRESHOLD = 500;
+
+/**
+ * Creates a sliding window controller for rendering large message lists.
+ *
+ * Only MAX_VISIBLE messages are kept in the DOM at once.  When the user
+ * scrolls near the top or bottom edge the window expands by BATCH_SIZE and
+ * trims the opposite end so the total never exceeds MAX_VISIBLE.
+ */
+export function createSlidingWindow() {
+	let startIndex = $state(0);
+	let endIndex = $state(0);
+	let loading = $state(false);
+
+	function reset(totalMessages: number, initialStart?: number) {
+		endIndex = totalMessages;
+		startIndex = initialStart ?? Math.max(0, totalMessages - BATCH_SIZE);
+	}
+
+	function sliceMessages(messages: Message[]): Message[] {
+		return messages.slice(startIndex, endIndex);
+	}
+
+	async function loadOlder(container: HTMLElement) {
+		if (loading || startIndex <= 0) return;
+		loading = true;
+
+		const prevHeight = container.scrollHeight;
+		startIndex = Math.max(0, startIndex - BATCH_SIZE);
+		if (endIndex - startIndex > MAX_VISIBLE) {
+			endIndex = startIndex + MAX_VISIBLE;
+		}
+
+		await tick();
+		container.scrollTop += container.scrollHeight - prevHeight;
+		loading = false;
+	}
+
+	async function loadNewer(container: HTMLElement, totalMessages: number) {
+		if (loading || endIndex >= totalMessages) return;
+		loading = true;
+
+		endIndex = Math.min(totalMessages, endIndex + BATCH_SIZE);
+		if (endIndex - startIndex > MAX_VISIBLE) {
+			const prevHeight = container.scrollHeight;
+			startIndex = endIndex - MAX_VISIBLE;
+			await tick();
+			container.scrollTop += container.scrollHeight - prevHeight;
+		}
+
+		loading = false;
+	}
+
+	function handleScroll(container: HTMLElement, totalMessages: number) {
+		if (loading) return;
+		if (container.scrollTop < SCROLL_THRESHOLD && startIndex > 0) {
+			loadOlder(container);
+		}
+		const distFromBottom =
+			container.scrollHeight - container.scrollTop - container.clientHeight;
+		if (distFromBottom < SCROLL_THRESHOLD && endIndex < totalMessages) {
+			loadNewer(container, totalMessages);
+		}
+	}
+
+	function expandToIndex(index: number, totalMessages: number) {
+		if (index < startIndex || index >= endIndex) {
+			startIndex = Math.max(0, index - Math.floor(MAX_VISIBLE / 2));
+			endIndex = Math.min(totalMessages, startIndex + MAX_VISIBLE);
+		}
+	}
+
+	async function scrollToIndex(
+		index: number,
+		container: HTMLElement,
+		totalMessages: number,
+		options?: { behavior?: ScrollBehavior; block?: ScrollLogicalPosition }
+	) {
+		expandToIndex(index, totalMessages);
+		await tick();
+		const target = container.querySelector(
+			`[data-msg-index="${index}"]`
+		) as HTMLElement | null;
+		if (target) {
+			target.scrollIntoView({
+				behavior: options?.behavior ?? 'smooth',
+				block: options?.block ?? 'start',
+			});
+		}
+	}
+
+	async function clearBeforeClose(totalMessages: number) {
+		startIndex = totalMessages;
+		await tick();
+	}
+
+	return {
+		get startIndex() { return startIndex; },
+		set startIndex(v: number) { startIndex = v; },
+		get endIndex() { return endIndex; },
+		set endIndex(v: number) { endIndex = v; },
+		get loading() { return loading; },
+		reset,
+		sliceMessages,
+		loadOlder,
+		loadNewer,
+		handleScroll,
+		expandToIndex,
+		scrollToIndex,
+		clearBeforeClose,
+	};
+}


### PR DESCRIPTION
## Summary

Fix UI hang when viewing sessions with 1000+ messages in the conversation overlay.

### Root cause

`{#each conversation.messages}` renders ALL messages at once, each running `marked()` + `DOMPurify` for markdown→HTML. For large sessions (1000+ messages), this blocks the main thread:

1. **Opening hang** — creating thousands of DOM nodes with markdown parsing freezes the UI
2. **Close button hang** — clicking X triggers Svelte's `transition:fade` which keeps the component alive while parent sets `conversation = null`, causing a reactivity cascade (re-renders during transition). Even without that, destroying thousands of complex DOM nodes blocks the thread
3. **Post-close sluggishness** — monitor UI becomes unresponsive after closing due to GC pressure from accumulated DOM/memory

### Fix: Sliding window rendering

- Initially render only the last 200 messages (view starts at bottom by default)
- Scroll up → prepend older messages in batches of 200
- Scroll down → append newer messages when bottom was previously trimmed
- **Cap total DOM at 400 messages** — trim the opposite end when loading, so DOM size stays bounded regardless of total message count
- **Close optimization** — clear `visibleMessages` before triggering close, so Svelte destroys an empty list instead of hundreds of nodes during the fade-out transition
- Show "N earlier messages" indicator at the top when messages are truncated
- **Message range indicator** in header (e.g., `1–200 / 897 messages`) — visible whenever total messages exceed one batch, regardless of scroll position
- Right-side nav map: clicking an item outside the visible window re-centers the window around the target and scrolls to it (works in both directions)

Applied to both `ExpandedCardOverlay` (Monitor) and `HistoryCardOverlay` (History). The right-side `MessageNavMap` is unchanged — it only renders lightweight truncated text items (no markdown), so its ~800 items don't cause performance issues.

### Future alternative: virtual scroll library

The current sliding window approach solves the immediate problem with minimal code change. A more robust long-term solution would be a proper virtual scroll library (e.g., `@tanstack/virtual`) that only renders items visible in the viewport. This would provide:

- Smoother scrolling with zero batch-loading jank
- Constant memory usage regardless of scroll position
- Better scroll position accuracy

The main challenge is that messages have **variable heights** (one-line prompts vs large code blocks), which requires dynamic height measurement. The sliding window was chosen as the pragmatic first step given the complexity trade-off.

### Known limitation: initial loading delay

Opening a large session (2000+ messages) still shows "Loading conversation..." for 2-3 seconds. This is the **backend** reading and parsing the entire JSONL file, not a frontend issue. This PR does not address backend performance — a future optimization could add server-side pagination (return only the last N messages initially) to reduce this delay.

## Test plan

- [x] Open a session with 1000+ messages → should load instantly, not hang
- [x] Open a session with 2000+ messages → same, no hang
- [x] Scroll up → older messages load, scroll position preserved
- [x] Scroll all the way up then back down → newer messages render back into view (sliding window)
- [x] Click X to close → closes instantly, no hang
- [x] After closing, monitor UI remains responsive
- [x] Right-side nav map → clicking an item scrolls to correct message (even if outside current window)
- [x] Small sessions (< 200 messages) → no behavior change

_🤖 On behalf of @grimmerk — generated with Claude Code_

## screenshot of UI change part (number visualization ux)

<img width="830" height="44" alt="截圖 2026-03-08 凌晨4 14 52" src="https://github.com/user-attachments/assets/bf06bb1a-c9ee-44f9-ae2f-ff7d5c4e8c01" />

<img width="254" height="388" alt="截圖 2026-03-08 凌晨4 15 04" src="https://github.com/user-attachments/assets/eee2b403-b82f-4447-9898-f65ab4beb1ee" />

