### PR TITLE
feat(ui): adopt pink as agent accent + de-dupe nav header

### DIFF
--- a/src/lib/components/ExpandedCardOverlay.svelte
+++ b/src/lib/components/ExpandedCardOverlay.svelte
@@ -45,6 +45,16 @@
 		return sw.sliceMessages(conversation.messages);
 	});
 
+	let navItemCount = $derived.by(() => {
+		if (!conversation) return 0;
+		return conversation.messages.filter(msg =>
+			msg.messageType === 'User' ||
+			msg.messageType === 'System' ||
+			(showThinking && msg.messageType === 'Thinking') ||
+			(showTools && msg.messageType === 'ToolUse' && (msg.content?.length ?? 0) > 0)
+		).length;
+	});
+
 	function handleNavItemClick() {
 		// Close the bottom sheet on mobile after navigating
 		navSheetOpen = false;
@@ -409,10 +419,11 @@
 				>
 					<span class="panel-chevron" class:rotated={navCollapsed}>▾</span>
 					<span class="panel-title">Navigation</span>
+					<span class="panel-count">{navItemCount}</span>
 				</button>
 				{#if !navCollapsed}
 					<div class="panel-body">
-						<MessageNavMap {conversation} scrollContainer={messagesContainer} bind:showTools bind:showThinking {onExpandToIndex} />
+						<MessageNavMap {conversation} scrollContainer={messagesContainer} bind:showTools bind:showThinking {onExpandToIndex} hideHeader />
 					</div>
 				{/if}
 			</div>
@@ -746,10 +757,10 @@
 		font-family: var(--font-pixel);
 		font-size: 10px;
 		font-weight: 500;
-		color: var(--accent-amber);
-		background: color-mix(in srgb, var(--accent-amber) 12%, transparent);
+		color: var(--accent-pink);
+		background: color-mix(in srgb, var(--accent-pink) 12%, transparent);
 		padding: 2px 6px;
-		border: 1px solid color-mix(in srgb, var(--accent-amber) 40%, transparent);
+		border: 1px solid color-mix(in srgb, var(--accent-pink) 40%, transparent);
 		text-transform: uppercase;
 		letter-spacing: 0.1em;
 	}
@@ -758,10 +769,10 @@
 		font-family: var(--font-pixel);
 		font-size: 10px;
 		font-weight: 500;
-		color: var(--accent-green);
-		background: color-mix(in srgb, var(--accent-green) 12%, transparent);
+		color: var(--accent-pink);
+		background: color-mix(in srgb, var(--accent-pink) 12%, transparent);
 		padding: 2px 6px;
-		border: 1px solid color-mix(in srgb, var(--accent-green) 40%, transparent);
+		border: 1px solid color-mix(in srgb, var(--accent-pink) 40%, transparent);
 		text-transform: uppercase;
 		letter-spacing: 0.1em;
 		white-space: nowrap;

--- a/src/lib/components/MessageNavMap.svelte
+++ b/src/lib/components/MessageNavMap.svelte
@@ -7,9 +7,10 @@
 		showTools?: boolean;
 		showThinking?: boolean;
 		onExpandToIndex?: (index: number) => void;
+		hideHeader?: boolean;
 	}
 
