### PR TITLE
refactor(pm): dedupe worker-id resolution via shared helper

### DIFF
--- a/src-tauri/src/cli/mod.rs
+++ b/src-tauri/src/cli/mod.rs
@@ -537,16 +537,11 @@ fn try_resolve_worker(target: &str) -> Option<String> {
         .filter_map(|w| w.get("sessionId").and_then(|s| s.as_str()).map(String::from))
         .collect();
 
-    // Exact match first
-    if ids.iter().any(|id| id == target) {
-        return Some(target.to_string());
-    }
-    // Unique prefix match
-    let prefix_matches: Vec<&String> = ids.iter().filter(|id| id.starts_with(target)).collect();
-    if prefix_matches.len() == 1 {
-        return Some(prefix_matches[0].clone());
-    }
-    None
+    // Delegate matching to the shared helper in pm_daemon so exact/prefix/
+    // ambiguous rules stay in one place. An ambiguous prefix silently falls
+    // through to None: the caller will next try PID parsing, which fails for
+    // a uuid-shaped prefix, landing in the WORKER_NOT_FOUND path from PM.
+    pm_daemon::resolve_worker_id_from_keys(ids.iter().map(|s| s.as_str()), target).ok()
 }
 
 fn cmd_watch(

--- a/src-tauri/src/cli/pm_daemon.rs
+++ b/src-tauri/src/cli/pm_daemon.rs
@@ -552,7 +552,7 @@ fn resolve_worker_id(
 
 /// Key-only variant of `resolve_worker_id`, factored out so it can be unit
 /// tested without constructing real `WorkerHandle`s.
-fn resolve_worker_id_from_keys<'a, I>(keys: I, prefix: &str) -> Result<String, String>
+pub(crate) fn resolve_worker_id_from_keys<'a, I>(keys: I, prefix: &str) -> Result<String, String>
 where
     I: IntoIterator<Item = &'a str>,
 {


### PR DESCRIPTION
## Summary

- `try_resolve_worker` in `cli/mod.rs` no longer reimplements exact/unique-prefix matching; it delegates to `resolve_worker_id_from_keys` in `pm_daemon.rs`
- Makes `resolve_worker_id_from_keys` `pub(crate)` so mod.rs can call it
- One source of truth for prefix-matching rules — no more drift risk between the two sites

Addresses MEMORY.md TODO #13.

## Test plan

- [x] `cargo check --features cli --no-default-features` clean
- [x] `cargo check --features gui` clean
- [x] `cargo test resolve_worker` — 6 passed

🤖 Spawned by c9watch PM orchestration (session f2a49bea)