### PR TITLE
feat(ui): Cmd+1/2/3/4 keyboard shortcuts for tab navigation

### DIFF
--- a/src/routes/(app)/+page.svelte
+++ b/src/routes/(app)/+page.svelte
@@ -130,6 +130,37 @@
 		}
 	});
 
+	$effect(() => {
+		if (!browser) return;
+
+		const tabByKey: Record<string, typeof activeTab> = {
+			'1': 'monitor',
+			'2': 'history',
+			'3': 'cost',
+			'4': 'memory'
+		};
+
+		const handler = (e: KeyboardEvent) => {
+			if (!(e.metaKey || e.ctrlKey)) return;
+			if (e.altKey || e.shiftKey) return;
+			const tab = tabByKey[e.key];
+			if (!tab) return;
+
+			const target = e.target as HTMLElement | null;
+			if (target) {
+				const tag = target.tagName;
+				if (tag === 'INPUT' || tag === 'TEXTAREA' || tag === 'SELECT') return;
+				if (target.isContentEditable) return;
+			}
+
+			e.preventDefault();
+			activeTab = tab;
+		};
+
+		window.addEventListener('keydown', handler);
+		return () => window.removeEventListener('keydown', handler);
+	});
+
 	// Helper function to group sessions by project path, then by status
 	function groupByProjectAndStatus(sessions: Session[]) {
 		const groups: Array<{

--- a/src/routes/(app)/+page.svelte
+++ b/src/routes/(app)/+page.svelte
@@ -354,7 +354,7 @@
 			toggleDemoMode();
 			return;
 		}
-		if (e.key >= '1' && e.key <= '9' && !expandedId) {
+		if (e.key >= '1' && e.key <= '9' && !expandedId && !e.metaKey && !e.ctrlKey) {
 			const index = parseInt(e.key) - 1;
 			if (index < filteredSessions.length) {
 				handleExpand(filteredSessions[index]);


### PR DESCRIPTION
## Summary

Adds keyboard shortcuts for main tab navigation:
- **Cmd+1** → MONITOR
- **Cmd+2** → HISTORY
- **Cmd+3** → COST
- **Cmd+4** → MEMORY

Cross-platform: also works with Ctrl on Linux/Windows.

Addresses backlog item #37 in `MEMORY.md`.

## Implementation

Single `$effect` in `src/routes/(app)/+page.svelte` registering a `window` keydown listener.

**Guards:**
- Requires `metaKey || ctrlKey`; rejects if `altKey` or `shiftKey` is also held
- Skips when target is `INPUT` / `TEXTAREA` / `SELECT` or `isContentEditable` (so Cmd+1 while typing into the rename field doesn't hijack the keystroke)
- Only intercepts digits `1–4`; any other Cmd+digit combo falls through to the OS/browser default
- `preventDefault()` only on the four shortcuts, never broadly
- Cleanup on effect teardown

## Verification

- `npm run check` — 0 errors, 0 new warnings (2 pre-existing in `CostTracker.svelte`)
- `npm run build` — ✓
- `cargo build --release --features cli --no-default-features` — ✓

## Test plan

- [ ] Open the app on MONITOR. Press Cmd+2 / 3 / 4 / 1 → tabs switch correctly
- [ ] Focus a text input (e.g. the session rename field). Press Cmd+1 → tab does NOT switch
- [ ] Press Cmd+5 or Cmd+0 → no-op, OS default preserved
- [ ] Press Cmd+Shift+1 or Cmd+Alt+1 → no-op

🤖 Generated with [Claude Code](https://claude.com/claude-code)