### PR TITLE
refactor(pm): InboxEvent::from_turn_result + ::crashed constructors

### DIFF
--- a/src-tauri/src/cli/pm_inbox.rs
+++ b/src-tauri/src/cli/pm_inbox.rs
@@ -40,6 +40,58 @@ pub enum EventStatus {
     Crashed,
 }
 
+/// Fields that vary between normal turn-end outcomes (success or error)
+/// reported by Claude's terminal `result` event.
+pub struct TurnResult {
+    pub status: EventStatus,
+    pub duration_ms: Option<u64>,
+    pub num_turns: Option<u64>,
+    pub stop_reason: Option<String>,
+    pub total_cost_usd: Option<f64>,
+    pub result_excerpt: Option<String>,
+    pub error_message: Option<String>,
+}
+
+impl InboxEvent {
+    /// Normal turn-end event from a `result` stream entry.
+    pub fn from_turn_result(
+        worker_session_id: &str,
+        spawned_by: &str,
+        tr: TurnResult,
+    ) -> Self {
+        Self {
+            event_id: new_event_id(),
+            session_id: worker_session_id.to_string(),
+            spawned_by: spawned_by.to_string(),
+            status: tr.status,
+            finished_at: Utc::now().to_rfc3339(),
+            duration_ms: tr.duration_ms,
+            num_turns: tr.num_turns,
+            stop_reason: tr.stop_reason,
+            total_cost_usd: tr.total_cost_usd,
+            result_excerpt: tr.result_excerpt,
+            error_message: tr.error_message,
+        }
+    }
+
+    /// Worker stdout closed without a terminal `result` event.
+    pub fn crashed(worker_session_id: &str, spawned_by: &str, error_message: String) -> Self {
+        Self {
+            event_id: new_event_id(),
+            session_id: worker_session_id.to_string(),
+            spawned_by: spawned_by.to_string(),
+            status: EventStatus::Crashed,
+            finished_at: Utc::now().to_rfc3339(),
+            duration_ms: None,
+            num_turns: None,
+            stop_reason: None,
+            total_cost_usd: None,
+            result_excerpt: None,
+            error_message: Some(error_message),
+        }
+    }
+}
+
 /// Max characters for `result_excerpt` to keep inbox reads cheap.
 pub const EXCERPT_LIMIT: usize = 500;
 

--- a/src-tauri/src/cli/pm_worker.rs
+++ b/src-tauri/src/cli/pm_worker.rs
@@ -386,7 +386,7 @@ async fn stdout_tee_task(
                 saw_terminal_result = true;
 
                 if let Some(ref ctx) = inbox {
-                    use crate::cli::pm_inbox::{self, InboxEvent, EventStatus};
+                    use crate::cli::pm_inbox::{self, EventStatus, InboxEvent, TurnResult};
                     let status = if is_error || subtype.as_deref().map(|s| s != "success").unwrap_or(false) {
                         EventStatus::Error
                     } else {
@@ -408,19 +408,19 @@ async fn stdout_tee_task(
                     } else {
                         None
                     };
-                    let ev = InboxEvent {
-                        event_id: pm_inbox::new_event_id(),
-                        session_id: ctx.session_id.clone(),
-                        spawned_by: ctx.spawned_by.clone(),
-                        status,
-                        finished_at: Utc::now().to_rfc3339(),
-                        duration_ms,
-                        num_turns,
-                        stop_reason,
-                        total_cost_usd,
-                        result_excerpt: excerpt,
-                        error_message: err_msg,
-                    };
+                    let ev = InboxEvent::from_turn_result(
+                        &ctx.session_id,
+                        &ctx.spawned_by,
+                        TurnResult {
+                            status,
+                            duration_ms,
+                            num_turns,
+                            stop_reason,
+                            total_cost_usd,
+                            result_excerpt: excerpt,
+                            error_message: err_msg,
+                        },
+                    );
                     if let Err(e) = pm_inbox::write_event(&ev) {
                         eprintln!("[pm_worker] Failed to write inbox event: {}", e);
                     }
@@ -434,20 +434,12 @@ async fn stdout_tee_task(
     // crashed or was killed mid-turn. Emit a Crashed event so the PM learns.
     if !saw_terminal_result {
         if let Some(ref ctx) = inbox {
-            use crate::cli::pm_inbox::{self, InboxEvent, EventStatus};
-            let ev = InboxEvent {
-                event_id: pm_inbox::new_event_id(),
-                session_id: ctx.session_id.clone(),
-                spawned_by: ctx.spawned_by.clone(),
-                status: EventStatus::Crashed,
-                finished_at: Utc::now().to_rfc3339(),
-                duration_ms: None,
-                num_turns: None,
-                stop_reason: None,
-                total_cost_usd: None,
-                result_excerpt: None,
-                error_message: Some("worker stdout closed without a terminal result event".to_string()),
-            };
+            use crate::cli::pm_inbox::{self, InboxEvent};
+            let ev = InboxEvent::crashed(
+                &ctx.session_id,
+                &ctx.spawned_by,
+                "worker stdout closed without a terminal result event".to_string(),
+            );
             if let Err(e) = pm_inbox::write_event(&ev) {
                 eprintln!("[pm_worker] Failed to write crash inbox event: {}", e);
             }


### PR DESCRIPTION
## Summary

- Introduces `InboxEvent::from_turn_result(...)` and `InboxEvent::crashed(...)` factories in `pm_inbox.rs`
- `pm_worker.rs` normal-exit and crash branches now use the constructors instead of inline field-by-field assembly
- Behavior unchanged: same JSON bytes written to inbox

Addresses MEMORY.md TODO #15.

## Test plan

- [x] `cargo check --features cli --no-default-features` clean
- [x] `cargo check --features gui` clean
- [x] `cargo test pm_inbox` — 8 passed

🤖 Spawned by c9watch PM orchestration (session f2a49bea)