### PR TITLE
feat: auto-symlink CLI when installing desktop app

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,9 @@ Built with **Tauri**, **Rust**, and **Svelte** -- not Electron. The app binary i
 curl -fsSL https://raw.githubusercontent.com/minchenlee/c9watch/main/install.sh | bash
 ```
 
-Or grab the latest `.dmg` from the [Releases](https://github.com/minchenlee/c9watch/releases) page.
+This installs the app to `/Applications` and symlinks the CLI to `~/.local/bin/c9watch`, so both the GUI and `c9watch list`, `c9watch view`, etc. work out of the box.
+
+Or grab the latest `.dmg` from the [Releases](https://github.com/minchenlee/c9watch/releases) page (you'll need to symlink the CLI manually: `ln -s /Applications/c9watch.app/Contents/MacOS/c9watch ~/.local/bin/c9watch`).
 
 ### CLI only (macOS & Linux)
 

--- a/install.sh
+++ b/install.sh
@@ -90,11 +90,34 @@ fi
 info "Installing to ${INSTALL_DIR}/${APP_BASENAME}..."
 cp -R "$APP_BUNDLE" "${INSTALL_DIR}/"
 
+# --- Symlink CLI ---
+
+CLI_DIR="${HOME}/.local/bin"
+CLI_BINARY="${INSTALL_DIR}/${APP_BASENAME}/Contents/MacOS/c9watch"
+
+if [ -x "$CLI_BINARY" ]; then
+  mkdir -p "$CLI_DIR"
+  ln -sf "$CLI_BINARY" "$CLI_DIR/c9watch"
+  info "CLI symlinked to ${CLI_DIR}/c9watch"
+
+  case ":${PATH}:" in
+    *":${CLI_DIR}:"*) ;;
+    *)
+      printf '\033[1;33m=>\033[0m %s\n' "${CLI_DIR} is not in your PATH. Add it with:"
+      echo ""
+      echo "    export PATH=\"${CLI_DIR}:\$PATH\""
+      echo ""
+      ;;
+  esac
+fi
+
 # --- Done ---
 
 echo ""
 info "c9watch has been installed to ${INSTALL_DIR}/${APP_BASENAME}"
-info "You can launch it from Spotlight or by running:"
+info "You can launch the app from Spotlight or by running:"
 echo ""
 echo "    open '${INSTALL_DIR}/${APP_BASENAME}'"
+echo ""
+info "CLI is available as 'c9watch' (e.g. c9watch list, c9watch --help)"
 echo ""

--- a/website/src/content/docs/install.md
+++ b/website/src/content/docs/install.md
@@ -23,11 +23,18 @@ c9watch comes in two forms: a **desktop app** with a full GUI dashboard, and a *
 curl -fsSL https://raw.githubusercontent.com/minchenlee/c9watch/main/install.sh | bash
 ```
 
-This script downloads the latest `.dmg` from GitHub Releases, mounts it, copies `c9watch.app` to your `/Applications` folder, and cleans up. If c9watch is already installed, it will be replaced with the latest version.
+This script downloads the latest `.dmg` from GitHub Releases, installs `c9watch.app` to `/Applications`, and symlinks the CLI to `~/.local/bin/c9watch`. Both the desktop dashboard and CLI commands (`c9watch list`, `c9watch view`, etc.) work out of the box.
 
 ### Download manually
 
 Grab the latest `.dmg` from the [Releases](https://github.com/minchenlee/c9watch/releases) page. Open the `.dmg` and drag c9watch to your Applications folder.
+
+To also use the CLI, symlink the bundled binary:
+
+```bash
+mkdir -p ~/.local/bin
+ln -s /Applications/c9watch.app/Contents/MacOS/c9watch ~/.local/bin/c9watch
+```
 
 On first launch, macOS may show a security warning because the app is not notarized by Apple. Go to **System Settings → Privacy & Security** and click **"Open Anyway"**.
 


### PR DESCRIPTION
## Summary

- `install.sh` now symlinks the bundled binary to `~/.local/bin/c9watch` after installing the .app
- Warns if `~/.local/bin` is not in PATH
- Updated README and website install docs to explain symlink behavior
- DMG manual installs include symlink instructions

Without this, users who install the desktop app have no way to use CLI commands like `c9watch list` unless they discover the bundle path manually.

## Test plan

- [ ] `curl ... install.sh | bash` installs app AND creates symlink
- [ ] `c9watch --version` works after install
- [ ] PATH warning shown if `~/.local/bin` not in PATH