### PR TITLE
fix(cli): route inbox, cost, adopt to CLI handler (v0.8.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to c9watch are documented here.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.8.1] - 2026-04-20
+
+### Fixed
+- **`c9watch inbox`, `cost`, `adopt` launched the GUI instead of the CLI** — `src-tauri/src/main.rs` kept a hardcoded allowlist of subcommand names for dispatching to the CLI handler. The three subcommands added in v0.8.0 (`inbox`, `adopt`) and v0.7.0 extension (`cost`) weren't added to the list, so running them on a GUI-inclusive build fell through and launched the Tauri desktop app. Added all three to the allowlist.
+
 ## [0.8.0] - 2026-04-20
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "c9watch",
-  "version": "0.8.0",
+  "version": "0.8.1",
   "description": "Monitor and control all your Claude Code sessions from one place",
   "type": "module",
   "scripts": {

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -438,7 +438,7 @@ dependencies = [
 
 [[package]]
 name = "c9watch"
-version = "0.8.0"
+version = "0.8.1"
 dependencies = [
  "anyhow",
  "axum",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "c9watch"
-version = "0.8.0"
+version = "0.8.1"
 description = "Monitor and control all your Claude Code sessions from one place"
 authors = ["minchenlee"]
 edition = "2021"

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -12,7 +12,7 @@ fn main() {
             let first = args[1].as_str();
             let known_commands = [
                 "list", "status", "self", "view", "history", "search", "stop", "watch", "tasks",
-                "spawn", "send", "workers", "daemon",
+                "spawn", "send", "workers", "inbox", "adopt", "cost", "daemon",
                 "help",
             ];
             let is_cli = known_commands.contains(&first)

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "c9watch",
-  "version": "0.8.0",
+  "version": "0.8.1",
   "identifier": "com.minchenlee.c9watch",
   "build": {
     "beforeDevCommand": "npm run dev",


### PR DESCRIPTION
## Summary

- `c9watch inbox`, `c9watch cost`, and `c9watch adopt` launched the Tauri desktop app instead of the CLI on GUI-inclusive builds
- Root cause: hardcoded allowlist in `src-tauri/src/main.rs` wasn't updated when these subcommands landed (inbox + adopt in v0.8.0 PR #84, cost in PR #94)
- One-line fix: add `inbox`, `adopt`, `cost` to the `known_commands` array
- Bumped version to 0.8.1 and added CHANGELOG entry

### Repro before fix

```
$ c9watch inbox
[c9watch][info] Mobile connection ready — URL: http://...
<QR code rendered in terminal>
```

### After fix

```
$ c9watch inbox
{"consumed":false,"count":0,"events":[],"ok":true,"pmSessionId":"..."}
```

### Why CLI-only builds weren't affected

The CLI-only binary (`--features cli --no-default-features`) parses argv as CLI unconditionally at `main.rs:34-37`. The allowlist only governs the dispatch decision on GUI-inclusive builds where both subsystems compile in.

### Follow-up worth considering (not in this PR)

The allowlist approach is fragile — every new subcommand requires touching two places (the clap enum + this list) with no compile-time link between them. A future refactor could either (a) try parsing with clap first and fall through to GUI only on parse failure, or (b) derive the subcommand list at runtime from clap's `Command::get_subcommands()`. Noting here so it doesn't get lost.

## Test plan

- [x] All 249 Rust unit tests pass (`cargo test --lib`)
- [x] CLI-only rebuild: `cargo build --release --features cli --no-default-features`
- [x] Verified `c9watch inbox --help`, `c9watch cost --help`, `c9watch adopt --help` all show proper CLI help
- [x] Verified `c9watch inbox` returns JSON (not QR code)
- [ ] Also verify on a GUI-inclusive build (`cargo build --release` without `--no-default-features`) — the original bug path
- [ ] Version strings consistent across `package.json`, `src-tauri/Cargo.toml`, `src-tauri/tauri.conf.json`, `src-tauri/Cargo.lock`
- [ ] CHANGELOG entry renders correctly