-	let { conversation, scrollContainer, showTools = $bindable(true), showThinking = $bindable(true), onExpandToIndex }: Props = $props();
+	let { conversation, scrollContainer, showTools = $bindable(true), showThinking = $bindable(true), onExpandToIndex, hideHeader = false }: Props = $props();
 
 	// Filter for "milestone" messages - user messages, tool blocks, and thinking steps
 	let items = $derived.by(() => {
@@ -76,10 +77,12 @@
 </script>
 
 <div class="nav-map-floating" class:hidden={!items.length}>
-	<div class="nav-header">
-		<span class="nav-title">Navigation</span>
-		<span class="nav-count">{items.length} items</span>
-	</div>
+	{#if !hideHeader}
+		<div class="nav-header">
+			<span class="nav-title">Navigation</span>
+			<span class="nav-count">{items.length} items</span>
+		</div>
+	{/if}
 	<div class="nav-list">
 		{#each items as { msg, index }}
 			<!-- svelte-ignore a11y_click_events_have_key_events -->

--- a/src/lib/components/SessionCard.svelte
+++ b/src/lib/components/SessionCard.svelte
@@ -164,9 +164,6 @@
 				onmouseleave={tipLeave}
 				onmousemove={tipMove}
 			>
-				<svg width="10" height="10" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
-					<path d="M12 2l3 7h7l-5.5 4.5L18 22l-6-4-6 4 1.5-8.5L2 9h7z" />
-				</svg>
 				<span class="pm-prefix-label">Worker of</span>
 				<span class="pm-prefix-id">{workerIdShort}</span>
 			</div>
@@ -451,10 +448,10 @@
 		font-family: var(--font-pixel);
 		font-size: 10px;
 		font-weight: 500;
-		color: var(--accent-amber);
-		background: color-mix(in srgb, var(--accent-amber) 12%, transparent);
+		color: var(--accent-pink);
+		background: color-mix(in srgb, var(--accent-pink) 12%, transparent);
 		padding: 2px 6px;
-		border: 1px solid color-mix(in srgb, var(--accent-amber) 40%, transparent);
+		border: 1px solid color-mix(in srgb, var(--accent-pink) 40%, transparent);
 		text-transform: uppercase;
 		letter-spacing: 0.1em;
 		display: inline-block;
@@ -465,10 +462,10 @@
 		font-family: var(--font-pixel);
 		font-size: 10px;
 		font-weight: 500;
-		color: var(--accent-green);
-		background: color-mix(in srgb, var(--accent-green) 12%, transparent);
+		color: var(--accent-pink);
+		background: color-mix(in srgb, var(--accent-pink) 12%, transparent);
 		padding: 2px 6px;
-		border: 1px solid color-mix(in srgb, var(--accent-green) 40%, transparent);
+		border: 1px solid color-mix(in srgb, var(--accent-pink) 40%, transparent);
 		text-transform: uppercase;
 		letter-spacing: 0.1em;
 		display: inline-block;
@@ -477,7 +474,7 @@
 	}
 
 	/* Workers-only view: surface the PM relationship as a first-class prefix
-	   row above the title. Amber matches the WORKER badge visual language. */
+	   row above the title. Pink matches the agent visual language. */
 	.pm-prefix {
 		display: inline-flex;
 		align-items: center;
@@ -485,15 +482,11 @@
 		font-family: var(--font-mono);
 		font-size: 10px;
 		font-weight: 500;
-		color: var(--accent-amber);
+		color: var(--accent-pink);
 		text-transform: uppercase;
 		letter-spacing: 0.1em;
 		margin-bottom: 2px;
 		width: fit-content;
-	}
-
-	.pm-prefix svg {
-		flex-shrink: 0;
 	}
 
 	.pm-prefix-label {
@@ -502,7 +495,7 @@
 
 	.pm-prefix-id {
 		font-weight: 600;
-		color: var(--accent-amber);
+		color: var(--accent-pink);
 		letter-spacing: 0.05em;
 	}
 

--- a/src/routes/(app)/+page.svelte
+++ b/src/routes/(app)/+page.svelte
@@ -1075,12 +1075,12 @@
 		border-color: var(--border-default);
 	}
 
-	/* Workers-filter active state gets an amber tint to reinforce the
-	   bot/worker visual language used by the WORKER badge on cards. */
+	/* Workers-filter active state gets a pink tint to reinforce the
+	   agent visual language used by the WORKER/PM badges on cards. */
 	.toggle-btn.active[title="Show PM workers"] {
-		color: var(--accent-amber);
-		background: color-mix(in srgb, var(--accent-amber) 12%, transparent);
-		border-color: color-mix(in srgb, var(--accent-amber) 40%, transparent);
+		color: var(--accent-pink);
+		background: color-mix(in srgb, var(--accent-pink) 12%, transparent);
+		border-color: color-mix(in srgb, var(--accent-pink) 40%, transparent);
 	}
 
 	.all-sessions-grid {


### PR DESCRIPTION
## Summary

- PM and WORKER badges (cards + expanded overlay), the "Worker of …" prefix row, and the workers-filter toggle (top-right) all now use `--accent-pink` (#FF69B4) so agent-related UI shares one visual language. Drops the star icon on the worker-of prefix.
- Side-panel Navigation header no longer doubles up: the inner `MessageNavMap` header is hidden via a new `hideHeader` prop, and the item count is surfaced on the outer chevron header for parity with the Workers panel.
- Workers panel header style intentionally unchanged.

## Test plan

- [ ] PM card on dashboard shows pink `PM · N` badge
- [ ] Worker cards show pink `WORKER` badge and pink "Worker of XXXX" prefix (no star)
- [ ] Workers-filter button (top-right) tints pink when active
- [ ] Open expanded overlay on a PM session — pink badges next to title
- [ ] Right-side Navigation panel shows a single header with item count, not duplicated