### PR TITLE
feat(detector): claude agents --json backend with legacy fallback

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -467,6 +467,7 @@ dependencies = [
  "thiserror 1.0.69",
  "tokio",
  "uuid",
+ "wait-timeout",
 ]
 
 [[package]]
@@ -5123,6 +5124,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fb067e4cbd1ff067d1df46c9194b5de0e98efd2810bbc95c5d5e5f25a3231150"
 dependencies = [
  "cc",
+ "libc",
+]
+
+[[package]]
+name = "wait-timeout"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09ac3b126d3914f9849036f826e054cbabdc8519970b8998ddaf3b5bd3c65f11"
+dependencies = [
  "libc",
 ]
 

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -68,6 +68,7 @@ base64 = { version = "0.22", optional = true }
 # ── CLI-only dependencies ────────────────────────────────────────────
 clap = { version = "4", features = ["derive"], optional = true }
 regex = { version = "1", optional = true }
+wait-timeout = "0.2"
 
 # ── macOS GUI-only ───────────────────────────────────────────────────
 # tauri-nspanel provides NSPanel support for the popover (above fullscreen apps).

--- a/src-tauri/examples/test_detector.rs
+++ b/src-tauri/examples/test_detector.rs
@@ -1,10 +1,10 @@
-use c9watch_lib::session::SessionDetector;
+use c9watch_lib::session::LegacySessionSource;
 
 fn main() {
     println!("Claude Session Detector Test\n");
 
     // Create a new detector
-    let mut detector = match SessionDetector::new() {
+    let mut detector = match LegacySessionSource::new() {
         Ok(d) => d,
         Err(e) => {
             eprintln!("Failed to create detector: {}", e);

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -22,7 +22,7 @@ pub mod cli;
 #[cfg(feature = "gui")]
 use actions::{open_session as open_session_action, stop_session as stop_session_action};
 #[cfg(feature = "gui")]
-use polling::{detect_and_enrich_sessions, start_polling, Session};
+use polling::{start_polling, Session};
 #[cfg(feature = "gui")]
 use serde::Serialize;
 #[cfg(feature = "gui")]
@@ -31,7 +31,7 @@ use session::conversation::Conversation;
 #[cfg(feature = "gui")]
 pub use session::conversation::get_conversation_data;
 #[cfg(feature = "gui")]
-use std::sync::Arc;
+use std::sync::{Arc, Mutex};
 #[cfg(feature = "gui")]
 use std::time::Duration;
 #[cfg(feature = "gui")]
@@ -58,8 +58,18 @@ fn greet(name: &str) -> String {
 
 #[cfg(all(not(mobile), feature = "gui"))]
 #[tauri::command]
-async fn get_sessions() -> Result<Vec<Session>, String> {
-    polling::detect_and_enrich_sessions().map(|(sessions, _)| sessions)
+async fn get_sessions(
+    detector: tauri::State<'_, Arc<Mutex<session::DetectorState>>>,
+) -> Result<Vec<Session>, String> {
+    let detect_result = {
+        let mut state = detector
+            .lock()
+            .map_err(|e| format!("Detector lock poisoned: {}", e))?;
+        state.detect()
+    };
+    let (detected, diag) = detect_result.map_err(|e| format!("Detect failed: {}", e))?;
+    session::enrichment::enrich_detected_sessions(detected, diag)
+        .map(|(sessions, _)| sessions)
 }
 
 #[cfg(all(not(mobile), feature = "gui"))]
@@ -165,12 +175,24 @@ async fn reveal_in_file_manager(path: String) -> Result<(), String> {
 
 #[cfg(all(not(mobile), feature = "gui"))]
 #[tauri::command]
-async fn stop_session(app: AppHandle, pid: u32) -> Result<(), String> {
+async fn stop_session(
+    app: AppHandle,
+    detector: tauri::State<'_, Arc<Mutex<session::DetectorState>>>,
+    pid: u32,
+) -> Result<(), String> {
     stop_session_action(pid)?;
     std::thread::sleep(Duration::from_millis(300));
 
-    if let Ok((sessions, _)) = detect_and_enrich_sessions() {
-        let _ = app.emit("sessions-updated", &sessions);
+    let detect_result = {
+        let mut state = detector
+            .lock()
+            .map_err(|e| format!("Detector lock poisoned: {}", e))?;
+        state.detect()
+    };
+    if let Ok((detected, diag)) = detect_result {
+        if let Ok((sessions, _)) = session::enrichment::enrich_detected_sessions(detected, diag) {
+            let _ = app.emit("sessions-updated", &sessions);
+        }
     }
     Ok(())
 }
@@ -185,6 +207,7 @@ async fn open_session(pid: u32, project_path: String) -> Result<(), String> {
 #[tauri::command]
 async fn rename_session(
     app: AppHandle,
+    detector: tauri::State<'_, Arc<Mutex<session::DetectorState>>>,
     session_id: String,
     new_name: String,
 ) -> Result<(), String> {
@@ -196,8 +219,16 @@ async fn rename_session(
     custom_titles.set(session_id, new_name);
     custom_titles.save()?;
 
-    if let Ok((sessions, _)) = detect_and_enrich_sessions() {
-        let _ = app.emit("sessions-updated", &sessions);
+    let detect_result = {
+        let mut state = detector
+            .lock()
+            .map_err(|e| format!("Detector lock poisoned: {}", e))?;
+        state.detect()
+    };
+    if let Ok((detected, diag)) = detect_result {
+        if let Ok((sessions, _)) = session::enrichment::enrich_detected_sessions(detected, diag) {
+            let _ = app.emit("sessions-updated", &sessions);
+        }
     }
     Ok(())
 }
@@ -387,20 +418,41 @@ pub fn run() {
             });
             tauri::async_runtime::spawn(web_server::start_server(ws_state));
 
-            // ── Polling loop ────────────────────────────────────
-            start_polling(app.handle().clone(), sessions_tx, notifications_tx);
+            // ── Shared detector state ───────────────────────────
+            let detector_state: Arc<Mutex<session::DetectorState>> =
+                Arc::new(Mutex::new(session::DetectorState::new()));
+            app.manage(detector_state.clone());
 
-            // ── Main window: hide on close instead of destroying ──────────────
-            // This allows "Open Dashboard" from the popover to re-show it.
-            // Without this, closing the window destroys it and show() is a no-op.
+            // ── Polling loop ────────────────────────────────────
+            start_polling(
+                app.handle().clone(),
+                detector_state.clone(),
+                sessions_tx,
+                notifications_tx,
+            );
+
+            // ── Main window: hide on close + recheck backend on focus ─────────
+            // hide-on-close keeps "Open Dashboard" working from the popover.
+            // Focused(true) triggers DetectorState::recheck_and_maybe_swap so a
+            // user upgrading Claude Code mid-session can pick up the new
+            // backend the next time they refocus the app.
+            // NOTE: on_window_event in Tauri 2 REPLACES (not appends) the
+            // handler — both behaviors must live in this single closure.
             #[cfg(not(mobile))]
             if let Some(main_win) = app.get_webview_window("main") {
                 let main_win_clone = main_win.clone();
-                main_win.on_window_event(move |event| {
-                    if let tauri::WindowEvent::CloseRequested { api, .. } = event {
+                let detector_for_focus = detector_state.clone();
+                main_win.on_window_event(move |event| match event {
+                    tauri::WindowEvent::CloseRequested { api, .. } => {
                         api.prevent_close();
                         let _ = main_win_clone.hide();
                     }
+                    tauri::WindowEvent::Focused(true) => {
+                        if let Ok(mut state) = detector_for_focus.lock() {
+                            state.recheck_and_maybe_swap();
+                        }
+                    }
+                    _ => {}
                 });
             }
 

--- a/src-tauri/src/polling.rs
+++ b/src-tauri/src/polling.rs
@@ -1,6 +1,6 @@
 use crate::session::enrichment::detect_and_enrich_sessions_with_detector;
 pub use crate::session::enrichment::{detect_and_enrich_sessions, truncate_string, Session};
-use crate::session::{SessionDetector, SessionStatus};
+use crate::session::{LegacySessionSource, SessionStatus};
 use serde::{Deserialize, Serialize};
 use std::collections::hash_map::DefaultHasher;
 use std::collections::{HashMap, HashSet};
@@ -111,7 +111,7 @@ pub fn start_polling(
         let poll_interval = Duration::from_millis(3500);
 
         // Create detector once and reuse across poll cycles
-        let mut detector = match SessionDetector::new() {
+        let mut detector = match LegacySessionSource::new() {
             Ok(d) => d,
             Err(e) => {
                 crate::debug_log::log_error(&format!(

--- a/src-tauri/src/polling.rs
+++ b/src-tauri/src/polling.rs
@@ -1,6 +1,6 @@
-use crate::session::enrichment::detect_and_enrich_sessions_with_source;
+use crate::session::enrichment::enrich_detected_sessions;
 pub use crate::session::enrichment::{detect_and_enrich_sessions, truncate_string, Session};
-use crate::session::SessionStatus;
+use crate::session::{DetectorState, SessionStatus};
 use serde::{Deserialize, Serialize};
 use std::collections::hash_map::DefaultHasher;
 use std::collections::{HashMap, HashSet};
@@ -103,16 +103,13 @@ fn load_workers_overlay() -> Arc<HashMap<String, String>> {
 /// 5. Broadcasts session data to WebSocket clients
 pub fn start_polling(
     app: AppHandle,
+    detector: Arc<Mutex<DetectorState>>,
     sessions_tx: tokio::sync::broadcast::Sender<String>,
     notifications_tx: tokio::sync::broadcast::Sender<String>,
 ) {
     thread::spawn(move || {
         let app_handle = Arc::new(app);
         let poll_interval = Duration::from_millis(3500);
-
-        // Create session source via factory once and reuse across poll cycles.
-        // Task 8 will replace this with shared Arc<Mutex<DetectorState>>.
-        let mut source = crate::session::create_session_source();
 
         // Track previous status for each session
         let previous_status: Arc<Mutex<HashMap<String, SessionStatus>>> =
@@ -131,8 +128,23 @@ pub fn start_polling(
         let mut prev_sessions_hash: Option<u64> = None;
 
         loop {
-            // Detect and enrich sessions
-            match detect_and_enrich_sessions_with_source(source.as_mut()) {
+            // Lock the shared DetectorState only for the detection step itself,
+            // then drop the guard BEFORE the slow enrichment pass so other call
+            // sites (Tauri commands, focus handler) aren't blocked.
+            let detect_result = {
+                let mut state = match detector.lock() {
+                    Ok(g) => g,
+                    Err(poisoned) => poisoned.into_inner(),
+                };
+                state.detect()
+            };
+
+            let enriched = match detect_result {
+                Ok((detected, diag)) => enrich_detected_sessions(detected, diag),
+                Err(e) => Err(format!("Detect failed: {}", e)),
+            };
+
+            match enriched {
                 Ok((mut sessions, diagnostics)) => {
                     // Overlay worker_of from ~/.claude/c9watch/workers/*/meta.json
                     let overlay = load_workers_overlay();

--- a/src-tauri/src/polling.rs
+++ b/src-tauri/src/polling.rs
@@ -1,6 +1,6 @@
-use crate::session::enrichment::detect_and_enrich_sessions_with_detector;
+use crate::session::enrichment::detect_and_enrich_sessions_with_source;
 pub use crate::session::enrichment::{detect_and_enrich_sessions, truncate_string, Session};
-use crate::session::{LegacySessionSource, SessionStatus};
+use crate::session::SessionStatus;
 use serde::{Deserialize, Serialize};
 use std::collections::hash_map::DefaultHasher;
 use std::collections::{HashMap, HashSet};
@@ -110,17 +110,9 @@ pub fn start_polling(
         let app_handle = Arc::new(app);
         let poll_interval = Duration::from_millis(3500);
 
-        // Create detector once and reuse across poll cycles
-        let mut detector = match LegacySessionSource::new() {
-            Ok(d) => d,
-            Err(e) => {
-                crate::debug_log::log_error(&format!(
-                    "Failed to create session detector: {}",
-                    e
-                ));
-                return;
-            }
-        };
+        // Create session source via factory once and reuse across poll cycles.
+        // Task 8 will replace this with shared Arc<Mutex<DetectorState>>.
+        let mut source = crate::session::create_session_source();
 
         // Track previous status for each session
         let previous_status: Arc<Mutex<HashMap<String, SessionStatus>>> =
@@ -140,7 +132,7 @@ pub fn start_polling(
 
         loop {
             // Detect and enrich sessions
-            match detect_and_enrich_sessions_with_detector(&mut detector) {
+            match detect_and_enrich_sessions_with_source(source.as_mut()) {
                 Ok((mut sessions, diagnostics)) => {
                     // Overlay worker_of from ~/.claude/c9watch/workers/*/meta.json
                     let overlay = load_workers_overlay();

--- a/src-tauri/src/session/detector.rs
+++ b/src-tauri/src/session/detector.rs
@@ -1,58 +1,19 @@
-use serde::{Deserialize, Serialize};
+use serde::Deserialize;
 use std::fs;
 use std::path::{Path, PathBuf};
 use sysinfo::{ProcessRefreshKind, ProcessesToUpdate, RefreshKind, System, UpdateKind};
-use thiserror::Error;
 
-#[derive(Error, Debug)]
-pub enum SessionDetectorError {
-    #[error("Failed to read directory: {0}")]
-    DirectoryRead(#[from] std::io::Error),
-
-    #[error("Failed to get home directory")]
-    HomeDirectoryNotFound,
-
-    #[error("Failed to refresh process information")]
-    ProcessRefreshError,
-}
-
-/// Information about a detected Claude Code session
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct DetectedSession {
-    /// Process ID of the running claude process
-    pub pid: u32,
-
-    /// Current working directory of the process
-    pub cwd: PathBuf,
-
-    /// Path to the session's project directory in ~/.claude/projects/
-    pub project_path: PathBuf,
-
-    /// Session ID (UUID from session file)
-    pub session_id: Option<String>,
-
-    /// Project name (derived from cwd)
-    pub project_name: String,
-}
-
-/// Diagnostics about the session detection process
-#[derive(Debug, Clone, Serialize, Deserialize, Default, PartialEq)]
-#[serde(rename_all = "camelCase")]
-pub struct DetectionDiagnostics {
-    pub claude_processes_found: u32,
-    pub processes_with_cwd: u32,
-    pub fda_likely_needed: bool,
-}
+use super::source::{DetectedSession, DetectionDiagnostics, SessionDetectorError, SessionSource};
 
 /// Session detector that finds running Claude processes and matches them to session files
-pub struct SessionDetector {
+pub struct LegacySessionSource {
     system: System,
     claude_projects_dir: PathBuf,
     claude_sessions_dir: PathBuf,
 }
 
-impl SessionDetector {
-    /// Creates a new SessionDetector
+impl LegacySessionSource {
+    /// Creates a new LegacySessionSource
     pub fn new() -> Result<Self, SessionDetectorError> {
         let home_dir = dirs::home_dir().ok_or(SessionDetectorError::HomeDirectoryNotFound)?;
 
@@ -224,13 +185,13 @@ impl SessionDetector {
                         })
                     {
                         used_session_ids.insert(meta.session_id.clone());
-                        sessions.push(DetectedSession {
-                            pid: proc.pid,
-                            cwd: proc_cwd.clone(),
-                            project_path: project_dir.clone(),
-                            session_id: Some(meta.session_id),
-                            project_name: project_name.clone(),
-                        });
+                        sessions.push(DetectedSession::with_legacy_defaults(
+                            proc.pid,
+                            proc_cwd.clone(),
+                            project_dir.clone(),
+                            Some(meta.session_id),
+                            project_name.clone(),
+                        ));
                         continue;
                     }
                 }
@@ -304,13 +265,13 @@ impl SessionDetector {
                 {
                     used_session_ids.insert(session_id.clone());
 
-                    sessions.push(DetectedSession {
-                        pid: proc.pid,
-                        cwd: proc_cwd.clone(),
-                        project_path: project_dir.clone(),
-                        session_id: Some(session_id),
-                        project_name: project_name.clone(),
-                    });
+                    sessions.push(DetectedSession::with_legacy_defaults(
+                        proc.pid,
+                        proc_cwd.clone(),
+                        project_dir.clone(),
+                        Some(session_id),
+                        project_name.clone(),
+                    ));
                 }
             } else {
                 crate::debug_log::log_warn(&format!(
@@ -439,9 +400,20 @@ impl SessionDetector {
     }
 }
 
-impl Default for SessionDetector {
+impl Default for LegacySessionSource {
     fn default() -> Self {
-        Self::new().expect("Failed to create SessionDetector")
+        Self::new().expect("Failed to create LegacySessionSource")
+    }
+}
+
+impl SessionSource for LegacySessionSource {
+    fn detect(
+        &mut self,
+    ) -> Result<(Vec<DetectedSession>, DetectionDiagnostics), SessionDetectorError> {
+        self.detect_sessions()
+    }
+    fn backend_name(&self) -> &'static str {
+        "legacy"
     }
 }
 
@@ -503,13 +475,13 @@ mod tests {
 
     #[test]
     fn test_detector_creation() {
-        let result = SessionDetector::new();
+        let result = LegacySessionSource::new();
         assert!(result.is_ok());
     }
 
     #[test]
     fn test_find_claude_processes() {
-        let detector = SessionDetector::new().unwrap();
+        let detector = LegacySessionSource::new().unwrap();
         let processes = detector.find_claude_processes();
         // This test will vary based on whether claude is running
         println!("Found {} claude processes", processes.len());
@@ -517,7 +489,7 @@ mod tests {
 
     #[test]
     fn test_enumerate_project_directories() {
-        let detector = SessionDetector::new().unwrap();
+        let detector = LegacySessionSource::new().unwrap();
         let result = detector.enumerate_project_directories();
         assert!(result.is_ok());
 

--- a/src-tauri/src/session/detector_cli.rs
+++ b/src-tauri/src/session/detector_cli.rs
@@ -86,6 +86,20 @@ impl SessionSource for CliSessionSource {
             .spawn()
             .map_err(|e| SessionDetectorError::CliFailed(format!("spawn: {e}")))?;
 
+        // Drain stdout on a background thread to avoid pipe-buffer deadlock
+        // when the child writes more than the OS pipe buffer (typically 64KB).
+        // The reader exits naturally when the child closes stdout (on exit or kill).
+        let stdout = child
+            .stdout
+            .take()
+            .ok_or_else(|| SessionDetectorError::CliFailed("stdout pipe missing".to_string()))?;
+        let reader = std::thread::spawn(move || {
+            let mut stdout = stdout;
+            let mut buf = Vec::new();
+            let _ = stdout.read_to_end(&mut buf);
+            buf
+        });
+
         let timeout = Duration::from_secs(2);
         let status = match child
             .wait_timeout(timeout)
@@ -94,21 +108,20 @@ impl SessionSource for CliSessionSource {
             Some(s) => s,
             None => {
                 let _ = child.kill();
+                // Still join the reader so it doesn't leak; kill closes the pipe.
+                let _ = reader.join();
                 return Err(SessionDetectorError::Timeout(timeout.as_millis()));
             }
         };
+
+        let buf = reader
+            .join()
+            .map_err(|_| SessionDetectorError::CliFailed("stdout reader panicked".to_string()))?;
 
         if !status.success() {
             return Err(SessionDetectorError::CliFailed(format!(
                 "exit code {status:?}"
             )));
-        }
-
-        let mut buf = Vec::new();
-        if let Some(mut stdout) = child.stdout.take() {
-            stdout
-                .read_to_end(&mut buf)
-                .map_err(|e| SessionDetectorError::CliFailed(format!("read: {e}")))?;
         }
 
         let agents: Vec<CliAgent> = serde_json::from_slice(&buf)

--- a/src-tauri/src/session/detector_cli.rs
+++ b/src-tauri/src/session/detector_cli.rs
@@ -108,7 +108,9 @@ impl SessionSource for CliSessionSource {
             Some(s) => s,
             None => {
                 let _ = child.kill();
-                // Still join the reader so it doesn't leak; kill closes the pipe.
+                // Reap to avoid leaving a zombie on Unix; then join the reader
+                // (kill closes the pipe so the reader exits naturally).
+                let _ = child.wait();
                 let _ = reader.join();
                 return Err(SessionDetectorError::Timeout(timeout.as_millis()));
             }

--- a/src-tauri/src/session/detector_cli.rs
+++ b/src-tauri/src/session/detector_cli.rs
@@ -15,6 +15,9 @@ use wait_timeout::ChildExt;
 struct CliAgent {
     pid: u32,
     cwd: PathBuf,
+    // `kind` was added alongside background-pinned sessions in CC 2.1.147.
+    // 2.1.145–146 emit `claude agents --json` without it; default to "interactive".
+    #[serde(default = "default_kind")]
     kind: String,
     #[serde(rename = "startedAt")]
     started_at: i64,
@@ -24,6 +27,10 @@ struct CliAgent {
     name: Option<String>,
     #[serde(default)]
     status: Option<String>,
+}
+
+fn default_kind() -> String {
+    "interactive".to_string()
 }
 
 pub struct CliSessionSource {
@@ -129,14 +136,49 @@ impl SessionSource for CliSessionSource {
         let agents: Vec<CliAgent> = serde_json::from_slice(&buf)
             .map_err(|e| SessionDetectorError::Parse(e.to_string()))?;
 
-        let sessions: Vec<DetectedSession> =
-            agents.into_iter().map(|a| self.map_agent_to_session(a)).collect();
+        // Filter out non-CLI entrypoints (e.g. sdk-ts from Zed/IDE integrations).
+        // `claude agents --json` lists every live agent including SDK-driven ones,
+        // but those don't write project JSONLs and aren't what c9watch monitors.
+        // The per-pid metadata at ~/.claude/sessions/<pid>.json carries `entrypoint`.
+        // If the file is missing or unreadable, keep the agent (older CC versions).
+        let sessions: Vec<DetectedSession> = agents
+            .into_iter()
+            .filter(|a| is_cli_entrypoint(a.pid))
+            .map(|a| self.map_agent_to_session(a))
+            .collect();
 
         Ok((sessions, DetectionDiagnostics::default()))
     }
 
     fn backend_name(&self) -> &'static str {
         "cli"
+    }
+}
+
+/// Returns true if the agent at this pid was launched as a `claude` CLI (not via
+/// the TypeScript/Python SDK). Reads `~/.claude/sessions/<pid>.json` and inspects
+/// the `entrypoint` field. Missing/unreadable file → keep (older CC builds didn't
+/// write this metadata; better to over-report than drop real CLIs).
+fn is_cli_entrypoint(pid: u32) -> bool {
+    match dirs::home_dir() {
+        Some(home) => is_cli_entrypoint_under(&home, pid),
+        None => true,
+    }
+}
+
+fn is_cli_entrypoint_under(home: &Path, pid: u32) -> bool {
+    let path = home.join(".claude").join("sessions").join(format!("{pid}.json"));
+    let raw = match std::fs::read_to_string(&path) {
+        Ok(s) => s,
+        Err(_) => return true,
+    };
+    let value: serde_json::Value = match serde_json::from_str(&raw) {
+        Ok(v) => v,
+        Err(_) => return true,
+    };
+    match value.get("entrypoint").and_then(|v| v.as_str()) {
+        Some(ep) => ep == "cli",
+        None => true,
     }
 }
 
@@ -256,6 +298,14 @@ mod tests {
     }
 
     #[test]
+    fn parse_cli_output_missing_kind_defaults_to_interactive() {
+        // CC 2.1.145–146 emit `claude agents --json` without the `kind` field.
+        let json = r#"[{"pid":1,"cwd":"/tmp","startedAt":1,"sessionId":"x"}]"#;
+        let agents: Vec<CliAgent> = serde_json::from_str(json).unwrap();
+        assert_eq!(agents[0].kind, "interactive");
+    }
+
+    #[test]
     fn parse_cli_output_empty_array() {
         let agents: Vec<CliAgent> = serde_json::from_str("[]").unwrap();
         assert!(agents.is_empty());
@@ -322,6 +372,59 @@ mod tests {
         let result = lookup_with_cache(home, &mut cache, &cwd, session_id);
         assert_eq!(result, proj_dir);
         assert_eq!(cache.len(), 1, "cache size unchanged on hit");
+    }
+
+    fn write_session_meta(home: &Path, pid: u32, entrypoint: Option<&str>) {
+        let dir = home.join(".claude").join("sessions");
+        std::fs::create_dir_all(&dir).unwrap();
+        let body = match entrypoint {
+            Some(ep) => format!(r#"{{"pid":{pid},"entrypoint":"{ep}"}}"#),
+            None => format!(r#"{{"pid":{pid}}}"#),
+        };
+        std::fs::write(dir.join(format!("{pid}.json")), body).unwrap();
+    }
+
+    #[test]
+    fn entrypoint_filter_keeps_cli() {
+        let tmp = tempfile::tempdir().unwrap();
+        write_session_meta(tmp.path(), 1, Some("cli"));
+        assert!(is_cli_entrypoint_under(tmp.path(), 1));
+    }
+
+    #[test]
+    fn entrypoint_filter_drops_sdk_ts() {
+        let tmp = tempfile::tempdir().unwrap();
+        write_session_meta(tmp.path(), 2, Some("sdk-ts"));
+        assert!(!is_cli_entrypoint_under(tmp.path(), 2));
+    }
+
+    #[test]
+    fn entrypoint_filter_drops_sdk_py() {
+        let tmp = tempfile::tempdir().unwrap();
+        write_session_meta(tmp.path(), 3, Some("sdk-py"));
+        assert!(!is_cli_entrypoint_under(tmp.path(), 3));
+    }
+
+    #[test]
+    fn entrypoint_filter_keeps_when_meta_missing() {
+        let tmp = tempfile::tempdir().unwrap();
+        assert!(is_cli_entrypoint_under(tmp.path(), 999));
+    }
+
+    #[test]
+    fn entrypoint_filter_keeps_when_field_missing() {
+        let tmp = tempfile::tempdir().unwrap();
+        write_session_meta(tmp.path(), 4, None);
+        assert!(is_cli_entrypoint_under(tmp.path(), 4));
+    }
+
+    #[test]
+    fn entrypoint_filter_keeps_when_meta_malformed() {
+        let tmp = tempfile::tempdir().unwrap();
+        let dir = tmp.path().join(".claude").join("sessions");
+        std::fs::create_dir_all(&dir).unwrap();
+        std::fs::write(dir.join("5.json"), "not json").unwrap();
+        assert!(is_cli_entrypoint_under(tmp.path(), 5));
     }
 
     #[test]

--- a/src-tauri/src/session/detector_cli.rs
+++ b/src-tauri/src/session/detector_cli.rs
@@ -1,0 +1,326 @@
+use super::detector::encode_path_for_matching;
+use super::source::{
+    CliActivity, DetectedSession, DetectionDiagnostics, SessionDetectorError, SessionKind,
+    SessionSource,
+};
+use serde::Deserialize;
+use std::collections::HashMap;
+use std::io::Read;
+use std::path::{Path, PathBuf};
+use std::process::{Command, Stdio};
+use std::time::Duration;
+use wait_timeout::ChildExt;
+
+#[derive(Deserialize, Debug)]
+struct CliAgent {
+    pid: u32,
+    cwd: PathBuf,
+    kind: String,
+    #[serde(rename = "startedAt")]
+    started_at: i64,
+    #[serde(rename = "sessionId")]
+    session_id: String,
+    #[serde(default)]
+    name: Option<String>,
+    #[serde(default)]
+    status: Option<String>,
+}
+
+pub struct CliSessionSource {
+    claude_bin: PathBuf,
+    path_cache: HashMap<String, PathBuf>,
+}
+
+impl CliSessionSource {
+    pub fn new() -> Self {
+        // Relies on PATH lookup at spawn time. We don't pull in `which` as a
+        // direct dep just for this — the probe already verified `claude` is on PATH.
+        Self {
+            claude_bin: PathBuf::from("claude"),
+            path_cache: HashMap::new(),
+        }
+    }
+
+    fn project_path_for_session(&mut self, cwd: &Path, session_id: &str) -> PathBuf {
+        let home = dirs::home_dir().unwrap_or_else(|| PathBuf::from("/"));
+        lookup_with_cache(&home, &mut self.path_cache, cwd, session_id)
+    }
+
+    fn map_agent_to_session(&mut self, a: CliAgent) -> DetectedSession {
+        let project_path = self.project_path_for_session(&a.cwd, &a.session_id);
+        DetectedSession {
+            pid: a.pid,
+            project_name: a
+                .cwd
+                .file_name()
+                .unwrap_or_default()
+                .to_string_lossy()
+                .into_owned(),
+            session_id: Some(a.session_id),
+            project_path,
+            kind: match a.kind.as_str() {
+                "interactive" => SessionKind::Interactive,
+                "background" => SessionKind::Background,
+                _ => SessionKind::Unknown,
+            },
+            started_at_ms: Some(a.started_at),
+            official_name: a.name,
+            cli_activity: match a.status.as_deref() {
+                Some("busy") => Some(CliActivity::Busy),
+                Some("idle") => Some(CliActivity::Idle),
+                _ => None,
+            },
+            cwd: a.cwd,
+        }
+    }
+}
+
+impl SessionSource for CliSessionSource {
+    fn detect(
+        &mut self,
+    ) -> Result<(Vec<DetectedSession>, DetectionDiagnostics), SessionDetectorError> {
+        let mut child = Command::new(&self.claude_bin)
+            .args(["agents", "--json"])
+            .stdout(Stdio::piped())
+            .stderr(Stdio::null())
+            .spawn()
+            .map_err(|e| SessionDetectorError::CliFailed(format!("spawn: {e}")))?;
+
+        let timeout = Duration::from_secs(2);
+        let status = match child
+            .wait_timeout(timeout)
+            .map_err(|e| SessionDetectorError::CliFailed(format!("wait: {e}")))?
+        {
+            Some(s) => s,
+            None => {
+                let _ = child.kill();
+                return Err(SessionDetectorError::Timeout(timeout.as_millis()));
+            }
+        };
+
+        if !status.success() {
+            return Err(SessionDetectorError::CliFailed(format!(
+                "exit code {status:?}"
+            )));
+        }
+
+        let mut buf = Vec::new();
+        if let Some(mut stdout) = child.stdout.take() {
+            stdout
+                .read_to_end(&mut buf)
+                .map_err(|e| SessionDetectorError::CliFailed(format!("read: {e}")))?;
+        }
+
+        let agents: Vec<CliAgent> = serde_json::from_slice(&buf)
+            .map_err(|e| SessionDetectorError::Parse(e.to_string()))?;
+
+        let sessions: Vec<DetectedSession> =
+            agents.into_iter().map(|a| self.map_agent_to_session(a)).collect();
+
+        Ok((sessions, DetectionDiagnostics::default()))
+    }
+
+    fn backend_name(&self) -> &'static str {
+        "cli"
+    }
+}
+
+/// Stateless resolver used by both production code (with real `home_dir()`) and
+/// tests (with a tempdir as `home`). Encoded-cwd fast-path then directory scan.
+fn resolve_project_path_under(home: &Path, cwd: &Path, session_id: &str) -> Option<PathBuf> {
+    let projects_root = home.join(".claude").join("projects");
+    let encoded = encode_path_for_matching(&cwd.to_string_lossy());
+    let fast = projects_root.join(&encoded);
+    if fast.join(format!("{session_id}.jsonl")).is_file() {
+        return Some(fast);
+    }
+    let entries = std::fs::read_dir(&projects_root).ok()?;
+    for entry in entries.flatten() {
+        let p = entry.path();
+        if p.is_dir() && p.join(format!("{session_id}.jsonl")).is_file() {
+            return Some(p);
+        }
+    }
+    None
+}
+
+fn fallback_path_under(home: &Path, cwd: &Path) -> PathBuf {
+    let encoded = encode_path_for_matching(&cwd.to_string_lossy());
+    home.join(".claude").join("projects").join(encoded)
+}
+
+/// Cache-aware resolver. Verifies stale cache entries (jsonl gone) and re-resolves.
+/// Falls back to `fallback_path_under` when resolution fails so enrichment has SOMETHING
+/// to try (and skip cleanly when JSONL never appears).
+fn lookup_with_cache(
+    home: &Path,
+    cache: &mut HashMap<String, PathBuf>,
+    cwd: &Path,
+    session_id: &str,
+) -> PathBuf {
+    if let Some(cached) = cache.get(session_id).cloned() {
+        if cached.join(format!("{session_id}.jsonl")).is_file() {
+            return cached;
+        }
+        cache.remove(session_id);
+    }
+    if let Some(resolved) = resolve_project_path_under(home, cwd, session_id) {
+        cache.insert(session_id.to_string(), resolved.clone());
+        return resolved;
+    }
+    fallback_path_under(home, cwd)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn full_schema_json() -> &'static str {
+        r#"[
+          {"pid":1,"cwd":"/tmp/a","kind":"interactive","startedAt":100,"sessionId":"sid-a","status":"busy"},
+          {"pid":2,"cwd":"/tmp/b","kind":"background","startedAt":200,"sessionId":"sid-b","name":"my-bg","status":"idle"}
+        ]"#
+    }
+
+    #[test]
+    fn parse_cli_output_full_schema() {
+        let agents: Vec<CliAgent> = serde_json::from_str(full_schema_json()).unwrap();
+        assert_eq!(agents.len(), 2);
+        assert_eq!(agents[0].pid, 1);
+        assert_eq!(agents[0].session_id, "sid-a");
+        assert_eq!(agents[1].name.as_deref(), Some("my-bg"));
+    }
+
+    #[test]
+    fn parse_cli_output_missing_status_yields_none_in_mapping() {
+        let json = r#"[{"pid":1,"cwd":"/tmp","kind":"interactive","startedAt":1,"sessionId":"x"}]"#;
+        let agents: Vec<CliAgent> = serde_json::from_str(json).unwrap();
+        assert!(agents[0].status.is_none());
+        let mapped_activity = match agents[0].status.as_deref() {
+            Some("busy") => Some(CliActivity::Busy),
+            Some("idle") => Some(CliActivity::Idle),
+            _ => None,
+        };
+        assert!(mapped_activity.is_none());
+    }
+
+    #[test]
+    fn parse_cli_output_busy_yields_some_busy() {
+        let json = r#"[{"pid":1,"cwd":"/tmp","kind":"interactive","startedAt":1,"sessionId":"x","status":"busy"}]"#;
+        let agents: Vec<CliAgent> = serde_json::from_str(json).unwrap();
+        let mapped = match agents[0].status.as_deref() {
+            Some("busy") => Some(CliActivity::Busy),
+            Some("idle") => Some(CliActivity::Idle),
+            _ => None,
+        };
+        assert_eq!(mapped, Some(CliActivity::Busy));
+    }
+
+    #[test]
+    fn parse_cli_output_unknown_status_yields_none() {
+        let json = r#"[{"pid":1,"cwd":"/tmp","kind":"interactive","startedAt":1,"sessionId":"x","status":"on_fire"}]"#;
+        let agents: Vec<CliAgent> = serde_json::from_str(json).unwrap();
+        let mapped = match agents[0].status.as_deref() {
+            Some("busy") => Some(CliActivity::Busy),
+            Some("idle") => Some(CliActivity::Idle),
+            _ => None,
+        };
+        assert!(mapped.is_none());
+    }
+
+    #[test]
+    fn parse_cli_output_unknown_kind_yields_unknown() {
+        let json = r#"[{"pid":1,"cwd":"/tmp","kind":"chimera","startedAt":1,"sessionId":"x"}]"#;
+        let agents: Vec<CliAgent> = serde_json::from_str(json).unwrap();
+        let mapped_kind = match agents[0].kind.as_str() {
+            "interactive" => SessionKind::Interactive,
+            "background" => SessionKind::Background,
+            _ => SessionKind::Unknown,
+        };
+        assert_eq!(mapped_kind, SessionKind::Unknown);
+    }
+
+    #[test]
+    fn parse_cli_output_empty_array() {
+        let agents: Vec<CliAgent> = serde_json::from_str("[]").unwrap();
+        assert!(agents.is_empty());
+    }
+
+    #[test]
+    fn parse_cli_output_malformed_returns_err() {
+        let result: Result<Vec<CliAgent>, _> = serde_json::from_str("not json");
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn resolve_project_path_finds_via_fast_path() {
+        let tmp = tempfile::tempdir().unwrap();
+        let home = tmp.path();
+        let cwd = PathBuf::from("/Users/test/proj");
+        let session_id = "sess-fast";
+        let encoded = encode_path_for_matching(&cwd.to_string_lossy());
+        let proj_dir = home.join(".claude").join("projects").join(&encoded);
+        std::fs::create_dir_all(&proj_dir).unwrap();
+        std::fs::write(proj_dir.join(format!("{session_id}.jsonl")), b"").unwrap();
+
+        let result = resolve_project_path_under(home, &cwd, session_id);
+        assert_eq!(result.as_deref(), Some(proj_dir.as_path()));
+    }
+
+    #[test]
+    fn resolve_project_path_falls_back_to_scan_when_encoding_mismatches() {
+        let tmp = tempfile::tempdir().unwrap();
+        let home = tmp.path();
+        let cwd = PathBuf::from("/Users/test/proj");
+        let session_id = "sess-scan";
+        let wrong_dir = home.join(".claude").join("projects").join("totally-different-dir");
+        std::fs::create_dir_all(&wrong_dir).unwrap();
+        std::fs::write(wrong_dir.join(format!("{session_id}.jsonl")), b"").unwrap();
+
+        let result = resolve_project_path_under(home, &cwd, session_id);
+        assert_eq!(result.as_deref(), Some(wrong_dir.as_path()));
+    }
+
+    #[test]
+    fn resolve_project_path_returns_none_when_jsonl_missing_everywhere() {
+        let tmp = tempfile::tempdir().unwrap();
+        let home = tmp.path();
+        let cwd = PathBuf::from("/Users/test/proj");
+        let result = resolve_project_path_under(home, &cwd, "absent");
+        assert!(result.is_none());
+    }
+
+    #[test]
+    fn path_cache_returns_cached_value_when_jsonl_still_exists() {
+        let tmp = tempfile::tempdir().unwrap();
+        let home = tmp.path();
+        let cwd = PathBuf::from("/Users/test/proj");
+        let session_id = "cache-hit";
+        let encoded = encode_path_for_matching(&cwd.to_string_lossy());
+        let proj_dir = home.join(".claude").join("projects").join(&encoded);
+        std::fs::create_dir_all(&proj_dir).unwrap();
+        std::fs::write(proj_dir.join(format!("{session_id}.jsonl")), b"").unwrap();
+
+        let mut cache: HashMap<String, PathBuf> = HashMap::new();
+        cache.insert(session_id.to_string(), proj_dir.clone());
+
+        let result = lookup_with_cache(home, &mut cache, &cwd, session_id);
+        assert_eq!(result, proj_dir);
+        assert_eq!(cache.len(), 1, "cache size unchanged on hit");
+    }
+
+    #[test]
+    fn path_cache_evicts_stale_entry_when_jsonl_gone() {
+        let tmp = tempfile::tempdir().unwrap();
+        let home = tmp.path();
+        let cwd = PathBuf::from("/Users/test/proj");
+        let session_id = "stale";
+        let stale_dir = home.join(".claude").join("projects").join("old-location");
+        std::fs::create_dir_all(&stale_dir).unwrap();
+        let mut cache: HashMap<String, PathBuf> = HashMap::new();
+        cache.insert(session_id.to_string(), stale_dir.clone());
+
+        let _result = lookup_with_cache(home, &mut cache, &cwd, session_id);
+        assert!(!cache.contains_key(session_id));
+    }
+}

--- a/src-tauri/src/session/enrichment.rs
+++ b/src-tauri/src/session/enrichment.rs
@@ -189,13 +189,21 @@ pub fn enrich_detected_sessions(
                 // Count messages in the file
                 let message_count = count_messages_in_jsonl(&session_file_path);
 
-                // Get file modification time
+                // Get file modification time. Fall back to started_at_ms for
+                // CLI-sourced placeholder sessions (no JSONL yet) so the frontend
+                // doesn't choke on `new Date("").getTime()` → NaN when sorting.
                 let modified = std::fs::metadata(&session_file_path)
                     .and_then(|m| m.modified())
                     .ok()
                     .map(|t| {
                         let datetime: DateTime<Utc> = t.into();
                         datetime.to_rfc3339()
+                    })
+                    .or_else(|| {
+                        detected.started_at_ms.and_then(|ms| {
+                            DateTime::<Utc>::from_timestamp_millis(ms)
+                                .map(|dt| dt.to_rfc3339())
+                        })
                     })
                     .unwrap_or_default();
 
@@ -540,5 +548,56 @@ mod merge_tests {
         assert_eq!(merged, SessionStatus::Working);
         let merged = merge_cli_activity(SessionStatus::WaitingForInput, None, true);
         assert_eq!(merged, SessionStatus::WaitingForInput);
+    }
+}
+
+#[cfg(test)]
+mod placeholder_tests {
+    use super::*;
+    use crate::session::source::{DetectedSession, DetectionDiagnostics, SessionKind};
+    use std::path::PathBuf;
+
+    #[test]
+    fn cli_placeholder_session_has_valid_modified_from_started_at_ms() {
+        // CLI-sourced session with no JSONL → must still produce parseable RFC3339
+        // `modified` so `new Date(modified).getTime()` doesn't yield NaN on the
+        // frontend (which would scramble sort/group ordering).
+        let tmp = tempfile::tempdir().unwrap();
+        let detected = DetectedSession {
+            pid: 12345,
+            cwd: PathBuf::from("/tmp/nonexistent"),
+            project_path: tmp.path().join("never-existed"),
+            session_id: Some("11111111-2222-3333-4444-555555555555".to_string()),
+            project_name: "nonexistent".to_string(),
+            kind: SessionKind::Interactive,
+            started_at_ms: Some(1_700_000_000_000),
+            official_name: None,
+            cli_activity: None,
+        };
+        let (sessions, _) =
+            enrich_detected_sessions(vec![detected], DetectionDiagnostics::default()).unwrap();
+        assert_eq!(sessions.len(), 1, "CLI placeholder should be emitted");
+        let s = &sessions[0];
+        assert!(!s.modified.is_empty(), "modified must not be empty");
+        let parsed = DateTime::parse_from_rfc3339(&s.modified);
+        assert!(parsed.is_ok(), "modified must parse as RFC3339, got: {}", s.modified);
+        assert_eq!(s.started_at_ms, Some(1_700_000_000_000));
+    }
+
+    #[test]
+    fn legacy_session_without_jsonl_still_skipped() {
+        // Legacy backend leaves started_at_ms = None. Without JSONL, no message
+        // count, no real data — keep dropping these to avoid the legacy ghost-pid bug.
+        let tmp = tempfile::tempdir().unwrap();
+        let detected = DetectedSession::with_legacy_defaults(
+            42,
+            PathBuf::from("/tmp/legacy"),
+            tmp.path().join("legacy-empty"),
+            Some("aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee".to_string()),
+            "legacy".to_string(),
+        );
+        let (sessions, _) =
+            enrich_detected_sessions(vec![detected], DetectionDiagnostics::default()).unwrap();
+        assert!(sessions.is_empty(), "legacy empty-JSONL session must be skipped");
     }
 }

--- a/src-tauri/src/session/enrichment.rs
+++ b/src-tauri/src/session/enrichment.rs
@@ -1,6 +1,7 @@
+use crate::session::source::{CliActivity, DetectedSession, DetectionDiagnostics, SessionSource};
 use crate::session::{
     determine_status, get_pending_tool_input, get_pending_tool_name, parse_last_n_entries,
-    parse_sessions_index, LegacySessionSource, SessionStatus,
+    parse_sessions_index, SessionStatus,
 };
 use chrono::{DateTime, Utc};
 use serde::Serialize;
@@ -34,6 +35,14 @@ pub struct Session {
     /// Populated in polling.rs by overlay from `~/.claude/c9watch/workers/*/meta.json`.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub worker_of: Option<String>,
+    /// User-set name from `claude agents` (Ctrl+T background-pinned sessions).
+    /// Only populated by the CLI backend; legacy backend leaves this None.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub official_name: Option<String>,
+    /// Session start time in ms since epoch (from `claude agents --json`).
+    /// Only populated by the CLI backend; legacy backend leaves this None.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub started_at_ms: Option<i64>,
 }
 
 /// Cache for native custom titles, keyed by file path.
@@ -66,22 +75,51 @@ pub(crate) fn get_cached_native_title(path: &Path) -> Option<String> {
     }
 }
 
-/// Detect sessions and enrich them with status and conversation data
-pub fn detect_and_enrich_sessions(
-) -> Result<(Vec<Session>, crate::session::DetectionDiagnostics), String> {
-    let mut detector =
-        LegacySessionSource::new().map_err(|e| format!("Failed to create session detector: {}", e))?;
-    detect_and_enrich_sessions_with_detector(&mut detector)
+/// Combines the existing heuristic-based SessionStatus with the CLI activity signal.
+///
+/// CLI activity NEVER overrides NeedsAttention or Connecting — those stay driven by
+/// JSONL content + PermissionChecker. It only refines Working vs WaitingForInput.
+pub fn merge_cli_activity(
+    heuristic: SessionStatus,
+    cli: Option<CliActivity>,
+    has_pending_tool: bool,
+) -> SessionStatus {
+    match (heuristic, cli) {
+        (SessionStatus::NeedsAttention, _) => SessionStatus::NeedsAttention,
+        (SessionStatus::Connecting, _) => SessionStatus::Connecting,
+        (heuristic, None) => heuristic,
+        (SessionStatus::WaitingForInput, Some(CliActivity::Busy)) => SessionStatus::Working,
+        (SessionStatus::Working, Some(CliActivity::Idle)) if !has_pending_tool => {
+            SessionStatus::WaitingForInput
+        }
+        (heuristic, _) => heuristic,
+    }
 }
 
-/// Detect sessions using an existing detector (avoids recreating System each call)
-pub fn detect_and_enrich_sessions_with_detector(
-    detector: &mut LegacySessionSource,
-) -> Result<(Vec<Session>, crate::session::DetectionDiagnostics), String> {
-    let (detected_sessions, diagnostics) = detector
-        .detect_sessions()
-        .map_err(|e| format!("Failed to detect sessions: {}", e))?;
+/// Detect sessions and enrich them with status and conversation data.
+/// Uses the configured backend (CLI or Legacy) via the factory.
+pub fn detect_and_enrich_sessions(
+) -> Result<(Vec<Session>, DetectionDiagnostics), String> {
+    let mut source = crate::session::create_session_source();
+    detect_and_enrich_sessions_with_source(source.as_mut())
+}
 
+/// Detect sessions using a SessionSource trait object and enrich them.
+pub fn detect_and_enrich_sessions_with_source(
+    source: &mut dyn SessionSource,
+) -> Result<(Vec<Session>, DetectionDiagnostics), String> {
+    let (detected, diag) = source
+        .detect()
+        .map_err(|e| format!("Failed to detect sessions: {}", e))?;
+    enrich_detected_sessions(detected, diag)
+}
+
+/// Enrichment-only: takes already-detected sessions and adds JSONL-derived fields.
+/// Split out so callers can drop a lock before doing slow JSONL parsing.
+pub fn enrich_detected_sessions(
+    detected_sessions: Vec<DetectedSession>,
+    diagnostics: DetectionDiagnostics,
+) -> Result<(Vec<Session>, DetectionDiagnostics), String> {
     let custom_names = crate::session::CustomNames::load();
     let custom_titles = crate::session::CustomTitles::load();
     let mut sessions = Vec::new();
@@ -172,7 +210,9 @@ pub fn detect_and_enrich_sessions_with_detector(
             }
         };
 
-        let status = if entries.is_empty() {
+        let pending_tool_name = get_pending_tool_name(&entries);
+
+        let heuristic_status = if entries.is_empty() {
             SessionStatus::Connecting
         } else {
             let raw_status = determine_status(&entries);
@@ -185,9 +225,13 @@ pub fn detect_and_enrich_sessions_with_detector(
                 raw_status
             }
         };
+        let status = merge_cli_activity(
+            heuristic_status,
+            detected.cli_activity,
+            pending_tool_name.is_some(),
+        );
 
         let latest_message = get_latest_message_from_entries(&entries);
-        let pending_tool_name = get_pending_tool_name(&entries);
         let pending_tool_input = get_pending_tool_input(&entries);
 
         // Skip empty sessions (0 messages)
@@ -223,6 +267,8 @@ pub fn detect_and_enrich_sessions_with_detector(
             pending_tool_name,
             pending_tool_input,
             worker_of: None,
+            official_name: detected.official_name.clone(),
+            started_at_ms: detected.started_at_ms,
         });
     }
 
@@ -424,5 +470,65 @@ mod tests {
     #[test]
     fn test_truncate_string_utf8_emoji() {
         assert_eq!(truncate_string("Hello 👋 World", 7), "Hello 👋...");
+    }
+}
+
+#[cfg(test)]
+mod merge_tests {
+    use super::*;
+    use crate::session::source::CliActivity;
+    use crate::session::SessionStatus;
+
+    #[test]
+    fn merge_preserves_needs_attention_when_busy() {
+        let merged =
+            merge_cli_activity(SessionStatus::NeedsAttention, Some(CliActivity::Busy), false);
+        assert_eq!(merged, SessionStatus::NeedsAttention);
+    }
+
+    #[test]
+    fn merge_preserves_needs_attention_when_idle() {
+        let merged =
+            merge_cli_activity(SessionStatus::NeedsAttention, Some(CliActivity::Idle), false);
+        assert_eq!(merged, SessionStatus::NeedsAttention);
+    }
+
+    #[test]
+    fn merge_preserves_connecting() {
+        let merged =
+            merge_cli_activity(SessionStatus::Connecting, Some(CliActivity::Busy), false);
+        assert_eq!(merged, SessionStatus::Connecting);
+    }
+
+    #[test]
+    fn merge_busy_promotes_waiting_to_working() {
+        let merged = merge_cli_activity(
+            SessionStatus::WaitingForInput,
+            Some(CliActivity::Busy),
+            false,
+        );
+        assert_eq!(merged, SessionStatus::Working);
+    }
+
+    #[test]
+    fn merge_idle_downgrades_working_without_pending_tool() {
+        let merged =
+            merge_cli_activity(SessionStatus::Working, Some(CliActivity::Idle), false);
+        assert_eq!(merged, SessionStatus::WaitingForInput);
+    }
+
+    #[test]
+    fn merge_idle_keeps_working_when_pending_tool() {
+        let merged =
+            merge_cli_activity(SessionStatus::Working, Some(CliActivity::Idle), true);
+        assert_eq!(merged, SessionStatus::Working);
+    }
+
+    #[test]
+    fn merge_none_returns_heuristic_unchanged() {
+        let merged = merge_cli_activity(SessionStatus::Working, None, false);
+        assert_eq!(merged, SessionStatus::Working);
+        let merged = merge_cli_activity(SessionStatus::WaitingForInput, None, true);
+        assert_eq!(merged, SessionStatus::WaitingForInput);
     }
 }

--- a/src-tauri/src/session/enrichment.rs
+++ b/src-tauri/src/session/enrichment.rs
@@ -1,6 +1,6 @@
 use crate::session::{
     determine_status, get_pending_tool_input, get_pending_tool_name, parse_last_n_entries,
-    parse_sessions_index, SessionDetector, SessionStatus,
+    parse_sessions_index, LegacySessionSource, SessionStatus,
 };
 use chrono::{DateTime, Utc};
 use serde::Serialize;
@@ -70,13 +70,13 @@ pub(crate) fn get_cached_native_title(path: &Path) -> Option<String> {
 pub fn detect_and_enrich_sessions(
 ) -> Result<(Vec<Session>, crate::session::DetectionDiagnostics), String> {
     let mut detector =
-        SessionDetector::new().map_err(|e| format!("Failed to create session detector: {}", e))?;
+        LegacySessionSource::new().map_err(|e| format!("Failed to create session detector: {}", e))?;
     detect_and_enrich_sessions_with_detector(&mut detector)
 }
 
 /// Detect sessions using an existing detector (avoids recreating System each call)
 pub fn detect_and_enrich_sessions_with_detector(
-    detector: &mut SessionDetector,
+    detector: &mut LegacySessionSource,
 ) -> Result<(Vec<Session>, crate::session::DetectionDiagnostics), String> {
     let (detected_sessions, diagnostics) = detector
         .detect_sessions()

--- a/src-tauri/src/session/enrichment.rs
+++ b/src-tauri/src/session/enrichment.rs
@@ -178,7 +178,13 @@ pub fn enrich_detected_sessions(
 
                 // Try to get first prompt from JSONL file
                 let first_prompt = get_first_prompt_from_jsonl(&session_file_path)
-                    .unwrap_or_else(|| "(Active session)".to_string());
+                    .unwrap_or_else(|| {
+                        if detected.started_at_ms.is_some() {
+                            "(No conversation yet)".to_string()
+                        } else {
+                            "(Active session)".to_string()
+                        }
+                    });
 
                 // Count messages in the file
                 let message_count = count_messages_in_jsonl(&session_file_path);
@@ -234,8 +240,12 @@ pub fn enrich_detected_sessions(
         let latest_message = get_latest_message_from_entries(&entries);
         let pending_tool_input = get_pending_tool_input(&entries);
 
-        // Skip empty sessions (0 messages)
-        if message_count == 0 {
+        // Skip empty sessions (0 messages) UNLESS CLI-sourced — `claude agents --json`
+        // confirms the agent is live even when no project JSONL exists (SDK-based
+        // interactive sessions never write to ~/.claude/projects/). Render a
+        // placeholder card so the dashboard count matches `claude agents --json`.
+        let cli_sourced = detected.started_at_ms.is_some();
+        if message_count == 0 && !cli_sourced {
             continue;
         }
 

--- a/src-tauri/src/session/mod.rs
+++ b/src-tauri/src/session/mod.rs
@@ -94,7 +94,10 @@ fn parse_semver(s: &str) -> Option<(u32, u32, u32)> {
 }
 
 fn semver_supports_agents_json(v: (u32, u32, u32)) -> bool {
-    v >= (2, 1, 150)
+    // `claude agents --json` shipped in 2.1.145. 2.1.145–146 omit the `kind`
+    // field (background-pinned sessions came in 2.1.147); CliAgent::kind has
+    // a default so the older schema still parses.
+    v >= (2, 1, 145)
 }
 
 pub fn probe_claude_supports_agents_json() -> bool {
@@ -226,6 +229,11 @@ mod factory_tests {
     }
 
     #[test]
+    fn version_gate_accepts_2_1_145() {
+        assert!(semver_supports_agents_json((2, 1, 145)));
+    }
+
+    #[test]
     fn version_gate_accepts_2_1_150() {
         assert!(semver_supports_agents_json((2, 1, 150)));
     }
@@ -236,8 +244,8 @@ mod factory_tests {
     }
 
     #[test]
-    fn version_gate_rejects_2_1_149() {
-        assert!(!semver_supports_agents_json((2, 1, 149)));
+    fn version_gate_rejects_2_1_144() {
+        assert!(!semver_supports_agents_json((2, 1, 144)));
     }
 
     #[test]

--- a/src-tauri/src/session/mod.rs
+++ b/src-tauri/src/session/mod.rs
@@ -41,3 +41,170 @@ pub use subagents::{
     active_subagents_for_path, all_subagents_by_session, get_subagent_transcript,
     SubagentInfo, SubagentStatus, SubagentTranscript,
 };
+
+use std::process::Command;
+use std::time::Duration;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum BackendMode {
+    Auto,
+    ForceCli,
+    ForceLegacy,
+}
+
+pub fn mode_from_env() -> BackendMode {
+    parse_mode(std::env::var("C9WATCH_DETECTOR_BACKEND").ok().as_deref())
+}
+
+fn parse_mode(value: Option<&str>) -> BackendMode {
+    match value {
+        Some("cli") => BackendMode::ForceCli,
+        Some("legacy") => BackendMode::ForceLegacy,
+        _ => BackendMode::Auto,
+    }
+}
+
+fn parse_semver(s: &str) -> Option<(u32, u32, u32)> {
+    let bytes = s.as_bytes();
+    let mut i = 0;
+    while i < bytes.len() {
+        if bytes[i].is_ascii_digit() {
+            let start = i;
+            while i < bytes.len() && (bytes[i].is_ascii_digit() || bytes[i] == b'.') {
+                i += 1;
+            }
+            let candidate = &s[start..i];
+            let parts: Vec<&str> = candidate.split('.').collect();
+            if parts.len() == 3 {
+                if let (Ok(maj), Ok(min), Ok(pat)) =
+                    (parts[0].parse(), parts[1].parse(), parts[2].parse())
+                {
+                    return Some((maj, min, pat));
+                }
+            }
+        } else {
+            i += 1;
+        }
+    }
+    None
+}
+
+fn semver_supports_agents_json(v: (u32, u32, u32)) -> bool {
+    v >= (2, 1, 150)
+}
+
+pub fn probe_claude_supports_agents_json() -> bool {
+    if !probe_version_supports() {
+        return false;
+    }
+    probe_command_works()
+}
+
+fn probe_version_supports() -> bool {
+    let Ok(out) = Command::new("claude").args(["--version"]).output() else {
+        return false;
+    };
+    if !out.status.success() {
+        return false;
+    }
+    let s = String::from_utf8_lossy(&out.stdout);
+    parse_semver(&s)
+        .map(semver_supports_agents_json)
+        .unwrap_or(false)
+}
+
+fn probe_command_works() -> bool {
+    use std::process::Stdio;
+    use wait_timeout::ChildExt;
+    let Ok(mut child) = Command::new("claude")
+        .args(["agents", "--json"])
+        .stdout(Stdio::piped())
+        .stderr(Stdio::null())
+        .spawn()
+    else {
+        return false;
+    };
+    match child.wait_timeout(Duration::from_secs(3)) {
+        Ok(Some(status)) if status.success() => {
+            let mut buf = Vec::new();
+            if let Some(mut stdout) = child.stdout.take() {
+                let _ = std::io::Read::read_to_end(&mut stdout, &mut buf);
+            }
+            serde_json::from_slice::<Vec<serde_json::Value>>(&buf).is_ok()
+        }
+        _ => {
+            let _ = child.kill();
+            false
+        }
+    }
+}
+
+pub fn create_session_source() -> Box<dyn SessionSource> {
+    use crate::session::detector::LegacySessionSource;
+    // CliSessionSource lands in Task 5; until then both auto-success and force-cli
+    // paths fall back to legacy. The match arms are kept distinct so Task 5 only
+    // needs to swap the constructor.
+    match mode_from_env() {
+        BackendMode::ForceCli => {
+            // TODO(Task 5): return Box::new(CliSessionSource::new())
+            Box::new(LegacySessionSource::new().expect("legacy ctor"))
+        }
+        BackendMode::ForceLegacy => Box::new(LegacySessionSource::new().expect("legacy ctor")),
+        BackendMode::Auto => {
+            if probe_claude_supports_agents_json() {
+                // TODO(Task 5): return Box::new(CliSessionSource::new())
+                Box::new(LegacySessionSource::new().expect("legacy ctor"))
+            } else {
+                Box::new(LegacySessionSource::new().expect("legacy ctor"))
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod factory_tests {
+    use super::*;
+
+    #[test]
+    fn parse_semver_extracts_triple_from_cc_output() {
+        assert_eq!(parse_semver("2.1.150 (Claude Code)\n"), Some((2, 1, 150)));
+    }
+
+    #[test]
+    fn parse_semver_handles_no_version_line() {
+        assert_eq!(parse_semver("not a version string"), None);
+    }
+
+    #[test]
+    fn parse_semver_handles_extra_text() {
+        assert_eq!(parse_semver("Claude Code 2.2.0 — build abc"), Some((2, 2, 0)));
+    }
+
+    #[test]
+    fn version_gate_accepts_2_1_150() {
+        assert!(semver_supports_agents_json((2, 1, 150)));
+    }
+
+    #[test]
+    fn version_gate_accepts_2_2_0() {
+        assert!(semver_supports_agents_json((2, 2, 0)));
+    }
+
+    #[test]
+    fn version_gate_rejects_2_1_149() {
+        assert!(!semver_supports_agents_json((2, 1, 149)));
+    }
+
+    #[test]
+    fn mode_from_env_defaults_to_auto() {
+        assert_eq!(parse_mode(None), BackendMode::Auto);
+        assert_eq!(parse_mode(Some("garbage")), BackendMode::Auto);
+        assert_eq!(parse_mode(Some("auto")), BackendMode::Auto);
+    }
+
+    #[test]
+    fn mode_from_env_recognizes_cli_and_legacy() {
+        assert_eq!(parse_mode(Some("cli")), BackendMode::ForceCli);
+        assert_eq!(parse_mode(Some("legacy")), BackendMode::ForceLegacy);
+    }
+}

--- a/src-tauri/src/session/mod.rs
+++ b/src-tauri/src/session/mod.rs
@@ -7,6 +7,8 @@ pub mod status;
 
 pub use custom_names::{CustomNames, CustomTitles};
 pub use detector::LegacySessionSource;
+pub mod detector_cli;
+pub use detector_cli::CliSessionSource;
 pub use source::{CliActivity, DetectedSession, DetectionDiagnostics, SessionKind, SessionSource};
 pub use parser::{
     extract_messages, parse_all_entries, parse_last_n_entries, parse_sessions_index, ImageBlock,
@@ -141,19 +143,13 @@ fn probe_command_works() -> bool {
 
 pub fn create_session_source() -> Box<dyn SessionSource> {
     use crate::session::detector::LegacySessionSource;
-    // CliSessionSource lands in Task 5; until then both auto-success and force-cli
-    // paths fall back to legacy. The match arms are kept distinct so Task 5 only
-    // needs to swap the constructor.
+    use crate::session::detector_cli::CliSessionSource;
     match mode_from_env() {
-        BackendMode::ForceCli => {
-            // TODO(Task 5): return Box::new(CliSessionSource::new())
-            Box::new(LegacySessionSource::new().expect("legacy ctor"))
-        }
+        BackendMode::ForceCli => Box::new(CliSessionSource::new()),
         BackendMode::ForceLegacy => Box::new(LegacySessionSource::new().expect("legacy ctor")),
         BackendMode::Auto => {
             if probe_claude_supports_agents_json() {
-                // TODO(Task 5): return Box::new(CliSessionSource::new())
-                Box::new(LegacySessionSource::new().expect("legacy ctor"))
+                Box::new(CliSessionSource::new())
             } else {
                 Box::new(LegacySessionSource::new().expect("legacy ctor"))
             }

--- a/src-tauri/src/session/mod.rs
+++ b/src-tauri/src/session/mod.rs
@@ -105,16 +105,45 @@ pub fn probe_claude_supports_agents_json() -> bool {
 }
 
 fn probe_version_supports() -> bool {
-    let Ok(out) = Command::new("claude").args(["--version"]).output() else {
+    use std::process::Stdio;
+    use wait_timeout::ChildExt;
+    let Ok(mut child) = Command::new("claude")
+        .args(["--version"])
+        .stdout(Stdio::piped())
+        .stderr(Stdio::null())
+        .spawn()
+    else {
         return false;
     };
-    if !out.status.success() {
-        return false;
+    // Drain stdout on a bg thread to avoid pipe deadlock (same pattern as
+    // detector_cli::detect). --version output is tiny, but the cost is trivial.
+    let stdout = match child.stdout.take() {
+        Some(s) => s,
+        None => return false,
+    };
+    let reader = std::thread::spawn(move || {
+        let mut stdout = stdout;
+        let mut buf = Vec::new();
+        let _ = std::io::Read::read_to_end(&mut stdout, &mut buf);
+        buf
+    });
+    match child.wait_timeout(Duration::from_secs(2)) {
+        Ok(Some(status)) if status.success() => {
+            let buf = match reader.join() {
+                Ok(b) => b,
+                Err(_) => return false,
+            };
+            let s = String::from_utf8_lossy(&buf);
+            parse_semver(&s)
+                .map(semver_supports_agents_json)
+                .unwrap_or(false)
+        }
+        _ => {
+            let _ = child.kill();
+            let _ = reader.join();
+            false
+        }
     }
-    let s = String::from_utf8_lossy(&out.stdout);
-    parse_semver(&s)
-        .map(semver_supports_agents_json)
-        .unwrap_or(false)
 }
 
 fn probe_command_works() -> bool {

--- a/src-tauri/src/session/mod.rs
+++ b/src-tauri/src/session/mod.rs
@@ -140,6 +140,8 @@ fn probe_version_supports() -> bool {
         }
         _ => {
             let _ = child.kill();
+            // Reap to avoid leaving a zombie on Unix.
+            let _ = child.wait();
             let _ = reader.join();
             false
         }
@@ -157,16 +159,32 @@ fn probe_command_works() -> bool {
     else {
         return false;
     };
+    // Drain stdout on a bg thread to avoid pipe-buffer deadlock when the child
+    // writes more than the OS pipe buffer (typically 64KB) — without draining
+    // concurrently, the child blocks on write and wait_timeout falsely fires.
+    let stdout = match child.stdout.take() {
+        Some(s) => s,
+        None => return false,
+    };
+    let reader = std::thread::spawn(move || {
+        let mut stdout = stdout;
+        let mut buf = Vec::new();
+        let _ = std::io::Read::read_to_end(&mut stdout, &mut buf);
+        buf
+    });
     match child.wait_timeout(Duration::from_secs(3)) {
         Ok(Some(status)) if status.success() => {
-            let mut buf = Vec::new();
-            if let Some(mut stdout) = child.stdout.take() {
-                let _ = std::io::Read::read_to_end(&mut stdout, &mut buf);
-            }
+            let buf = match reader.join() {
+                Ok(b) => b,
+                Err(_) => return false,
+            };
             serde_json::from_slice::<Vec<serde_json::Value>>(&buf).is_ok()
         }
         _ => {
             let _ = child.kill();
+            // Reap to avoid leaving a zombie on Unix.
+            let _ = child.wait();
+            let _ = reader.join();
             false
         }
     }

--- a/src-tauri/src/session/mod.rs
+++ b/src-tauri/src/session/mod.rs
@@ -2,10 +2,12 @@ pub mod custom_names;
 pub mod detector;
 pub mod parser;
 pub mod permissions;
+pub mod source;
 pub mod status;
 
 pub use custom_names::{CustomNames, CustomTitles};
-pub use detector::{DetectedSession, DetectionDiagnostics, SessionDetector};
+pub use detector::LegacySessionSource;
+pub use source::{CliActivity, DetectedSession, DetectionDiagnostics, SessionKind, SessionSource};
 pub use parser::{
     extract_messages, parse_all_entries, parse_last_n_entries, parse_sessions_index, ImageBlock,
     MessageContent, MessageType, SessionEntry, SessionIndexEntry, SessionsIndex,

--- a/src-tauri/src/session/mod.rs
+++ b/src-tauri/src/session/mod.rs
@@ -9,6 +9,8 @@ pub use custom_names::{CustomNames, CustomTitles};
 pub use detector::LegacySessionSource;
 pub mod detector_cli;
 pub use detector_cli::CliSessionSource;
+pub mod state;
+pub use state::DetectorState;
 pub use source::{CliActivity, DetectedSession, DetectionDiagnostics, SessionKind, SessionSource};
 pub use parser::{
     extract_messages, parse_all_entries, parse_last_n_entries, parse_sessions_index, ImageBlock,

--- a/src-tauri/src/session/source.rs
+++ b/src-tauri/src/session/source.rs
@@ -1,0 +1,119 @@
+use serde::{Deserialize, Serialize};
+use std::path::PathBuf;
+use thiserror::Error;
+
+#[derive(Error, Debug)]
+pub enum SessionDetectorError {
+    #[error("Failed to read directory: {0}")]
+    DirectoryRead(#[from] std::io::Error),
+    #[error("Failed to get home directory")]
+    HomeDirectoryNotFound,
+    #[error("Failed to refresh process information")]
+    ProcessRefreshError,
+    #[error("CLI subprocess failed: {0}")]
+    CliFailed(String),
+    #[error("CLI subprocess timed out after {0}ms")]
+    Timeout(u128),
+    #[error("Failed to parse CLI output: {0}")]
+    Parse(String),
+}
+
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "lowercase")]
+pub enum SessionKind {
+    Interactive,
+    Background,
+    Unknown,
+}
+
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "lowercase")]
+pub enum CliActivity {
+    Busy,
+    Idle,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, Default, PartialEq)]
+#[serde(rename_all = "camelCase")]
+pub struct DetectionDiagnostics {
+    pub claude_processes_found: u32,
+    pub processes_with_cwd: u32,
+    pub fda_likely_needed: bool,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct DetectedSession {
+    pub pid: u32,
+    pub cwd: PathBuf,
+    pub project_path: PathBuf,
+    pub session_id: Option<String>,
+    pub project_name: String,
+    pub kind: SessionKind,
+    pub started_at_ms: Option<i64>,
+    pub official_name: Option<String>,
+    pub cli_activity: Option<CliActivity>,
+}
+
+impl DetectedSession {
+    /// Legacy backend doesn't fill the new (Phase 2) fields. Helper enforces the defaults.
+    pub fn with_legacy_defaults(
+        pid: u32,
+        cwd: PathBuf,
+        project_path: PathBuf,
+        session_id: Option<String>,
+        project_name: String,
+    ) -> Self {
+        Self {
+            pid,
+            cwd,
+            project_path,
+            session_id,
+            project_name,
+            kind: SessionKind::Interactive,
+            started_at_ms: None,
+            official_name: None,
+            cli_activity: None,
+        }
+    }
+}
+
+pub trait SessionSource: Send {
+    fn detect(
+        &mut self,
+    ) -> Result<(Vec<DetectedSession>, DetectionDiagnostics), SessionDetectorError>;
+    fn backend_name(&self) -> &'static str;
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn session_kind_serializes_as_lowercase() {
+        assert_eq!(serde_json::to_string(&SessionKind::Interactive).unwrap(), "\"interactive\"");
+        assert_eq!(serde_json::to_string(&SessionKind::Background).unwrap(), "\"background\"");
+        assert_eq!(serde_json::to_string(&SessionKind::Unknown).unwrap(), "\"unknown\"");
+    }
+
+    #[test]
+    fn cli_activity_serializes_as_lowercase() {
+        assert_eq!(serde_json::to_string(&CliActivity::Busy).unwrap(), "\"busy\"");
+        assert_eq!(serde_json::to_string(&CliActivity::Idle).unwrap(), "\"idle\"");
+    }
+
+    #[test]
+    fn detected_session_defaults_for_legacy_backend_have_kind_interactive() {
+        let d = DetectedSession::with_legacy_defaults(
+            42,
+            PathBuf::from("/tmp"),
+            PathBuf::from("/tmp/proj"),
+            Some("uuid".to_string()),
+            "tmp".to_string(),
+        );
+        assert!(matches!(d.kind, SessionKind::Interactive));
+        assert_eq!(d.started_at_ms, None);
+        assert!(d.official_name.is_none());
+        assert!(d.cli_activity.is_none());
+    }
+}

--- a/src-tauri/src/session/state.rs
+++ b/src-tauri/src/session/state.rs
@@ -1,0 +1,189 @@
+// src-tauri/src/session/state.rs
+use super::source::{
+    DetectedSession, DetectionDiagnostics, SessionDetectorError, SessionSource,
+};
+use super::{create_session_source, mode_from_env, BackendMode};
+use crate::session::detector::LegacySessionSource;
+use std::sync::atomic::{AtomicU32, Ordering};
+use std::sync::Arc;
+
+const DOWNGRADE_THRESHOLD: u32 = 5;
+
+pub struct DetectorState {
+    source: Box<dyn SessionSource>,
+    consecutive_failures: u32,
+    telemetry_counter: Arc<AtomicU32>,
+    mode: BackendMode,
+}
+
+impl DetectorState {
+    pub fn new() -> Self {
+        Self {
+            source: create_session_source(),
+            consecutive_failures: 0,
+            telemetry_counter: Arc::new(AtomicU32::new(0)),
+            mode: mode_from_env(),
+        }
+    }
+
+    pub fn detect(
+        &mut self,
+    ) -> Result<(Vec<DetectedSession>, DetectionDiagnostics), SessionDetectorError> {
+        match self.source.detect() {
+            Ok(out) => {
+                self.consecutive_failures = 0;
+                Ok(out)
+            }
+            Err(e) => {
+                self.consecutive_failures += 1;
+                if self.should_downgrade() {
+                    self.downgrade_to_legacy();
+                }
+                Err(e)
+            }
+        }
+    }
+
+    fn should_downgrade(&self) -> bool {
+        self.mode == BackendMode::Auto
+            && self.source.backend_name() == "cli"
+            && self.consecutive_failures >= DOWNGRADE_THRESHOLD
+    }
+
+    fn downgrade_to_legacy(&mut self) {
+        self.source = Box::new(LegacySessionSource::new().expect("legacy ctor"));
+        self.consecutive_failures = 0;
+        self.telemetry_counter.fetch_add(1, Ordering::Relaxed);
+    }
+
+    pub fn recheck_and_maybe_swap(&mut self) {
+        if self.mode != BackendMode::Auto {
+            return;
+        }
+        let supports_cli = super::probe_claude_supports_agents_json();
+        let want = if supports_cli { "cli" } else { "legacy" };
+        if self.source.backend_name() != want {
+            self.source = create_session_source();
+            self.consecutive_failures = 0;
+            self.telemetry_counter.fetch_add(1, Ordering::Relaxed);
+        }
+    }
+
+    pub fn backend_name(&self) -> &'static str {
+        self.source.backend_name()
+    }
+
+    pub fn telemetry_counter(&self) -> Arc<AtomicU32> {
+        self.telemetry_counter.clone()
+    }
+}
+
+#[cfg(test)]
+impl DetectorState {
+    /// Test-only constructor that injects an explicit source + mode.
+    pub fn for_test(source: Box<dyn SessionSource>, mode: BackendMode) -> Self {
+        Self {
+            source,
+            consecutive_failures: 0,
+            telemetry_counter: Arc::new(AtomicU32::new(0)),
+            mode,
+        }
+    }
+
+    /// Test-only helper to replace the underlying source mid-test (e.g. to
+    /// schedule a fresh batch of failures via a new FakeSource instance).
+    pub fn replace_source(&mut self, src: Box<dyn SessionSource>) {
+        self.source = src;
+        self.consecutive_failures = 0;
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::cell::Cell;
+
+    struct FakeSource {
+        name: &'static str,
+        fail_next: Cell<u32>,
+    }
+
+    impl FakeSource {
+        fn new(name: &'static str, fails: u32) -> Self {
+            Self { name, fail_next: Cell::new(fails) }
+        }
+    }
+
+    impl SessionSource for FakeSource {
+        fn detect(&mut self) -> Result<(Vec<DetectedSession>, DetectionDiagnostics), SessionDetectorError> {
+            let n = self.fail_next.get();
+            if n > 0 {
+                self.fail_next.set(n - 1);
+                return Err(SessionDetectorError::CliFailed("fake".into()));
+            }
+            Ok((Vec::new(), DetectionDiagnostics::default()))
+        }
+        fn backend_name(&self) -> &'static str { self.name }
+    }
+
+    #[test]
+    fn detect_success_resets_counter() {
+        let mut s = DetectorState::for_test(Box::new(FakeSource::new("cli", 0)), BackendMode::Auto);
+        s.consecutive_failures = 3;
+        let _ = s.detect().unwrap();
+        assert_eq!(s.consecutive_failures, 0);
+    }
+
+    #[test]
+    fn detect_failure_increments_counter() {
+        let mut s = DetectorState::for_test(Box::new(FakeSource::new("cli", 1)), BackendMode::Auto);
+        let _ = s.detect();
+        assert_eq!(s.consecutive_failures, 1);
+    }
+
+    #[test]
+    fn five_failures_in_auto_cli_mode_swap_to_legacy() {
+        let mut s = DetectorState::for_test(Box::new(FakeSource::new("cli", 5)), BackendMode::Auto);
+        for _ in 0..5 {
+            let _ = s.detect();
+        }
+        assert_eq!(s.backend_name(), "legacy");
+        assert_eq!(s.consecutive_failures, 0);
+    }
+
+    #[test]
+    fn force_cli_mode_never_downgrades() {
+        let mut s = DetectorState::for_test(Box::new(FakeSource::new("cli", 20)), BackendMode::ForceCli);
+        for _ in 0..20 {
+            let _ = s.detect();
+        }
+        assert_eq!(s.backend_name(), "cli");
+    }
+
+    #[test]
+    fn legacy_backend_failures_do_not_swap() {
+        let mut s = DetectorState::for_test(Box::new(FakeSource::new("legacy", 10)), BackendMode::Auto);
+        for _ in 0..10 {
+            let _ = s.detect();
+        }
+        assert_eq!(s.backend_name(), "legacy");
+    }
+
+    #[test]
+    fn counter_resets_on_success_between_failures() {
+        let mut s = DetectorState::for_test(Box::new(FakeSource::new("cli", 3)), BackendMode::Auto);
+        for _ in 0..3 { let _ = s.detect(); }
+        let _ = s.detect();
+        assert_eq!(s.consecutive_failures, 0);
+        s.replace_source(Box::new(FakeSource::new("cli", 3)));
+        for _ in 0..3 { let _ = s.detect(); }
+        assert_eq!(s.backend_name(), "cli");
+    }
+
+    #[test]
+    fn recheck_no_swap_in_force_modes() {
+        let mut s = DetectorState::for_test(Box::new(FakeSource::new("cli", 0)), BackendMode::ForceLegacy);
+        s.recheck_and_maybe_swap();
+        assert_eq!(s.backend_name(), "cli");
+    }
+}

--- a/src/lib/components/SessionCard.svelte
+++ b/src/lib/components/SessionCard.svelte
@@ -34,7 +34,17 @@
 	function tipLeave() { tooltipText = ''; }
 	function tipMove(e: MouseEvent) { tooltipX = e.clientX + 12; tooltipY = e.clientY + 12; }
 
-	let cardTitle = $derived(session.customTitle || session.summary || session.firstPrompt);
+	let cardTitle = $derived(
+		session.customTitle
+		|| session.officialName
+		|| session.summary
+		|| session.firstPrompt
+	);
+	let startedAtIso = $derived(
+		session.startedAtMs != null
+			? new Date(session.startedAtMs).toISOString()
+			: session.modified
+	);
 	let workerTip = $derived(session.workerOf ? `Worker of ${session.workerOf}` : '');
 	let workerIdShort = $derived(session.workerOf?.slice(0, 8) ?? '');
 
@@ -241,7 +251,7 @@
 							{costLabel}
 						</span>
 					{/if}
-					<span class="time-badge">{formatTimeSince(session.modified)}</span>
+					<span class="time-badge">{formatTimeSince(startedAtIso)}</span>
 				</div>
 			{/if}
 			

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -57,6 +57,12 @@ export interface Session {
 
   /** Session ID of the PM that spawned this session (if it's a c9watch worker) */
   workerOf?: string | null;
+
+  /** Name set via `claude agents` Ctrl+T pin (CC ≥ 2.1.150). */
+  officialName?: string | null;
+
+  /** Session start timestamp from `claude agents --json` (ms since epoch). */
+  startedAtMs?: number | null;
 }
 
 /**


### PR DESCRIPTION
## Summary

- Trait-based `SessionSource` with `CliSessionSource` (new) + `LegacySessionSource` (existing, renamed)
- Mode-aware factory: `C9WATCH_DETECTOR_BACKEND=auto|cli|legacy` (default `auto`)
- Two-stage probe: `claude --version >= 2.1.150` + `claude agents --json` runs cleanly (both bounded by 2-3s timeouts with bg-thread stdout drain to avoid pipe-deadlock under high agent count)
- `DetectorState` wrapper holds source + consecutive-failure counter (5 strikes in auto+cli → swap to legacy, telemetry tick; force modes never swap)
- All call sites (polling thread, `get_sessions`, `rename_session`, `stop_session`, window focus) route through `Arc<Mutex<DetectorState>>` for coherent failure tracking and backend swaps; lock dropped before slow enrichment pass at every site
- sessionId-first JSONL resolution with encoded-cwd fast-path + HashMap cache (eliminates Windows path-encoding bug class)
- Phase 2 fields surfaced: `cli_activity` merged into `SessionStatus` without breaking permission/question handling, `officialName` in card title chain, `startedAtMs` for accurate "started Xh ago"

Spec: \`docs/superpowers/specs/2026-05-23-detector-cli-refactor-design.md\`
Plan: \`docs/superpowers/plans/2026-05-23-detector-cli-refactor.md\`

## Test plan

- [x] Unit tests pass — \`cargo test --features cli --no-default-features --lib\` → 279/0/1
- [x] GUI feature tests pass — \`cargo test --lib\` → 291/0/1
- [x] Frontend type-check passes — \`npm run check\` → 0 errors
- [ ] Dashboard renders sessions from \`claude agents --json\` (auto mode) — needs manual dogfood
- [ ] Permission prompts still surface NeedsAttention (does not get masked by cli_activity) — needs manual dogfood
- [ ] \`C9WATCH_DETECTOR_BACKEND=legacy npm run tauri dev\` — legacy backend used
- [ ] \`C9WATCH_DETECTOR_BACKEND=cli npm run tauri dev\` — CLI backend used, no auto-downgrade
- [ ] Auto mode + 5 forced CLI failures → swaps to legacy, telemetry counter ticks (rename/remove claude bin to simulate)
- [ ] Window focus after CC upgrade → swap to CLI without restart

## Commits

10 atomic commits — see \`git log main..HEAD\`. Two extra fix commits beyond the plan: \`1a1b13e\` (bg-thread stdout drain in CliSessionSource — fixes pipe-buffer deadlock risk flagged in review) and \`8a92f5b\` (bounded \`probe_version_supports\` with 2s timeout — fixes unbounded blocking on window focus).

🤖 Generated with [Claude Code](https://claude.com/claude-code)