### PR TITLE
chore: bump version to 0.8.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,25 @@ All notable changes to c9watch are documented here.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.8.0] - 2026-04-20
+
+### Added
+- **PM orchestration CLI** — spawn, send messages to, and manage child Claude Code worker sessions from a parent "PM" session. New commands: `c9watch spawn`, `send`, `workers`, `stop`, `adopt`, `inbox`, `tasks`. Workers show a "WORKER" badge on session cards; PMs show a "PM" badge with a Workers panel in the expanded overlay. ([#84](https://github.com/minchenlee/c9watch/pull/84))
+- **Subagent visibility** — detect and display Task-tool subagents spawned inside any session. 2-row card layout with click-to-preview transcript and async completion resolution. ([#92](https://github.com/minchenlee/c9watch/pull/92))
+- **Entry animations** — three-tier cascade pacing across MONITOR, HISTORY, MEMORY, and COST tabs plus overlay panel fly-ins. History preloaded at startup to avoid tab-switch lag. ([#93](https://github.com/minchenlee/c9watch/pull/93))
+- **Cost per session** — new `c9watch cost --session <id>` and `--session-prefix <any>` CLI flags for per-session breakdown in JSON. ([#94](https://github.com/minchenlee/c9watch/pull/94))
+- **USD/TOKENS toggle** in cost tab plus per-card cost pill on SessionCard and overlay charts. ([#85](https://github.com/minchenlee/c9watch/pull/85))
+- **CLI auto-symlink** — installing the desktop app now symlinks the `c9watch` CLI into `~/.local/bin/` automatically. ([#83](https://github.com/minchenlee/c9watch/pull/83))
+
+### Fixed
+- **App icon padding** — added ~100px inset to `icon.png` master so macOS Sequoia no longer oversizes it in the Dock. Master restored to 1024×1024 after Tauri CLI downscale. ([#97](https://github.com/minchenlee/c9watch/pull/97))
+- **debug_log test races** — serialized ring-buffer tests to prevent flaky CI. ([#82](https://github.com/minchenlee/c9watch/pull/82))
+
+### Improved
+- **Pink agent accent + de-duped nav header** — agent sessions now use pink for visual distinction; overlay navigation header consolidated. ([#90](https://github.com/minchenlee/c9watch/pull/90))
+- **Shared UI utilities** — extracted `time-utils.ts`, `status-utils.ts`, unified preview state, and usage-stats helper from PR #92 for reuse across cards and overlay. ([#96](https://github.com/minchenlee/c9watch/pull/96))
+- **Removed leaked internal planning docs** — repo now ignores `docs/superpowers/` by default. ([#89](https://github.com/minchenlee/c9watch/pull/89))
+
 ## [0.7.0] - 2026-04-06
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -139,6 +139,17 @@ c9watch watch --interval 2 --compact --changes-only
 
 # View tasks/todos for a session
 c9watch tasks abc123
+
+# Cost breakdown, including per-session lookup
+c9watch cost --daily
+c9watch cost --session abc12345 --pretty
+c9watch cost --session-prefix abc
+
+# PM orchestration: spawn and manage child worker sessions
+c9watch spawn --name my-worker --cwd ../my-worktree --append-system-prompt "..."
+c9watch send <session-id> --message "do this task"
+c9watch workers
+c9watch inbox --pretty
 ```
 
 Use `--pretty` on any command for human-readable JSON. The `watch` command streams newline-delimited JSON events (`started`, `status_changed`, `stopped`) for real-time monitoring.
@@ -165,7 +176,10 @@ See [SKILLS.md](SKILLS.md) for more install options.
 - **Session history** -- Browse and search all past sessions with instant metadata filter and deep content search; click a result to scroll to and highlight the matching message
 - **Memory viewer** -- Browse and inspect Claude Code memory files with a two-panel layout and quick Claude command access
 - **Cost tracker** -- Track Claude Code spending with daily, per-project, and per-model breakdowns; click any session to preview the conversation; sort by date or cost
-- **CLI for agents** -- `c9watch list`, `view`, `history`, `search`, `stop`, `watch` commands for scriptable session management and agent-to-agent monitoring
+- **CLI for agents** -- `c9watch list`, `view`, `history`, `search`, `stop`, `watch`, `cost` commands for scriptable session management and agent-to-agent monitoring
+- **PM orchestration** -- Spawn, message, and manage child Claude Code "worker" sessions from a parent "PM" session via `c9watch spawn`, `send`, `workers`, `adopt`, `inbox`, `tasks`. WORKER and PM badges visible on session cards; PMs show a Workers panel in the overlay
+- **Subagent visibility** -- Detect and display Task-tool subagents spawned inside any session, with click-to-preview transcripts
+- **Entry animations** -- Staggered cascade transitions across tabs and overlay panels for fluid navigation
 - **Token distance visualizer** -- See your token usage as a rice stack towering past 22 real-world landmarks, with animated stacking, native share sheet, and Instagram-ready PNG export
 - **Debug console** -- Hidden diagnostic panel (`Cmd+Shift+D`) for troubleshooting session detection issues
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "c9watch",
-  "version": "0.7.0",
+  "version": "0.8.0",
   "description": "Monitor and control all your Claude Code sessions from one place",
   "type": "module",
   "scripts": {

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -438,7 +438,7 @@ dependencies = [
 
 [[package]]
 name = "c9watch"
-version = "0.7.0"
+version = "0.8.0"
 dependencies = [
  "anyhow",
  "axum",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "c9watch"
-version = "0.7.0"
+version = "0.8.0"
 description = "Monitor and control all your Claude Code sessions from one place"
 authors = ["minchenlee"]
 edition = "2021"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "c9watch",
-  "version": "0.7.0",
+  "version": "0.8.0",
   "identifier": "com.minchenlee.c9watch",
   "build": {
     "beforeDevCommand": "npm run dev",


### PR DESCRIPTION
## Summary

- Bump version to 0.8.0 across `package.json`, `src-tauri/tauri.conf.json`, `src-tauri/Cargo.toml`, `src-tauri/Cargo.lock`
- Add CHANGELOG entry for 0.8.0 covering 11 commits since v0.7.0
- Update README Features list and CLI examples for the new commands

## Highlights shipping in 0.8.0

**Added**
- PM orchestration CLI (#84) — spawn/send/workers/stop/adopt/inbox/tasks + PM and WORKER badges
- Subagent visibility (#92) — 2-row card layout + click-to-preview transcript
- Entry animations (#93) — three-tier cascade pacing across all tabs
- `c9watch cost --session` and `--session-prefix` (#94)
- USD/TOKENS toggle + per-card cost pill (#85)
- CLI auto-symlink on desktop install (#83)

**Fixed**
- App icon padding for macOS Sequoia Dock (#97)
- Flaky `debug_log` ring-buffer tests (#82)

**Improved**
- Pink agent accent + de-duped nav header (#90)
- Shared UI utilities: `time-utils.ts`, `status-utils.ts`, unified preview state (#96)
- Ignore `docs/superpowers/` (#89)

## QA verification (main @ `bd176f1`)

Pre-release QA worker verified:
- Rust tests: 240 passed / 0 failed / 1 ignored
- `cargo check`: 0 errors
- `svelte-check`: 0 errors (2 pre-existing a11y warnings in `CostTracker.svelte`)
- Icon master: 1024×1024 ✓
- Transitions: `CASCADE_CAP=20`, `|global` present in all 5 expected files
- `/simplify` extractions: `time-utils.ts` + `status-utils.ts` exist and are imported
- CLI smoke: all 4 PR #94 error paths return clean JSON

**Overall: PASS — ready to tag v0.8.0.**

## Test plan

- [ ] Version strings consistent across all 4 files
- [ ] CHANGELOG.md renders correctly in GitHub preview
- [ ] README Features list and CLI block render correctly

## Follow-up (post-merge)

Owner should rebuild+reinstall the CLI symlink — `~/.local/bin/c9watch` currently points at a pre-PR#94 build (observed by QA worker).