### PR TITLE
feat(ui): accordion MEMORY tab with slide animation + larger body text

### DIFF
--- a/src/lib/components/MemoryViewer.svelte
+++ b/src/lib/components/MemoryViewer.svelte
@@ -19,6 +19,21 @@
 
 	let copied = $state(false);
 
+	let expanded = $state<Record<string, boolean>>({});
+
+	$effect(() => {
+		if (!selectedProject) return;
+		const next: Record<string, boolean> = {};
+		selectedProject.files.forEach((f, i) => {
+			next[f.filename] = i === 0;
+		});
+		expanded = next;
+	});
+
+	function toggleFile(filename: string) {
+		expanded = { ...expanded, [filename]: !expanded[filename] };
+	}
+
 	function copyClaudeCommand() {
 		if (!selectedProject) return;
 		const cmd = `claude "Review my memory files and suggest improvements" --project-dir ${selectedProject.projectPath}`;
@@ -105,10 +120,20 @@
 						</div>
 						{#each selectedProject.files as file, i (file.filename)}
 							<div class="file-section" in:flyIn|global={{ index: i + 1, duration: 800, stride: 120 }}>
-								<div class="file-header">{file.filename}</div>
-								<div class="markdown-body">
-									{@html renderMarkdown(file.content)}
-								</div>
+								<button
+									class="file-header"
+									class:expanded={expanded[file.filename]}
+									onclick={() => toggleFile(file.filename)}
+									aria-expanded={expanded[file.filename] ? 'true' : 'false'}
+								>
+									<span class="file-header-name">{file.filename}</span>
+									<span class="file-header-chevron">{expanded[file.filename] ? '▾' : '▸'}</span>
+								</button>
+								{#if expanded[file.filename]}
+									<div class="markdown-body">
+										{@html renderMarkdown(file.content)}
+									</div>
+								{/if}
 							</div>
 						{/each}
 					{/key}
@@ -329,19 +354,50 @@
 	/* ── File sections ───────────────────────────────────────────── */
 
 	.file-section {
-		margin-bottom: var(--space-xl);
+		margin-bottom: var(--space-md);
 	}
 
 	.file-header {
+		display: flex;
+		align-items: center;
+		justify-content: space-between;
+		width: 100%;
 		font-family: var(--font-pixel);
-		font-size: 11px;
+		font-size: 13px;
 		font-weight: 600;
 		text-transform: uppercase;
-		letter-spacing: 0.05em;
+		letter-spacing: 0.1em;
 		color: var(--accent);
-		margin-bottom: var(--space-md);
-		padding: var(--space-xs) 0;
+		margin: 0;
+		padding: var(--space-sm) 0;
+		background: none;
+		border: none;
 		border-bottom: 1px solid var(--border-default);
+		cursor: pointer;
+		text-align: left;
+		transition: color 0.15s ease;
+	}
+
+	.file-header:hover {
+		color: var(--text-primary);
+	}
+
+	.file-header-name {
+		overflow: hidden;
+		text-overflow: ellipsis;
+		white-space: nowrap;
+	}
+
+	.file-header-chevron {
+		font-family: var(--font-mono);
+		font-size: 12px;
+		color: var(--text-muted);
+		flex-shrink: 0;
+		margin-left: var(--space-sm);
+	}
+
+	.file-header.expanded {
+		margin-bottom: var(--space-md);
 	}
 
 	/* ── Markdown body ───────────────────────────────────────────── */

--- a/src/lib/components/MemoryViewer.svelte
+++ b/src/lib/components/MemoryViewer.svelte
@@ -1,5 +1,7 @@
 <script lang="ts">
-	import { onMount } from 'svelte';
+	import { onMount, tick } from 'svelte';
+	import { slide } from 'svelte/transition';
+	import { cubicOut } from 'svelte/easing';
 	import { marked } from 'marked';
 	import DOMPurify from 'dompurify';
 	import { getMemoryFiles, revealInFileManager } from '$lib/api';
@@ -20,14 +22,19 @@
 	let copied = $state(false);
 
 	let expanded = $state<string | null>(null);
+	let fileHeaders: Record<string, HTMLButtonElement | null> = {};
 
 	$effect(() => {
 		if (!selectedProject) return;
 		expanded = selectedProject.files[0]?.filename ?? null;
 	});
 
-	function toggleFile(filename: string) {
+	async function toggleFile(filename: string) {
 		expanded = expanded === filename ? null : filename;
+		if (expanded === filename) {
+			await tick();
+			fileHeaders[filename]?.scrollIntoView({ behavior: 'smooth', block: 'start' });
+		}
 	}
 
 	function copyClaudeCommand() {
@@ -117,6 +124,7 @@
 						{#each selectedProject.files as file, i (file.filename)}
 							<div class="file-section" in:flyIn|global={{ index: i + 1, duration: 800, stride: 120 }}>
 								<button
+									bind:this={fileHeaders[file.filename]}
 									class="file-header"
 									class:expanded={expanded === file.filename}
 									onclick={() => toggleFile(file.filename)}
@@ -126,7 +134,7 @@
 									<span class="file-header-chevron">{expanded === file.filename ? '▾' : '▸'}</span>
 								</button>
 								{#if expanded === file.filename}
-									<div class="markdown-body">
+									<div class="markdown-body" transition:slide|local={{ duration: 250, easing: cubicOut }}>
 										{@html renderMarkdown(file.content)}
 									</div>
 								{/if}

--- a/src/lib/components/MemoryViewer.svelte
+++ b/src/lib/components/MemoryViewer.svelte
@@ -23,6 +23,7 @@
 
 	let expanded = $state<string | null>(null);
 	let fileHeaders: Record<string, HTMLButtonElement | null> = {};
+	let contentPane: HTMLDivElement | null = null;
 
 	$effect(() => {
 		if (!selectedProject) return;
@@ -31,10 +32,14 @@
 
 	async function toggleFile(filename: string) {
 		expanded = expanded === filename ? null : filename;
-		if (expanded === filename) {
-			await tick();
-			fileHeaders[filename]?.scrollIntoView({ behavior: 'smooth', block: 'start' });
-		}
+		if (expanded !== filename || !contentPane) return;
+		await tick();
+		const header = fileHeaders[filename];
+		if (!header) return;
+		const paneRect = contentPane.getBoundingClientRect();
+		const headerRect = header.getBoundingClientRect();
+		const targetTop = contentPane.scrollTop + (headerRect.top - paneRect.top);
+		contentPane.scrollTo({ top: targetTop, behavior: 'smooth' });
 	}
 
 	function copyClaudeCommand() {
@@ -102,7 +107,7 @@
 				{/each}
 			</aside>
 
-			<div class="memory-content">
+			<div class="memory-content" bind:this={contentPane}>
 				{#if selectedProject}
 					{#key selectedProject.projectPath}
 						<div class="content-header" in:flyIn|global={{ index: 0, duration: 800, stride: 120 }}>

--- a/src/lib/components/MemoryViewer.svelte
+++ b/src/lib/components/MemoryViewer.svelte
@@ -404,8 +404,8 @@
 
 	.markdown-body {
 		font-family: var(--font-sans);
-		font-size: 13px;
-		line-height: 1.6;
+		font-size: 15px;
+		line-height: 1.65;
 		color: var(--text-primary);
 	}
 
@@ -417,9 +417,9 @@
 		color: var(--text-primary);
 	}
 
-	.markdown-body :global(h1) { font-size: 16px; }
-	.markdown-body :global(h2) { font-size: 14px; }
-	.markdown-body :global(h3) { font-size: 13px; }
+	.markdown-body :global(h1) { font-size: 20px; }
+	.markdown-body :global(h2) { font-size: 17px; }
+	.markdown-body :global(h3) { font-size: 15px; }
 
 	.markdown-body :global(p) {
 		margin: var(--space-sm) 0;
@@ -439,7 +439,7 @@
 		background: rgba(255, 255, 255, 0.06);
 		padding: 2px 5px;
 		border-radius: 3px;
-		font-size: 12px;
+		font-size: 13px;
 		font-family: var(--font-mono);
 	}
 
@@ -467,8 +467,8 @@
 		margin: 0;
 		padding: var(--space-md);
 		overflow-x: auto;
-		font-size: 12px;
-		line-height: 1.5;
+		font-size: 13px;
+		line-height: 1.55;
 	}
 
 	.markdown-body :global(pre code) {
@@ -503,7 +503,7 @@
 		width: 100%;
 		border-collapse: collapse;
 		margin: var(--space-md) 0;
-		font-size: 12px;
+		font-size: 14px;
 	}
 
 	.markdown-body :global(th),

--- a/src/lib/components/MemoryViewer.svelte
+++ b/src/lib/components/MemoryViewer.svelte
@@ -19,19 +19,15 @@
 
 	let copied = $state(false);
 
-	let expanded = $state<Record<string, boolean>>({});
+	let expanded = $state<string | null>(null);
 
 	$effect(() => {
 		if (!selectedProject) return;
-		const next: Record<string, boolean> = {};
-		selectedProject.files.forEach((f, i) => {
-			next[f.filename] = i === 0;
-		});
-		expanded = next;
+		expanded = selectedProject.files[0]?.filename ?? null;
 	});
 
 	function toggleFile(filename: string) {
-		expanded = { ...expanded, [filename]: !expanded[filename] };
+		expanded = expanded === filename ? null : filename;
 	}
 
 	function copyClaudeCommand() {
@@ -122,14 +118,14 @@
 							<div class="file-section" in:flyIn|global={{ index: i + 1, duration: 800, stride: 120 }}>
 								<button
 									class="file-header"
-									class:expanded={expanded[file.filename]}
+									class:expanded={expanded === file.filename}
 									onclick={() => toggleFile(file.filename)}
-									aria-expanded={expanded[file.filename] ? 'true' : 'false'}
+									aria-expanded={expanded === file.filename ? 'true' : 'false'}
 								>
 									<span class="file-header-name">{file.filename}</span>
-									<span class="file-header-chevron">{expanded[file.filename] ? '▾' : '▸'}</span>
+									<span class="file-header-chevron">{expanded === file.filename ? '▾' : '▸'}</span>
 								</button>
-								{#if expanded[file.filename]}
+								{#if expanded === file.filename}
 									<div class="markdown-body">
 										{@html renderMarkdown(file.content)}
 									</div>


### PR DESCRIPTION
## Summary

- MEMORY tab files are now collapsible — click any header to expand, only one file open at a time (accordion style)
- Smooth 250ms slide transition on expand/collapse (svelte `slide`, `cubicOut`)
- When you click an unexpanded header, the content pane scrolls so the clicked header sits at the top
- Larger body font (13→15px) and heading sizes (H1 16→20, H2 14→17, H3 13→15) for readability
- First file of each project auto-expands when switching projects
- Chevron indicator (▸/▾) + `aria-expanded` on headers for accessibility

Single file touched: `src/lib/components/MemoryViewer.svelte` (+85, -20).

## Test plan

- [ ] Open MEMORY tab, switch between projects — first file auto-expands each time
- [ ] Click a collapsed file header — previously expanded file slides closed, new one slides open
- [ ] Clicked header scrolls to top of the content pane (not of the window)
- [ ] Click the currently-expanded header — it collapses cleanly, no file expanded
- [ ] Keyboard: `Tab` to a header, `Enter` toggles it (plain `<button>` element now)
- [ ] Large files (like MEMORY.md itself) render at the new font sizes without layout breaking

🤖 Generated with [Claude Code](https://claude.com/claude-code)