### PR TITLE
feat(search): phrase match default + case-sensitive/whole-word toggles in HISTORY

### DIFF
--- a/src-tauri/src/cli/mod.rs
+++ b/src-tauri/src/cli/mod.rs
@@ -94,6 +94,14 @@ pub enum Commands {
         /// Maximum number of results to return
         #[arg(short = 'n', long, default_value = "20")]
         limit: usize,
+
+        /// Match case exactly (default: case-insensitive)
+        #[arg(long)]
+        case_sensitive: bool,
+
+        /// Require the query to match at word boundaries
+        #[arg(long)]
+        whole_word: bool,
     },
 
     /// Identify this session (find the calling agent's own session by PID ancestry)
@@ -246,7 +254,16 @@ pub fn run(cli: Cli) {
             query,
             project,
             limit,
-        } => cmd_search(&query, project.as_deref(), limit, cli.pretty),
+            case_sensitive,
+            whole_word,
+        } => cmd_search(
+            &query,
+            project.as_deref(),
+            limit,
+            case_sensitive,
+            whole_word,
+            cli.pretty,
+        ),
         Commands::SelfId => cmd_self(cli.pretty),
         Commands::Stop { target } => cmd_stop(&target, cli.pretty),
         Commands::Watch {
@@ -446,12 +463,14 @@ fn cmd_search(
     query: &str,
     project_filter: Option<&str>,
     limit: usize,
+    case_sensitive: bool,
+    whole_word: bool,
     pretty: bool,
 ) -> Result<(), String> {
     if query.trim().is_empty() {
         return Err("Search query cannot be empty".to_string());
     }
-    let hits = session::deep_search(query)?;
+    let hits = session::deep_search(query, case_sensitive, whole_word)?;
 
     let enriched: Vec<serde_json::Value> = hits
         .into_iter()

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -76,11 +76,19 @@ async fn get_session_history() -> Result<Vec<session::HistoryEntry>, String> {
 
 #[cfg(all(not(mobile), feature = "gui"))]
 #[tauri::command]
-async fn deep_search_sessions(query: String) -> Result<Vec<session::DeepSearchHit>, String> {
+async fn deep_search_sessions(
+    query: String,
+    #[allow(non_snake_case)] caseSensitive: Option<bool>,
+    #[allow(non_snake_case)] wholeWord: Option<bool>,
+) -> Result<Vec<session::DeepSearchHit>, String> {
     if query.trim().is_empty() {
         return Ok(vec![]);
     }
-    session::deep_search(&query)
+    session::deep_search(
+        &query,
+        caseSensitive.unwrap_or(false),
+        wholeWord.unwrap_or(false),
+    )
 }
 
 #[cfg(all(not(mobile), feature = "gui"))]

--- a/src-tauri/src/session/history.rs
+++ b/src-tauri/src/session/history.rs
@@ -163,37 +163,23 @@ fn phrase_match(haystack: &str, needle: &str, whole_word: bool) -> bool {
     if !whole_word {
         return haystack.contains(needle);
     }
-    let needle_bytes = needle.as_bytes();
-    let nlen = needle_bytes.len();
-    let bytes = haystack.as_bytes();
+    let nlen = needle.len();
     let mut start = 0usize;
     while let Some(rel) = haystack[start..].find(needle) {
         let pos = start + rel;
-        let before_ok = if pos == 0 {
-            true
-        } else {
-            // Char before match must not be alphanumeric. Find previous char boundary.
-            let mut p = pos;
-            while p > 0 && !haystack.is_char_boundary(p - 1) {
-                p -= 1;
-            }
-            let prev_char = haystack[p.saturating_sub(1)..pos].chars().next_back();
-            prev_char.map_or(true, |c| !c.is_alphanumeric())
-        };
-        let end_pos = pos + nlen;
-        let after_ok = if end_pos >= bytes.len() {
-            true
-        } else {
-            haystack[end_pos..].chars().next().map_or(true, |c| !c.is_alphanumeric())
-        };
+        // `pos` from str::find is always on a char boundary.
+        let before_ok = haystack[..pos]
+            .chars()
+            .next_back()
+            .map_or(true, |c| !c.is_alphanumeric());
+        let after_ok = haystack[pos + nlen..]
+            .chars()
+            .next()
+            .map_or(true, |c| !c.is_alphanumeric());
         if before_ok && after_ok {
             return true;
         }
-        // Advance past the first byte of this match to find the next occurrence
         start = pos + 1;
-        if start >= haystack.len() {
-            break;
-        }
     }
     false
 }

--- a/src-tauri/src/session/history.rs
+++ b/src-tauri/src/session/history.rs
@@ -153,19 +153,63 @@ pub struct DeepSearchHit {
     pub snippet: String,
 }
 
-/// Extract a short snippet from `text` centred around the first occurrence of any query word.
-/// For multi-word queries, centres on the first word found.
+/// Returns true if `haystack` contains `needle` according to the given mode flags.
+/// - `case_sensitive = false`: both sides are lowercased (haystack is assumed pre-lowered when passed in).
+/// - `whole_word = true`: the match must be flanked by non-alphanumeric chars (or the string ends).
+fn phrase_match(haystack: &str, needle: &str, whole_word: bool) -> bool {
+    if needle.is_empty() {
+        return false;
+    }
+    if !whole_word {
+        return haystack.contains(needle);
+    }
+    let needle_bytes = needle.as_bytes();
+    let nlen = needle_bytes.len();
+    let bytes = haystack.as_bytes();
+    let mut start = 0usize;
+    while let Some(rel) = haystack[start..].find(needle) {
+        let pos = start + rel;
+        let before_ok = if pos == 0 {
+            true
+        } else {
+            // Char before match must not be alphanumeric. Find previous char boundary.
+            let mut p = pos;
+            while p > 0 && !haystack.is_char_boundary(p - 1) {
+                p -= 1;
+            }
+            let prev_char = haystack[p.saturating_sub(1)..pos].chars().next_back();
+            prev_char.map_or(true, |c| !c.is_alphanumeric())
+        };
+        let end_pos = pos + nlen;
+        let after_ok = if end_pos >= bytes.len() {
+            true
+        } else {
+            haystack[end_pos..].chars().next().map_or(true, |c| !c.is_alphanumeric())
+        };
+        if before_ok && after_ok {
+            return true;
+        }
+        // Advance past the first byte of this match to find the next occurrence
+        start = pos + 1;
+        if start >= haystack.len() {
+            break;
+        }
+    }
+    false
+}
+
+/// Extract a short snippet from `text` centred around the first occurrence of the query.
+/// `query_norm` is the case-normalised query (lowercased if case-insensitive, original if
+/// case-sensitive). `text_norm` is the matching-form of `text`.
 /// Returns at most 200 characters with the match roughly in the middle.
-fn extract_snippet(text: &str, query_lower: &str) -> String {
-    let lower = text.to_lowercase();
-    let words: Vec<&str> = query_lower.split_whitespace().filter(|w| !w.is_empty()).collect();
-    // Find the earliest occurrence of any word
-    let pos = words.iter()
-        .filter_map(|w| lower.find(w).map(|p| (p, w.len())))
-        .min_by_key(|(p, _)| *p);
-    let Some((pos, word_len)) = pos else {
+fn extract_snippet(text: &str, text_norm: &str, query_norm: &str) -> String {
+    if query_norm.is_empty() {
+        return text.chars().take(200).collect();
+    }
+    let Some(pos) = text_norm.find(query_norm) else {
         return text.chars().take(200).collect();
     };
+    let word_len = query_norm.len();
     let half = 80usize;
     let start = pos.saturating_sub(half);
     let end = (pos + word_len + half).min(text.len());
@@ -236,10 +280,17 @@ fn extract_message_text(line: &str) -> Option<String> {
     }
 }
 
-/// Search all session JSONL files under ~/.claude/projects/ for a query string.
-/// Returns hits with session ID and a short matching snippet, case-insensitive.
+/// Search all session JSONL files under ~/.claude/projects/ for a query.
+///
+/// Matches the query as a literal substring (phrase match). When
+/// `case_sensitive` is false the comparison is lowercased; when `whole_word`
+/// is true the match must be flanked by non-alphanumeric chars.
 /// Runs file reads concurrently using threads.
-pub fn deep_search(query: &str) -> Result<Vec<DeepSearchHit>, String> {
+pub fn deep_search(
+    query: &str,
+    case_sensitive: bool,
+    whole_word: bool,
+) -> Result<Vec<DeepSearchHit>, String> {
     let home_dir = dirs::home_dir().ok_or("Failed to get home directory")?;
     let projects_dir = home_dir.join(".claude").join("projects");
 
@@ -247,12 +298,14 @@ pub fn deep_search(query: &str) -> Result<Vec<DeepSearchHit>, String> {
         return Ok(vec![]);
     }
 
-    let query_lower = query.to_lowercase();
-    let query_words: Vec<String> = query_lower
-        .split_whitespace()
-        .filter(|w| !w.is_empty())
-        .map(|w| w.to_string())
-        .collect();
+    let query_norm = if case_sensitive {
+        query.to_string()
+    } else {
+        query.to_lowercase()
+    };
+    if query_norm.is_empty() {
+        return Ok(vec![]);
+    }
 
     // Collect all candidate JSONL file paths
     let mut candidates: Vec<(String, std::path::PathBuf)> = Vec::new();
@@ -281,46 +334,38 @@ pub fn deep_search(query: &str) -> Result<Vec<DeepSearchHit>, String> {
     // Search files concurrently using threads
     use std::sync::{Arc, Mutex};
     let matched: Arc<Mutex<Vec<DeepSearchHit>>> = Arc::new(Mutex::new(Vec::new()));
-    let query_lower = Arc::new(query_lower);
-    let query_words = Arc::new(query_words);
+    let query_norm = Arc::new(query_norm);
 
     let handles: Vec<_> = candidates
         .into_iter()
         .map(|(session_id, path)| {
             let matched = Arc::clone(&matched);
-            let query_lower = Arc::clone(&query_lower);
-            let query_words = Arc::clone(&query_words);
+            let query_norm = Arc::clone(&query_norm);
             std::thread::spawn(move || {
                 if let Ok(content) = std::fs::read_to_string(&path) {
                     // Only search user/assistant message text — skip metadata entries
                     // (summary, file-history-snapshot, etc.) which contain fields like
                     // sessionId, cwd, gitBranch that would trivially match most queries.
-                    // For multi-word queries, ALL words must appear somewhere in the
-                    // session's messages (not necessarily in the same line).
-                    // Collect (original, lowercased) pairs so we lowercase once.
+                    // Collect (original, matching-form) pairs; matching form is the
+                    // original when case-sensitive, or lowercased otherwise.
                     let messages: Vec<(String, String)> = content
                         .lines()
                         .filter_map(|line| extract_message_text(line))
                         .map(|text| {
-                            let lower = text.to_lowercase();
-                            (text, lower)
+                            let norm = if case_sensitive {
+                                text.clone()
+                            } else {
+                                text.to_lowercase()
+                            };
+                            (text, norm)
                         })
                         .collect();
-                    // Check each word against all messages joined.
-                    // W is typically ≤5 and Rust's contains() is SIMD-optimized.
-                    let combined_lower: String = messages.iter()
-                        .map(|(_, lower)| lower.as_str())
-                        .collect::<Vec<_>>()
-                        .join(" ");
-                    let all_match = query_words.iter().all(|w| combined_lower.contains(w.as_str()));
-                    if all_match {
-                        // Find the first message line containing any query word for snippet
-                        let snippet = messages.iter()
-                            .find(|(_, lower)| {
-                                query_words.iter().any(|w| lower.contains(w.as_str()))
-                            })
-                            .map(|(text, _)| extract_snippet(text, &query_lower))
-                            .unwrap_or_default();
+                    // Find first message containing the query (as phrase).
+                    let hit = messages.iter().find(|(_, norm)| {
+                        phrase_match(norm, query_norm.as_str(), whole_word)
+                    });
+                    if let Some((text, norm)) = hit {
+                        let snippet = extract_snippet(text, norm, query_norm.as_str());
                         if !snippet.is_empty() {
                             let mut guard = matched.lock().unwrap();
                             guard.push(DeepSearchHit { session_id, snippet });
@@ -500,5 +545,49 @@ mod tests {
         }];
         let out = filter_and_enrich(entries, tmp.path(), false);
         assert!(out.is_empty());
+    }
+
+    // ── phrase_match ────────────────────────────────────────────────
+
+    #[test]
+    fn test_phrase_match_substring_default() {
+        // Plain substring — case-insensitive caller lowercases both sides.
+        assert!(phrase_match("hello claude code world", "claude code", false));
+        // Two words present but not as a phrase → no match
+        assert!(!phrase_match("claude is here and code is there", "claude code", false));
+    }
+
+    #[test]
+    fn test_phrase_match_case_sensitive_caller_controls_case() {
+        // Helper itself is byte-level; the case_sensitive flag at the caller
+        // decides whether to lowercase inputs. Verify that the raw compare
+        // distinguishes case when caller does NOT lowercase.
+        assert!(phrase_match("HELLO CLAUDE CODE", "CLAUDE CODE", false));
+        assert!(!phrase_match("HELLO CLAUDE CODE", "claude code", false));
+    }
+
+    #[test]
+    fn test_phrase_match_whole_word() {
+        // whole-word ON: "cat" must not match "concatenate"
+        assert!(!phrase_match("the concatenate function", "cat", true));
+        assert!(phrase_match("the cat sat on the mat", "cat", true));
+        // Edge of string
+        assert!(phrase_match("cat", "cat", true));
+        assert!(phrase_match("cat.", "cat", true));
+        assert!(phrase_match(".cat", "cat", true));
+        // Numeric boundary also counts as alphanumeric
+        assert!(!phrase_match("cats123", "cats", true));
+    }
+
+    #[test]
+    fn test_phrase_match_empty_needle_false() {
+        assert!(!phrase_match("anything", "", false));
+        assert!(!phrase_match("anything", "", true));
+    }
+
+    #[test]
+    fn test_phrase_match_multiple_occurrences_with_whole_word() {
+        // Earlier occurrence is a non-boundary hit; later one is a match.
+        assert!(phrase_match("catalog, then cat", "cat", true));
     }
 }

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -104,10 +104,18 @@ export async function getSessionHistory(): Promise<HistoryEntry[]> {
  * Returns session IDs of matching sessions.
  * (Desktop/Tauri only — returns empty array on mobile/browser)
  */
-export async function deepSearchSessions(query: string): Promise<DeepSearchHit[]> {
+export async function deepSearchSessions(
+	query: string,
+	caseSensitive = false,
+	wholeWord = false,
+): Promise<DeepSearchHit[]> {
 	if (get(isDemoMode)) return [];
 	if (useWebSocket()) return [];
-	return await invoke<DeepSearchHit[]>('deep_search_sessions', { query });
+	return await invoke<DeepSearchHit[]>('deep_search_sessions', {
+		query,
+		caseSensitive,
+		wholeWord,
+	});
 }
 
 /**

--- a/src/lib/components/HistoryCardOverlay.svelte
+++ b/src/lib/components/HistoryCardOverlay.svelte
@@ -81,14 +81,12 @@
 				}
 				tick().then(() => {
 					if (searchQuery) {
-						// Find the first user/assistant message matching all query words.
-						// Uses multi-word AND to stay consistent with Rust deep_search.
-						const words = searchQuery.toLowerCase().split(/\s+/).filter(Boolean);
+						// Case-insensitive phrase match — consistent with deep_search defaults.
+						const needle = searchQuery.toLowerCase();
 						const matchIndex = conversation!.messages.findIndex(
 							(m) => {
 								if (m.messageType !== 'User' && m.messageType !== 'Assistant') return false;
-								const lower = m.content.toLowerCase();
-								return words.some((w) => lower.includes(w));
+								return m.content.toLowerCase().includes(needle);
 							}
 						);
 						if (matchIndex >= 0) {

--- a/src/lib/components/SessionHistory.svelte
+++ b/src/lib/components/SessionHistory.svelte
@@ -471,8 +471,8 @@
 		font-family: var(--font-pixel);
 		font-size: 11px;
 		letter-spacing: 0.08em;
-		width: 48px;
-		height: 24px;
+		width: 35.5px;
+		height: 35.5px;
 		display: flex;
 		align-items: center;
 		justify-content: center;

--- a/src/lib/components/SessionHistory.svelte
+++ b/src/lib/components/SessionHistory.svelte
@@ -471,8 +471,12 @@
 		font-family: var(--font-pixel);
 		font-size: 11px;
 		letter-spacing: 0.08em;
-		padding: 0 var(--space-sm);
-		min-width: 30px;
+		width: 24px;
+		height: 24px;
+		display: flex;
+		align-items: center;
+		justify-content: center;
+		padding: 0;
 		background: transparent;
 		border: none;
 		color: var(--text-muted);
@@ -486,7 +490,8 @@
 	}
 
 	.match-btn.active {
-		color: var(--accent-amber);
+		background: rgba(255, 255, 255, 0.1);
+		color: var(--text-primary);
 	}
 
 	.search-input:focus {

--- a/src/lib/components/SessionHistory.svelte
+++ b/src/lib/components/SessionHistory.svelte
@@ -471,7 +471,7 @@
 		font-family: var(--font-pixel);
 		font-size: 11px;
 		letter-spacing: 0.08em;
-		width: 24px;
+		width: 48px;
 		height: 24px;
 		display: flex;
 		align-items: center;

--- a/src/lib/components/SessionHistory.svelte
+++ b/src/lib/components/SessionHistory.svelte
@@ -19,6 +19,8 @@
 	let sortOrder = $state<'newest' | 'oldest'>('newest');
 	let groupByProject = $state(false);
 	let collapsedProjects = $state<Set<string>>(new Set());
+	let caseSensitive = $state(false);
+	let wholeWord = $state(false);
 
 	let deepSearching = $state(false);
 	// Map of sessionId → matching snippet. null = no search run yet.
@@ -34,6 +36,9 @@
 			if (savedSort === 'newest' || savedSort === 'oldest') sortOrder = savedSort;
 			const savedGroup = localStorage.getItem('historyGroup');
 			if (savedGroup === 'true') groupByProject = true;
+			if (localStorage.getItem('c9watch.historySearch.caseSensitive') === 'true')
+				caseSensitive = true;
+			if (localStorage.getItem('c9watch.historySearch.wholeWord') === 'true') wholeWord = true;
 		}
 		// History data is preloaded at app startup (see +page.svelte onMount);
 		// this refresh picks up anything new if the tab was reopened later.
@@ -48,11 +53,22 @@
 		if (browser) localStorage.setItem('historyGroup', String(groupByProject));
 	});
 
+	$effect(() => {
+		if (browser)
+			localStorage.setItem('c9watch.historySearch.caseSensitive', String(caseSensitive));
+	});
+
+	$effect(() => {
+		if (browser) localStorage.setItem('c9watch.historySearch.wholeWord', String(wholeWord));
+	});
+
 	// Debounced deep search: fires 300ms after the query settles.
 	// deepSearching is set only after the timer fires — no spinner during the
 	// debounce window itself, which avoids flicker on every keystroke.
 	$effect(() => {
 		const q = query;
+		const cs = caseSensitive;
+		const ww = wholeWord;
 		if (!q.trim()) {
 			deepSearchResults = null;
 			deepSearching = false;
@@ -63,7 +79,7 @@
 		const timer = setTimeout(async () => {
 			deepSearching = true;
 			try {
-				const hits = await deepSearchSessions(q);
+				const hits = await deepSearchSessions(q, cs, ww);
 				if (!cancelled) deepSearchResults = new Map(hits.map((h) => [h.sessionId, h.snippet]));
 			} catch (e) {
 				if (!cancelled) console.error('Deep search failed:', e);
@@ -77,20 +93,46 @@
 		};
 	});
 
+	// ── Match helpers ────────────────────────────────────────────────
+	/** Normalize a string for comparison given the current case-sensitivity mode. */
+	function norm(s: string): string {
+		return caseSensitive ? s : s.toLowerCase();
+	}
+
+	/** Whole-word match: true if `needle` appears in `haystack` flanked by non-alphanumerics. */
+	function phraseMatch(haystack: string, needle: string): boolean {
+		if (!needle) return false;
+		if (!wholeWord) return haystack.includes(needle);
+		let from = 0;
+		while (from <= haystack.length) {
+			const pos = haystack.indexOf(needle, from);
+			if (pos < 0) return false;
+			const before = pos === 0 ? '' : haystack.charAt(pos - 1);
+			const after = pos + needle.length >= haystack.length ? '' : haystack.charAt(pos + needle.length);
+			const boundaryBefore = before === '' || !/[a-z0-9]/i.test(before);
+			const boundaryAfter = after === '' || !/[a-z0-9]/i.test(after);
+			if (boundaryBefore && boundaryAfter) return true;
+			from = pos + 1;
+		}
+		return false;
+	}
+
 	// ── Filtering & sorting ──────────────────────────────────────────
 	let filtered = $derived.by(() => {
 		let entries = allEntries;
 
 		if (query.trim()) {
-			const words = query.toLowerCase().split(/\s+/).filter(Boolean);
-			entries = entries.filter(
-				(e) => {
-					const display = e.display.toLowerCase();
-					const project = e.projectName.toLowerCase();
-					const title = e.customTitle?.toLowerCase() ?? '';
-					return words.every((w) => display.includes(w) || project.includes(w) || title.includes(w));
-				}
-			);
+			const needle = norm(query);
+			entries = entries.filter((e) => {
+				const display = norm(e.display);
+				const project = norm(e.projectName);
+				const title = e.customTitle ? norm(e.customTitle) : '';
+				return (
+					phraseMatch(display, needle) ||
+					phraseMatch(project, needle) ||
+					phraseMatch(title, needle)
+				);
+			});
 
 			// If deep search has run, also include sessions that matched full content
 			if (deepSearchResults !== null) {
@@ -178,14 +220,31 @@
 
 	// ── Helpers ──────────────────────────────────────────────────────
 
-	/** Wrap every occurrence of each search word in `text` with <mark> tags (case-insensitive). */
+	/** Wrap every occurrence of the query phrase in `text` with <mark> tags.
+	 * Honors the current caseSensitive + wholeWord toggle state. */
 	function highlight(text: string, kw: string): string {
 		if (!kw.trim()) return escapeHtml(text);
-		const words = kw.split(/\s+/).filter(Boolean);
-		if (words.length === 0) return escapeHtml(text);
-		const escaped = escapeHtml(text);
-		const pattern = words.map((w) => w.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')).join('|');
-		return escaped.replace(new RegExp(pattern, 'gi'), (m) => `<mark>${m}</mark>`);
+		const escapedQuery = kw.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+		const pattern = wholeWord ? `(?<![a-z0-9])${escapedQuery}(?![a-z0-9])` : escapedQuery;
+		const flags = caseSensitive ? 'g' : 'gi';
+		let re: RegExp;
+		try {
+			re = new RegExp(pattern, flags);
+		} catch {
+			return escapeHtml(text);
+		}
+		// Walk the source string so the <mark> wraps the matched substring with
+		// its original casing, then escape only the surrounding segments.
+		let out = '';
+		let last = 0;
+		for (const m of text.matchAll(re)) {
+			const start = m.index ?? 0;
+			out += escapeHtml(text.slice(last, start));
+			out += `<mark>${escapeHtml(m[0])}</mark>`;
+			last = start + m[0].length;
+		}
+		out += escapeHtml(text.slice(last));
+		return out;
 	}
 
 	function escapeHtml(s: string): string {
@@ -222,6 +281,22 @@
 				placeholder="Search sessions..."
 				bind:value={query}
 			/>
+			<div class="match-toggle" role="group" aria-label="Search match options">
+				<button
+					class="match-btn"
+					class:active={caseSensitive}
+					onclick={() => (caseSensitive = !caseSensitive)}
+					title="Match case"
+					aria-pressed={caseSensitive}
+				>Aa</button>
+				<button
+					class="match-btn"
+					class:active={wholeWord}
+					onclick={() => (wholeWord = !wholeWord)}
+					title="Match whole word"
+					aria-pressed={wholeWord}
+				>W</button>
+			</div>
 		</div>
 
 		<div class="options-row" in:flyIn|global={{ index: 2, duration: 350, stride: 25 }}>
@@ -367,8 +442,15 @@
 		border-bottom: 1px solid var(--border-default);
 	}
 
+	.search-row {
+		display: flex;
+		align-items: stretch;
+		gap: var(--space-sm);
+	}
+
 	.search-input {
-		width: 100%;
+		flex: 1;
+		min-width: 0;
 		background: var(--bg-elevated);
 		border: 1px solid var(--border-default);
 		color: var(--text-primary);
@@ -377,6 +459,34 @@
 		padding: var(--space-sm) var(--space-md);
 		outline: none;
 		box-sizing: border-box;
+	}
+
+	.match-toggle {
+		display: flex;
+		border: 1px solid var(--border-default);
+		flex-shrink: 0;
+	}
+
+	.match-btn {
+		font-family: var(--font-pixel);
+		font-size: 11px;
+		letter-spacing: 0.08em;
+		padding: 0 var(--space-sm);
+		min-width: 30px;
+		background: transparent;
+		border: none;
+		color: var(--text-muted);
+		cursor: pointer;
+		text-transform: uppercase;
+	}
+
+	.match-btn:hover {
+		color: var(--text-primary);
+		background: rgba(255, 255, 255, 0.08);
+	}
+
+	.match-btn.active {
+		color: var(--accent-amber);
 	}
 
 	.search-input:focus {


### PR DESCRIPTION
## Summary

HISTORY tab search now matches phrases literally and exposes IDE-style modifier toggles.

- **Phrase-substring match by default** — typing `claude code` matches entries containing the literal substring. Previously this was a two-word AND match, which was surprising and rarely what you wanted.
- **`Aa` toggle** — case-sensitive mode (off by default)
- **`W` toggle** — whole-word match (off by default; enforces non-alphanumeric flanks)
- Both toggle states persist in `localStorage`
- Buttons are 35.5×35.5 squares grouped next to the search box, styled like the existing sort-group buttons (subtle grey active state, not amber)
- Backend (`session::deep_search`) extended with `case_sensitive` + `whole_word` parameters; tauri command signature uses `Option<bool>` for back-compat
- CLI flags `--case-sensitive` / `--whole-word` on `c9watch search`
- `HistoryCardOverlay` scroll-to-match logic updated for consistency with the new match semantics

## Tests

- 5 new unit tests for `phrase_match` in `src-tauri/src/session/history.rs` covering case-sensitivity control, whole-word boundaries, and multiple-occurrence runs
- All 260 lib tests pass (`cargo test --lib`)
- `npm run check` — 0 errors

## Files

- `src-tauri/src/session/history.rs` — phrase match impl + tests
- `src-tauri/src/lib.rs` — tauri command signature
- `src-tauri/src/cli/mod.rs` — CLI flags
- `src/lib/api.ts` — typed API wrapper
- `src/lib/components/SessionHistory.svelte` — toggles UI + phrase-match filter
- `src/lib/components/HistoryCardOverlay.svelte` — scroll-to-match consistency

## Test plan

- [ ] Type \`claude code\` — see results containing that literal two-word substring
- [ ] Click \`Aa\` — search becomes case-sensitive; \`Claude\` no longer matches \`claude\`
- [ ] Click \`W\` — search becomes whole-word; \`claud\` no longer matches \`claude\`
- [ ] Reload the app — toggle states restore from localStorage
- [ ] Click a result, open the overlay — scroll-to-match lands on the matching text correctly in all modes
- [ ] Run \`c9watch search 'error' --case-sensitive\` and \`--whole-word\` from CLI — flags work
- [ ] Buttons render as 35.5×35.5 squares next to the search box, active state is subtle grey

🤖 Generated with [Claude Code](https://claude.com/claude-code)