### PR TITLE
feat(ui): TODO side-panel in conversation preview overlay

### DIFF
--- a/src-tauri/src/cli/mod.rs
+++ b/src-tauri/src/cli/mod.rs
@@ -1713,3 +1713,55 @@ mod cost_session_tests {
         assert!(res.is_ok(), "parse failed: {:?}", res.err());
     }
 }
+
+#[cfg(test)]
+mod read_session_tasks_tests {
+    use super::*;
+    use std::fs;
+    use tempfile::tempdir;
+
+    fn write_task(home: &std::path::Path, session_id: &str, file: &str, body: &str) {
+        let dir = home.join(".claude").join("tasks").join(session_id);
+        fs::create_dir_all(&dir).unwrap();
+        fs::write(dir.join(file), body).unwrap();
+    }
+
+    #[test]
+    fn returns_empty_when_dir_missing() {
+        let home = tempdir().unwrap();
+        let got = read_session_tasks_in(home.path(), "no-such-session").unwrap();
+        assert!(got.is_empty());
+    }
+
+    #[test]
+    fn parses_and_sorts_by_numeric_id() {
+        let home = tempdir().unwrap();
+        let sid = "session-abc";
+        write_task(home.path(), sid, "10.json", r#"{"id":"10","content":"ten","status":"pending"}"#);
+        write_task(home.path(), sid, "2.json", r#"{"id":"2","content":"two","status":"in_progress"}"#);
+        write_task(home.path(), sid, "1.json", r#"{"id":"1","content":"one","status":"completed"}"#);
+
+        let got = read_session_tasks_in(home.path(), sid).unwrap();
+        let ids: Vec<&str> = got
+            .iter()
+            .map(|t| t.get("id").and_then(|v| v.as_str()).unwrap_or(""))
+            .collect();
+        assert_eq!(ids, vec!["1", "2", "10"]);
+    }
+
+    #[test]
+    fn skips_malformed_json_and_non_json_files() {
+        let home = tempdir().unwrap();
+        let sid = "session-xyz";
+        write_task(home.path(), sid, "1.json", r#"{"id":"1","content":"good","status":"pending"}"#);
+        write_task(home.path(), sid, "2.json", "not valid json {{{");
+        write_task(home.path(), sid, "ignore.txt", r#"{"id":"99"}"#);
+
+        let got = read_session_tasks_in(home.path(), sid).unwrap();
+        assert_eq!(got.len(), 1);
+        assert_eq!(
+            got[0].get("id").and_then(|v| v.as_str()),
+            Some("1")
+        );
+    }
+}

--- a/src-tauri/src/cli/mod.rs
+++ b/src-tauri/src/cli/mod.rs
@@ -1337,8 +1337,15 @@ fn find_session_metadata(session_id: &str) -> (Option<String>, Option<String>) {
     (None, None)
 }
 
-fn read_session_tasks(session_id: &str) -> Result<Vec<serde_json::Value>, String> {
+pub(crate) fn read_session_tasks(session_id: &str) -> Result<Vec<serde_json::Value>, String> {
     let home_dir = dirs::home_dir().ok_or("Failed to get home directory")?;
+    read_session_tasks_in(&home_dir, session_id)
+}
+
+fn read_session_tasks_in(
+    home_dir: &std::path::Path,
+    session_id: &str,
+) -> Result<Vec<serde_json::Value>, String> {
     let tasks_dir = home_dir.join(".claude").join("tasks").join(session_id);
 
     if !tasks_dir.exists() {

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -118,6 +118,15 @@ async fn get_subagent_transcript(
         .ok_or_else(|| format!("subagent {} not found in session {}", subagent_id, parent_session_id))
 }
 
+/// Returns the parsed TodoWrite tasks for a session, sorted by numeric `id`.
+/// Reads `~/.claude/tasks/<session_id>/*.json`. Returns an empty list when
+/// the directory does not exist; silently skips malformed JSON files.
+#[cfg(all(not(mobile), feature = "gui", feature = "cli"))]
+#[tauri::command]
+async fn get_session_tasks(session_id: String) -> Result<Vec<serde_json::Value>, String> {
+    cli::read_session_tasks(&session_id)
+}
+
 /// Save base64-encoded PNG data to a temp file and return the path.
 /// Used by the token distance visualizer to share canvas screenshots.
 #[cfg(all(not(mobile), feature = "gui"))]
@@ -536,6 +545,7 @@ pub fn run() {
             get_memory_files,
             get_subagents,
             get_subagent_transcript,
+            get_session_tasks,
             save_temp_image,
             reveal_in_file_manager,
             stop_session,

--- a/src/lib/components/ExpandedCardOverlay.svelte
+++ b/src/lib/components/ExpandedCardOverlay.svelte
@@ -541,7 +541,7 @@
 		<!-- Desktop: right column (nav + workers stacked) -->
 		<div class="right-column nav-desktop">
 			<!-- Navigation panel -->
-			<div class="nav-map-side" class:collapsed={navCollapsed} in:flyInX|global={{ index: 0, base: 200 }}>
+			<div class="nav-map-side" class:collapsed={navCollapsed} in:flyInX|global={{ index: 0 }}>
 				<button
 					type="button"
 					class="panel-header"
@@ -564,11 +564,13 @@
 				{session}
 				collapsed={tasksCollapsed}
 				onToggle={() => (tasksCollapsed = !tasksCollapsed)}
+				transitionIndex={1}
+
 			/>
 
 			<!-- Workers panel (only when relevant) -->
 			{#if showWorkersPanel}
-				<div class="workers-side-panel" class:collapsed={workersCollapsed} in:flyInX|global={{ index: 1, base: 200 }}>
+				<div class="workers-side-panel" class:collapsed={workersCollapsed} in:flyInX|global={{ index: 2 }}>
 					<button
 						type="button"
 						class="panel-header"

--- a/src/lib/components/ExpandedCardOverlay.svelte
+++ b/src/lib/components/ExpandedCardOverlay.svelte
@@ -40,6 +40,7 @@
 	import { SessionStatus } from '$lib/types';
 	import MessageBubble from './MessageBubble.svelte';
 	import MessageNavMap from './MessageNavMap.svelte';
+	import TodoPanel from './TodoPanel.svelte';
 	import { createSlidingWindow, BATCH_SIZE } from '$lib/slidingWindow.svelte';
 	import { sessionCostMap, costMode } from '$lib/stores/cost';
 	import { workersByPm, expandedSessionId } from '$lib/stores/sessions';
@@ -70,6 +71,7 @@
 	let tooltipX = $state(0);
 	let tooltipY = $state(0);
 	let navCollapsed = $state(false);
+	let tasksCollapsed = $state(false);
 	let workersCollapsed = $state(false);
 	// Only stagger the first batch of messages when the overlay mounts;
 	// subsequent streaming/polling of new messages should NOT animate.
@@ -556,6 +558,13 @@
 					</div>
 				{/if}
 			</div>
+
+			<!-- TODOs panel (only when the session has tasks) -->
+			<TodoPanel
+				{session}
+				collapsed={tasksCollapsed}
+				onToggle={() => (tasksCollapsed = !tasksCollapsed)}
+			/>
 
 			<!-- Workers panel (only when relevant) -->
 			{#if showWorkersPanel}

--- a/src/lib/components/TodoPanel.svelte
+++ b/src/lib/components/TodoPanel.svelte
@@ -10,7 +10,7 @@
 
 	let { session, collapsed = false, onToggle }: Props = $props();
 
-	let tasks = $derived(($tasksBySession.get(session.id) ?? []) as Task[]);
+	let tasks = $derived($tasksBySession.get(session.id) ?? []);
 	let total = $derived(tasks.length);
 	let completed = $derived(tasks.filter((t) => t.status === 'completed').length);
 

--- a/src/lib/components/TodoPanel.svelte
+++ b/src/lib/components/TodoPanel.svelte
@@ -1,14 +1,17 @@
 <script lang="ts">
 	import { tasksBySession } from '$lib/stores/tasks';
+	import { flyInX } from '$lib/transitions';
 	import type { Session, Task } from '$lib/types';
 
 	interface Props {
 		session: Session;
 		collapsed?: boolean;
 		onToggle?: () => void;
+		/** Cascade index for the entry transition (parent owns the order). */
+		transitionIndex?: number;
 	}
 
-	let { session, collapsed = false, onToggle }: Props = $props();
+	let { session, collapsed = false, onToggle, transitionIndex = 0 }: Props = $props();
 
 	let tasks = $derived($tasksBySession.get(session.id) ?? []);
 	let total = $derived(tasks.length);
@@ -22,7 +25,7 @@
 </script>
 
 {#if total > 0}
-	<div class="todo-side-panel" class:collapsed>
+	<div class="todo-side-panel" class:collapsed in:flyInX|global={{ index: transitionIndex }}>
 		<button
 			type="button"
 			class="panel-header"
@@ -38,7 +41,7 @@
 				{#each tasks as t (t.id)}
 					<div class="todo-row" class:completed={t.status === 'completed'}>
 						<span class="todo-icon todo-icon-{t.status}">{statusIcon(t.status)}</span>
-						<span class="todo-content">{t.content}</span>
+						<span class="todo-content">{t.status === 'in_progress' ? t.activeForm : t.subject}</span>
 					</div>
 				{/each}
 			</div>

--- a/src/lib/components/TodoPanel.svelte
+++ b/src/lib/components/TodoPanel.svelte
@@ -1,0 +1,159 @@
+<script lang="ts">
+	import { tasksBySession } from '$lib/stores/tasks';
+	import type { Session, Task } from '$lib/types';
+
+	interface Props {
+		session: Session;
+		collapsed?: boolean;
+		onToggle?: () => void;
+	}
+
+	let { session, collapsed = false, onToggle }: Props = $props();
+
+	let tasks = $derived(($tasksBySession.get(session.id) ?? []) as Task[]);
+	let total = $derived(tasks.length);
+	let completed = $derived(tasks.filter((t) => t.status === 'completed').length);
+
+	function statusIcon(status: Task['status']): string {
+		if (status === 'completed') return '✓';
+		if (status === 'in_progress') return '⟳';
+		return '◯';
+	}
+</script>
+
+{#if total > 0}
+	<div class="todo-side-panel" class:collapsed>
+		<button
+			type="button"
+			class="panel-header"
+			onclick={onToggle}
+			aria-expanded={!collapsed}
+		>
+			<span class="panel-chevron" class:rotated={collapsed}>▾</span>
+			<span class="panel-title">Todos</span>
+			<span class="panel-count">{completed}/{total}</span>
+		</button>
+		{#if !collapsed}
+			<div class="todo-list">
+				{#each tasks as t (t.id)}
+					<div class="todo-row" class:completed={t.status === 'completed'}>
+						<span class="todo-icon todo-icon-{t.status}">{statusIcon(t.status)}</span>
+						<span class="todo-content">{t.content}</span>
+					</div>
+				{/each}
+			</div>
+		{/if}
+	</div>
+{/if}
+
+<style>
+	.todo-side-panel {
+		background: var(--bg-card);
+		border: 1px solid var(--border-default);
+		display: flex;
+		flex-direction: column;
+		flex-shrink: 0;
+	}
+
+	.panel-header {
+		display: flex;
+		align-items: center;
+		gap: var(--space-sm);
+		width: 100%;
+		background: none;
+		border: none;
+		border-bottom: 1px solid var(--border-muted);
+		padding: var(--space-sm) var(--space-lg);
+		cursor: pointer;
+		text-align: left;
+		transition: background var(--transition-fast);
+	}
+
+	.panel-header:hover {
+		background: color-mix(in srgb, var(--text-muted) 6%, transparent);
+	}
+
+	.todo-side-panel.collapsed .panel-header {
+		border-bottom: none;
+	}
+
+	.panel-chevron {
+		font-family: var(--font-mono);
+		font-size: 11px;
+		color: var(--text-muted);
+		transition: transform 0.2s ease;
+		display: inline-block;
+		flex-shrink: 0;
+	}
+
+	.panel-chevron.rotated {
+		transform: rotate(-90deg);
+	}
+
+	.panel-title {
+		font-family: var(--font-pixel);
+		font-size: 12px;
+		text-transform: uppercase;
+		letter-spacing: 0.1em;
+		color: var(--text-muted);
+		flex: 1;
+	}
+
+	.panel-count {
+		font-family: var(--font-mono);
+		font-size: 11px;
+		color: var(--text-muted);
+		opacity: 0.5;
+	}
+
+	.todo-list {
+		display: flex;
+		flex-direction: column;
+		gap: 2px;
+		padding: var(--space-sm) 0;
+	}
+
+	.todo-row {
+		display: flex;
+		align-items: flex-start;
+		gap: var(--space-sm);
+		padding: 4px var(--space-lg);
+		font-family: var(--font-mono);
+		font-size: 13px;
+		color: var(--text-secondary);
+		word-break: break-word;
+	}
+
+	.todo-row.completed {
+		text-decoration: line-through;
+		opacity: 0.6;
+	}
+
+	.todo-icon {
+		flex-shrink: 0;
+		display: inline-block;
+		width: 14px;
+		text-align: center;
+		font-family: var(--font-mono);
+		font-size: 13px;
+		line-height: 1.4;
+	}
+
+	.todo-icon-pending {
+		color: var(--text-muted);
+	}
+
+	.todo-icon-in_progress {
+		color: var(--status-input);
+	}
+
+	.todo-icon-completed {
+		color: var(--accent-green);
+	}
+
+	.todo-content {
+		flex: 1;
+		min-width: 0;
+		line-height: 1.4;
+	}
+</style>

--- a/src/lib/stores/tasks.ts
+++ b/src/lib/stores/tasks.ts
@@ -1,0 +1,78 @@
+/**
+ * Store for TodoWrite task lists, sourced from `~/.claude/tasks/<session_id>/*.json`.
+ *
+ * No backend hook required: each polling tick iterates the current `sessions`
+ * store and invokes the `get_session_tasks` Tauri command per session id.
+ * Read-only — writes back to disk would race with Claude itself.
+ */
+
+import { writable, get } from 'svelte/store';
+import { invoke } from '@tauri-apps/api/core';
+import { sessions } from './sessions';
+import { isTauri } from '../ws';
+import type { Task, TaskStatus } from '../types';
+
+/** Raw map: session id -> ordered task list (sorted by numeric id). */
+export const tasksBySession = writable<Map<string, Task[]>>(new Map());
+
+let pollHandle: ReturnType<typeof setInterval> | null = null;
+
+function normalizeStatus(s: unknown): TaskStatus {
+	if (s === 'in_progress' || s === 'completed') return s;
+	return 'pending';
+}
+
+async function refreshOnce() {
+	if (!isTauri()) return;
+	const ids = get(sessions).map((s) => s.id);
+	const next = new Map<string, Task[]>();
+
+	await Promise.all(
+		ids.map(async (sessionId) => {
+			try {
+				const raw = await invoke<unknown[]>('get_session_tasks', { sessionId });
+				const tasks: Task[] = raw.map((t) => {
+					const obj = t as Record<string, unknown>;
+					return {
+						id: String(obj.id ?? ''),
+						content: typeof obj.content === 'string' ? obj.content : '',
+						status: normalizeStatus(obj.status),
+					};
+				});
+				if (tasks.length > 0) {
+					next.set(sessionId, tasks);
+				}
+			} catch {
+				// Backend may be unavailable; skip silently (mirrors subagents).
+			}
+		}),
+	);
+
+	tasksBySession.set(next);
+}
+
+/**
+ * Start polling for TodoWrite task updates. Re-fetches on `sessions` store
+ * changes (cheapest signal that JSONL activity may have appended TodoWrite
+ * tool_use entries) and on a fixed 4 s backstop.
+ */
+export function initializeTasksPolling() {
+	if (pollHandle !== null) return;
+	const unsub = sessions.subscribe(() => {
+		refreshOnce();
+	});
+	pollHandle = setInterval(refreshOnce, 4000);
+	refreshOnce();
+	return () => {
+		if (pollHandle !== null) {
+			clearInterval(pollHandle);
+			pollHandle = null;
+		}
+		unsub();
+	};
+}
+
+/** Test helper: read a snapshot of the current map. */
+export function _snapshotForTests(): Map<string, Task[]> {
+	return get(tasksBySession);
+}

--- a/src/lib/stores/tasks.ts
+++ b/src/lib/stores/tasks.ts
@@ -33,9 +33,14 @@ async function refreshOnce() {
 				const raw = await invoke<unknown[]>('get_session_tasks', { sessionId });
 				const tasks: Task[] = raw.map((t) => {
 					const obj = t as Record<string, unknown>;
+					const subject = typeof obj.subject === 'string' ? obj.subject
+						: typeof obj.description === 'string' ? obj.description
+						: '';
+					const activeForm = typeof obj.activeForm === 'string' ? obj.activeForm : subject;
 					return {
 						id: String(obj.id ?? ''),
-						content: typeof obj.content === 'string' ? obj.content : '',
+						subject,
+						activeForm,
 						status: normalizeStatus(obj.status),
 					};
 				});

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -229,3 +229,11 @@ export interface DetectionDiagnostics {
   processesWithCwd: number;
   fdaLikelyNeeded: boolean;
 }
+
+export type TaskStatus = 'pending' | 'in_progress' | 'completed';
+
+export interface Task {
+  id: string;
+  content: string;
+  status: TaskStatus;
+}

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -234,6 +234,7 @@ export type TaskStatus = 'pending' | 'in_progress' | 'completed';
 
 export interface Task {
   id: string;
-  content: string;
+  subject: string;
+  activeForm: string;
   status: TaskStatus;
 }

--- a/src/routes/(app)/+layout.svelte
+++ b/src/routes/(app)/+layout.svelte
@@ -2,6 +2,7 @@
 	import { onMount } from 'svelte';
 	import { initializeSessionListeners, sessions } from '$lib/stores/sessions';
 	import { initializeSubagentPolling } from '$lib/stores/subagents';
+	import { initializeTasksPolling } from '$lib/stores/tasks';
 	import { getSessions } from '$lib/api';
 	import { loadDemoDataIfActive } from '$lib/demo';
 	import { checkForUpdates } from '$lib/updater';
@@ -16,6 +17,7 @@
 		if (isTauri()) {
 			await initializeSessionListeners();
 			initializeSubagentPolling();
+			initializeTasksPolling();
 
 			if (!demoActive) {
 				const initialSessions = await getSessions();


### PR DESCRIPTION
## Summary

Adds a collapsible **TODOS** panel to the right-column of `ExpandedCardOverlay`, slotted between Navigation and Workers. Renders the session's live TodoWrite state from `~/.claude/tasks/<session_id>/*.json`, polled every 4 s (same pattern as the Subagents store). Read-only, hidden when the session has zero tasks.

Closes backlog item #34 from `MEMORY.md` ("TODO side-panel in conversation preview overlay").

## Design decisions (locked during brainstorming)

| # | Q | Answer |
|---|---|---|
| Q1 | Visibility | Every session, but panel hidden when `tasks.length === 0` |
| Q2 | Reactivity | 4 s setInterval + `sessions.subscribe` retrigger |
| Q3 | Edit vs read-only | Read-only |
| Q4 | Auto-scroll | None |
| Q5 | Panel ordering | Navigation → **TODOS** → Workers → Subagents |
| Q6 | Default collapsed state | Expanded |

Full spec: `docs/superpowers/specs/2026-04-20-todo-side-panel-design.md` (local/gitignored).

## Architecture

- **Rust:** `read_session_tasks` in `cli/mod.rs` is now `pub(crate)`. New `#[tauri::command] get_session_tasks` wrapper in `lib.rs` (gated `#[cfg(all(not(mobile), feature = "gui", feature = "cli"))]`). `read_session_tasks_in(home, id)` private helper extracted for hermetic unit tests.
- **Frontend:** new `src/lib/stores/tasks.ts` (mirrors `stores/subagents.ts`), new `src/lib/components/TodoPanel.svelte`. Mount point in `ExpandedCardOverlay.svelte` between Navigation and Workers. Polling bootstrapped next to `initializeSubagentPolling()`.

## Commits

1. `9e1f4db` feat(rust): expose read_session_tasks + add get_session_tasks tauri command
2. `2d1891d` test(rust): unit tests for read_session_tasks
3. `ba86445` feat(types): add Task and TaskStatus types
4. `2b494aa` feat(store): add tasks store with 4s polling
5. `ef783f0` feat(ui): TodoPanel component
6. `9c091a6` feat(ui): mount TodoPanel in ExpandedCardOverlay right-column
7. `e77a998` feat(ui): bootstrap initializeTasksPolling
8. `1ebf6c9` chore(simplify): drop redundant Task[] cast in TodoPanel

## Verification

- `cargo test --manifest-path src-tauri/Cargo.toml` — **255 passed, 1 ignored** (3 new tests in `read_session_tasks_tests`)
- `npm run check` — **0 errors, 0 new warnings** (2 pre-existing CostTracker warnings untouched)
- `npm run build` — ✓ in 2.52s
- `cargo build --release --features cli --no-default-features` — ✓ (CLI binary 5.0 M)

## Test plan

- [ ] Open the overlay for a session with TodoWrite history — confirm TODOS panel appears between Navigation and Workers
- [ ] Count reads `{completed}/{total}` correctly; icons: ◯ pending, ⟳ in_progress, ✓ completed
- [ ] Completed rows show strikethrough + dimmed
- [ ] Collapse chevron toggles the body
- [ ] Switch to a session with no TodoWrite history — panel is not rendered (not even the header)
- [ ] Wait 4 s after Claude ticks a task — panel reflects the new state

🤖 Generated with [Claude Code](https://claude.com/claude-code)