### PR TITLE
feat(pm): claude --bg backend to dodge 2026-06-15 billing split

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,17 @@ All notable changes to c9watch are documented here.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+- PM-orchestration `bg` backend: spawn workers via `claude --bg` instead of
+  `claude --print`. Workers stay on Pro/Max subscription quota after
+  Anthropic's 2026-06-15 Agent SDK billing split. Auto-detected when CC
+  >= 2.1.150. Override with `C9WATCH_WORKER_BACKEND=bg|print|auto`.
+- `c9watch spawn --prompt <text>` flag (required when bg backend is active).
+- `EventStatus::Awaiting` + `InboxEvent::awaiting()` for bg workers entering
+  `state:blocked` (turn ended waiting on user input — distinct from done/crashed).
+
 ## [0.8.1] - 2026-04-20
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -178,6 +178,10 @@ See [SKILLS.md](SKILLS.md) for more install options.
 - **Cost tracker** -- Track Claude Code spending with daily, per-project, and per-model breakdowns; click any session to preview the conversation; sort by date or cost
 - **CLI for agents** -- `c9watch list`, `view`, `history`, `search`, `stop`, `watch`, `cost` commands for scriptable session management and agent-to-agent monitoring
 - **PM orchestration** -- Spawn, message, and manage child Claude Code "worker" sessions from a parent "PM" session via `c9watch spawn`, `send`, `workers`, `adopt`, `inbox`, `tasks`. WORKER and PM badges visible on session cards; PMs show a Workers panel in the overlay
+- **PM-orchestration on subscription quota** — c9watch workers run as
+  `claude --bg` background-pinned sessions, billed against your Pro/Max
+  chat quota (not the separate Agent SDK credit pool that took effect
+  2026-06-15). Falls back to legacy `--print` mode on older CC.
 - **Subagent visibility** -- Detect and display Task-tool subagents spawned inside any session, with click-to-preview transcripts
 - **Entry animations** -- Staggered cascade transitions across tabs and overlay panels for fluid navigation
 - **Token distance visualizer** -- See your token usage as a rice stack towering past 22 real-world landmarks, with animated stacking, native share sheet, and Instagram-ready PNG export

--- a/docs/notes/pm-bg-backend.md
+++ b/docs/notes/pm-bg-backend.md
@@ -24,8 +24,12 @@ Auto-detect picks `bg` when both:
 ## Bg backend internals
 
 - Spawn: `claude --bg --session-id <uuid> --name <id> --permission-mode <m> [...] "<prompt>"`. Initial prompt REQUIRED (idle-spawn + later `reply` is unreliable). Pass via `c9watch spawn --prompt "<text>"`.
-- Send: control.sock `{op:"reply", short, text}` one-shot RPC.
-- Events: dedicated UDS per worker, `{op:"subscribe", short}` push stream. `state:"done"` and `state:"blocked"` both count as turn-end.
+- Send: control.sock `{op:"reply", short, text}` one-shot RPC. Callers should
+  serialize sends: wait for the previous turn to complete before sending the
+  next prompt.
+- Events: dedicated UDS per worker, `{op:"subscribe", short}` push stream.
+  `state:"done"`, `state:"blocked"`, and `state:"working" + tempo:"idle"` count
+  as turn-end.
 - Kill: control.sock `{op:"kill", short}` RPC + parallel `claude rm <short>` subprocess for jobs-dir cleanup.
 
 ## Limitations
@@ -33,3 +37,9 @@ Auto-detect picks `bg` when both:
 - `claude --bg` flag is undocumented; CC may rename in future releases. We pin to >= 2.1.150 and fail-soft to print backend on probe error.
 - Subscribe streams don't multiplex — N workers = N file descriptors. Acceptable at N ≤ 16.
 - `BgWorkerHandle` holds the daemon state mutex while `wait_for_turn` is awaiting events. Other RPCs serialize behind a pending `--wait`. Acceptable for current single-PM dogfooding; revisit if multiple concurrent `--wait`s become common.
+- Rapid back-to-back `reply` RPCs are daemon-ambiguous. CC 2.1.150 may queue
+  the second prompt as its own turn, coalesce multiple prompts into one user
+  message, or inject a prompt into the currently running turn. The subscribe
+  stream does not expose a per-turn counter or reply acknowledgement, so the bg
+  backend cannot reliably attribute separate assistant responses unless callers
+  wait between sends.

--- a/docs/notes/pm-bg-backend.md
+++ b/docs/notes/pm-bg-backend.md
@@ -1,0 +1,35 @@
+# PM Worker Backends
+
+c9watch ships two PM-worker backends:
+
+- **`bg` (default on CC >= 2.1.150)**: workers spawn via the hidden
+  `claude --bg` flag and are managed by the CC supervisor daemon. They
+  appear in `claude agents --json` as `kind:"background"`. Billing goes
+  against your Pro/Max chat subscription quota.
+- **`print` (legacy fallback)**: workers spawn via `claude --print` and
+  are managed entirely by c9watch's own daemon. Billing goes against the
+  Agent SDK credit pool ($20 Pro / $100 Max 5x / $200 Max 20x) at full
+  API rates after Anthropic's 2026-06-15 split.
+
+## Selection
+
+- `C9WATCH_WORKER_BACKEND=bg` — force bg backend
+- `C9WATCH_WORKER_BACKEND=print` — force print backend (escape hatch)
+- `C9WATCH_WORKER_BACKEND=auto` or unset — auto-detect
+
+Auto-detect picks `bg` when both:
+1. `claude --version` >= 2.1.150
+2. `/tmp/cc-daemon-{uid}/{host}/control.sock` exists (daemon has run)
+
+## Bg backend internals
+
+- Spawn: `claude --bg --session-id <uuid> --name <id> --permission-mode <m> [...] "<prompt>"`. Initial prompt REQUIRED (idle-spawn + later `reply` is unreliable). Pass via `c9watch spawn --prompt "<text>"`.
+- Send: control.sock `{op:"reply", short, text}` one-shot RPC.
+- Events: dedicated UDS per worker, `{op:"subscribe", short}` push stream. `state:"done"` and `state:"blocked"` both count as turn-end.
+- Kill: control.sock `{op:"kill", short}` RPC + parallel `claude rm <short>` subprocess for jobs-dir cleanup.
+
+## Limitations
+
+- `claude --bg` flag is undocumented; CC may rename in future releases. We pin to >= 2.1.150 and fail-soft to print backend on probe error.
+- Subscribe streams don't multiplex — N workers = N file descriptors. Acceptable at N ≤ 16.
+- `BgWorkerHandle` holds the daemon state mutex while `wait_for_turn` is awaiting events. Other RPCs serialize behind a pending `--wait`. Acceptable for current single-PM dogfooding; revisit if multiple concurrent `--wait`s become common.

--- a/src-tauri/src/cli/bg_backend.rs
+++ b/src-tauri/src/cli/bg_backend.rs
@@ -196,6 +196,14 @@ impl SettleDetector {
         }
         if let Some(t) = &patch.tempo {
             self.tempo = Some(t.clone());
+            // Worker started a new turn — invalidate the previous settle so
+            // is_settled() flips back to false and a subsequent done/blocked
+            // is recognised as a NEW settle. The daemon never emits a fresh
+            // state:active patch; only tempo carries the resumption signal.
+            if matches!(t.as_str(), "active" | "running") {
+                self.state = None;
+                self.needs = None;
+            }
         }
         if let Some(n) = &patch.needs {
             self.needs = Some(n.clone());
@@ -226,14 +234,30 @@ use tokio::sync::broadcast;
 
 /// Open a dedicated control.sock connection and subscribe to `short`'s events.
 ///
-/// Returns a broadcast receiver that emits `SubscribeEvent` (filtered: `Stream`
-/// frames are dropped silently — they're ANSI PTY redraws, not useful for c9watch).
-/// The reader task runs until the connection EOFs or the receiver is dropped.
+/// Returns `(Sender, Vec<Receiver>)` where the receivers count matches
+/// `receiver_count`. Receivers are minted BEFORE the reader task starts
+/// streaming events so callers cannot race past the initial snapshot.
+///
+/// Tokio broadcast receivers start at the current channel position when
+/// `subscribe()` is called; they do NOT replay older messages. So all
+/// downstream consumers MUST be created up-front.
+///
+/// Reader task discards `Stream` frames (ANSI PTY redraws). Reader exits on
+/// connection EOF or when all receivers are dropped.
 pub async fn subscribe(
     sock: &std::path::Path,
     short: &str,
-) -> Result<broadcast::Receiver<crate::cli::bg_protocol::SubscribeEvent>, String> {
+    receiver_count: usize,
+) -> Result<
+    (
+        broadcast::Sender<crate::cli::bg_protocol::SubscribeEvent>,
+        Vec<broadcast::Receiver<crate::cli::bg_protocol::SubscribeEvent>>,
+    ),
+    String,
+> {
     use crate::cli::bg_protocol::SubscribeEvent;
+
+    assert!(receiver_count >= 1, "subscribe requires receiver_count >= 1");
 
     let mut conn = UnixStream::connect(sock)
         .await
@@ -251,9 +275,19 @@ pub async fn subscribe(
         .map_err(|e| format!("subscribe newline: {}", e))?;
     conn.flush().await.map_err(|e| format!("subscribe flush: {}", e))?;
 
-    let (tx, rx) = broadcast::channel::<SubscribeEvent>(64);
-    let short_owned = short.to_string();
+    let (tx, first_rx) = broadcast::channel::<SubscribeEvent>(64);
+    // Mint all requested receivers SYNCHRONOUSLY before spawning the reader
+    // task so the channel is fully provisioned. New tokio broadcast receivers
+    // start at the current sender cursor — late subscribers do NOT replay
+    // older sends. So additional receivers must exist before any event flows.
+    let mut receivers = Vec::with_capacity(receiver_count);
+    receivers.push(first_rx);
+    for _ in 1..receiver_count {
+        receivers.push(tx.subscribe());
+    }
 
+    let reader_tx = tx.clone();
+    let short_owned = short.to_string();
     tokio::spawn(async move {
         let mut reader = BufReader::new(conn);
         let mut line = String::new();
@@ -277,13 +311,13 @@ pub async fn subscribe(
             if matches!(ev, SubscribeEvent::Stream { .. }) {
                 continue; // discard PTY frames
             }
-            if tx.send(ev).is_err() {
-                break; // receiver dropped
-            }
+            // Drop the event when all receivers are gone (post-kill); otherwise
+            // it lands on every active receiver's queue.
+            let _ = reader_tx.send(ev);
         }
     });
 
-    Ok(rx)
+    Ok((tx, receivers))
 }
 
 #[cfg(test)]
@@ -383,6 +417,51 @@ mod tests {
             ..Default::default()
         });
         assert!(!det.is_settled());
+    }
+
+    #[test]
+    fn settle_detector_resets_state_on_active_tempo() {
+        // Worker settles, then resumes with a tempo:active patch (no state
+        // field). Detector must clear `state` so the next done counts as a
+        // NEW settle — otherwise the settle_watcher dedupe latches forever.
+        let mut det = SettleDetector::new();
+        det.apply_patch(&StatePatch {
+            state: Some("done".to_string()),
+            tempo: Some("idle".to_string()),
+            ..Default::default()
+        });
+        assert!(det.is_settled());
+        // Worker starts next turn — only tempo flips.
+        det.apply_patch(&StatePatch {
+            tempo: Some("active".to_string()),
+            ..Default::default()
+        });
+        assert!(!det.is_settled(), "active tempo must clear prior settle");
+        // Next done arrives.
+        det.apply_patch(&StatePatch {
+            state: Some("done".to_string()),
+            tempo: Some("idle".to_string()),
+            ..Default::default()
+        });
+        assert!(det.is_settled());
+    }
+
+    #[test]
+    fn settle_detector_resets_state_on_running_tempo() {
+        let mut det = SettleDetector::new();
+        det.apply_patch(&StatePatch {
+            state: Some("blocked".to_string()),
+            tempo: Some("blocked".to_string()),
+            needs: Some("user input".to_string()),
+            ..Default::default()
+        });
+        assert!(det.is_settled());
+        det.apply_patch(&StatePatch {
+            tempo: Some("running".to_string()),
+            ..Default::default()
+        });
+        assert!(!det.is_settled());
+        assert_eq!(det.needs(), None, "needs must clear after resume");
     }
 
     #[test]

--- a/src-tauri/src/cli/bg_backend.rs
+++ b/src-tauri/src/cli/bg_backend.rs
@@ -42,6 +42,51 @@ pub fn resolve_control_sock() -> Result<PathBuf, String> {
     ))
 }
 
+use crate::cli::bg_protocol::{OneShotReply, Request};
+use std::path::Path;
+use std::time::Duration;
+use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
+use tokio::net::UnixStream;
+
+/// Send one request, read one reply, drop the connection.
+///
+/// The daemon closes the connection after each one-shot reply, so this is
+/// the only safe pattern for `reply`/`kill`/`nudge`/`ping`. Do NOT use for
+/// `subscribe` (subscribe takes over the connection — use [`subscribe`]).
+pub async fn rpc(sock: &Path, req: Request) -> Result<OneShotReply, String> {
+    let wire = req.to_wire();
+
+    let mut conn = tokio::time::timeout(
+        Duration::from_secs(2),
+        UnixStream::connect(sock),
+    )
+    .await
+    .map_err(|_| "connect timeout".to_string())?
+    .map_err(|e| format!("connect {}: {}", sock.display(), e))?;
+
+    conn.write_all(wire.as_bytes())
+        .await
+        .map_err(|e| format!("write request: {}", e))?;
+    conn.write_all(b"\n")
+        .await
+        .map_err(|e| format!("write newline: {}", e))?;
+    conn.flush().await.map_err(|e| format!("flush: {}", e))?;
+
+    let mut reader = BufReader::new(conn);
+    let mut line = String::new();
+    tokio::time::timeout(Duration::from_secs(5), reader.read_line(&mut line))
+        .await
+        .map_err(|_| "reply timeout".to_string())?
+        .map_err(|e| format!("read reply: {}", e))?;
+
+    if line.is_empty() {
+        return Err("daemon closed connection without reply".to_string());
+    }
+
+    serde_json::from_str::<OneShotReply>(line.trim())
+        .map_err(|e| format!("parse reply {:?}: {}", line, e))
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -54,5 +99,14 @@ mod tests {
             Ok(p) => assert!(p.ends_with("control.sock")),
             Err(e) => assert!(e.contains("/tmp/cc-daemon-")),
         }
+    }
+
+    #[test]
+    fn rpc_request_serializes_one_line_no_trailing_newline() {
+        use crate::cli::bg_protocol::Request;
+        let req = Request::Kill { short: "abc12345".to_string() };
+        let wire = req.to_wire();
+        assert!(!wire.contains('\n'), "to_wire must not embed newlines");
+        assert!(wire.starts_with('{') && wire.ends_with('}'));
     }
 }

--- a/src-tauri/src/cli/bg_backend.rs
+++ b/src-tauri/src/cli/bg_backend.rs
@@ -1,0 +1,58 @@
+//! BgBackend: spawn and manage Claude Code workers via `claude --bg`
+//! and `/tmp/cc-daemon-{uid}/{host-id}/control.sock` JSON-RPC.
+
+use std::path::PathBuf;
+
+/// Find the CC daemon's control.sock for the current user.
+///
+/// Pattern: `/tmp/cc-daemon-{uid}/{host-id}/control.sock` where `host-id`
+/// is a per-machine hash chosen by the daemon. Typically exactly one
+/// host-id subdirectory exists per user.
+///
+/// Returns `Err` if the daemon has never run on this machine OR the
+/// host directory is missing.
+pub fn resolve_control_sock() -> Result<PathBuf, String> {
+    let uid = unsafe { libc::getuid() };
+    let base = PathBuf::from(format!("/tmp/cc-daemon-{}", uid));
+
+    if !base.exists() {
+        return Err(format!(
+            "CC daemon socket dir not found: {} (is claude installed and has it ever run?)",
+            base.display()
+        ));
+    }
+
+    // Pick the first (typically only) host-id subdir.
+    let entries = std::fs::read_dir(&base)
+        .map_err(|e| format!("read_dir {}: {}", base.display(), e))?;
+    for entry in entries.flatten() {
+        let path = entry.path();
+        if !path.is_dir() {
+            continue;
+        }
+        let sock = path.join("control.sock");
+        if sock.exists() {
+            return Ok(sock);
+        }
+    }
+
+    Err(format!(
+        "no control.sock found under {} (daemon may be down)",
+        base.display()
+    ))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn resolve_returns_path_or_clear_error() {
+        // Best-effort: if claude has run on this machine, path resolves.
+        // If not, error message must mention the missing dir.
+        match resolve_control_sock() {
+            Ok(p) => assert!(p.ends_with("control.sock")),
+            Err(e) => assert!(e.contains("/tmp/cc-daemon-")),
+        }
+    }
+}

--- a/src-tauri/src/cli/bg_backend.rs
+++ b/src-tauri/src/cli/bg_backend.rs
@@ -23,8 +23,8 @@ pub fn resolve_control_sock() -> Result<PathBuf, String> {
     }
 
     // Pick the first (typically only) host-id subdir.
-    let entries = std::fs::read_dir(&base)
-        .map_err(|e| format!("read_dir {}: {}", base.display(), e))?;
+    let entries =
+        std::fs::read_dir(&base).map_err(|e| format!("read_dir {}: {}", base.display(), e))?;
     for entry in entries.flatten() {
         let path = entry.path();
         if !path.is_dir() {
@@ -56,13 +56,10 @@ use tokio::net::UnixStream;
 pub async fn rpc(sock: &Path, req: Request) -> Result<OneShotReply, String> {
     let wire = req.to_wire();
 
-    let mut conn = tokio::time::timeout(
-        Duration::from_secs(2),
-        UnixStream::connect(sock),
-    )
-    .await
-    .map_err(|_| "connect timeout".to_string())?
-    .map_err(|e| format!("connect {}: {}", sock.display(), e))?;
+    let mut conn = tokio::time::timeout(Duration::from_secs(2), UnixStream::connect(sock))
+        .await
+        .map_err(|_| "connect timeout".to_string())?
+        .map_err(|e| format!("connect {}: {}", sock.display(), e))?;
 
     conn.write_all(wire.as_bytes())
         .await
@@ -119,16 +116,31 @@ pub fn parse_short_from_spawn(stdout: &str) -> Option<String> {
 use crate::cli::pm_worker::SpawnArgs;
 use tokio::process::Command;
 
-/// Spawn a new bg-pinned worker via `claude --bg`. Returns the 8-hex `short`.
+/// Result of `spawn_bg`: CC daemon's `short` handle (used for RPC) plus the
+/// `sessionId` CC actually assigned to the bg session. The latter is REQUIRED
+/// for detector linkage because `claude --bg` ignores the `--session-id` flag
+/// and mints its own UUID for bg-pinned sessions (verified empirically on
+/// CC 2.1.150 — see roster.json's `launch.args` for the rewrite evidence).
+#[derive(Debug, Clone)]
+pub struct BgSpawnInfo {
+    pub short: String,
+    pub cc_session_id: String,
+}
+
+/// Spawn a new bg-pinned worker via `claude --bg`.
 ///
 /// Requires CC >= 2.1.150 with the daemon running. The initial prompt is
 /// REQUIRED (idle-spawn + later `reply` was found unreliable in Phase 0).
+///
+/// After spawn, queries `claude agents --json` to recover CC's actual
+/// `sessionId` (which differs from the pre-generated `session_id` we passed —
+/// CC ignores `--session-id` for bg sessions).
 pub async fn spawn_bg(
     args: &SpawnArgs,
     session_id: &str,
     worker_name: &str,
     initial_prompt: &str,
-) -> Result<String, String> {
+) -> Result<BgSpawnInfo, String> {
     let mut cmd = Command::new("claude");
     cmd.arg("--bg")
         .arg("--session-id")
@@ -164,19 +176,72 @@ pub async fn spawn_bg(
     }
 
     let stdout = String::from_utf8_lossy(&output.stdout);
-    parse_short_from_spawn(&stdout).ok_or_else(|| {
+    let short = parse_short_from_spawn(&stdout).ok_or_else(|| {
         format!(
             "claude --bg did not emit 'backgrounded · <short>' line; stdout={:?}",
             stdout
         )
+    })?;
+
+    let cc_session_id = lookup_cc_session_id_by_name(worker_name).await?;
+    Ok(BgSpawnInfo {
+        short,
+        cc_session_id,
     })
 }
 
-/// Tracks whether a worker has settled into a turn-end state (done or blocked).
+/// Query `claude agents --json` and return the `sessionId` of the bg-pinned
+/// session whose `name` equals `worker_name`. CC's daemon does not honor
+/// `--session-id` on `--bg`, so this is how we recover the real UUID assigned
+/// to our worker.
+///
+/// Retries up to 5 times with 100ms backoff because `claude agents --json`
+/// reads from the daemon's roster, and there's a small window between spawn
+/// returning and the roster being flushed.
+async fn lookup_cc_session_id_by_name(worker_name: &str) -> Result<String, String> {
+    for attempt in 0..5 {
+        let output = Command::new("claude")
+            .arg("agents")
+            .arg("--json")
+            .output()
+            .await
+            .map_err(|e| format!("claude agents --json failed: {}", e))?;
+
+        if output.status.success() {
+            let stdout = String::from_utf8_lossy(&output.stdout);
+            if let Ok(agents) = serde_json::from_str::<Vec<serde_json::Value>>(&stdout) {
+                for agent in agents {
+                    if agent.get("name").and_then(|n| n.as_str()) == Some(worker_name) {
+                        if let Some(sid) = agent.get("sessionId").and_then(|s| s.as_str()) {
+                            return Ok(sid.to_string());
+                        }
+                    }
+                }
+            }
+        }
+
+        if attempt < 4 {
+            tokio::time::sleep(std::time::Duration::from_millis(100)).await;
+        }
+    }
+    Err(format!(
+        "claude agents --json did not list a bg session named '{}' after 5 attempts",
+        worker_name
+    ))
+}
+
+/// Tracks whether a worker has settled into a turn-end state.
+///
+/// Three terminal shapes observed in CC 2.1.150:
+/// - `state:"done"` (normal finish)
+/// - `state:"blocked"` (awaiting user input)
+/// - `state:"working", tempo:"idle"` (open-ended assistant text classified as
+///   "conversation continues but engine is quiescent" — typical for replies
+///   ending in phrases like "awaiting your next instruction")
 ///
 /// Per Phase 0 findings: pid-only patches and `tempo:"active"` patches mid-turn
-/// must NOT count as settle. Only an explicit `state:"done"` or `state:"blocked"`
-/// transition is authoritative.
+/// must NOT count as settle. Worker re-entry (`tempo:"active"|"running"`)
+/// clears the prior settle so subsequent done/blocked/working counts as new.
 #[derive(Debug, Default)]
 pub struct SettleDetector {
     state: Option<String>,
@@ -214,7 +279,16 @@ impl SettleDetector {
     }
 
     pub fn is_settled(&self) -> bool {
+        // Primary terminal states observed in CC 2.1.150: `done` (normal finish)
+        // and `blocked` (awaiting user input). A third terminal shape exists for
+        // open-ended assistant text that CC's classifier interprets as
+        // "conversation continues but engine is quiescent": `state:"working"` +
+        // `tempo:"idle"`. Without this clause `wait_for_turn` hangs until
+        // timeout. The tempo qualifier prevents mid-turn `working+active`
+        // patches (none observed in 2.1.150, but defensive) from short-circuiting
+        // the wait.
         matches!(self.state.as_deref(), Some("done") | Some("blocked"))
+            || (self.state.as_deref() == Some("working") && self.tempo.as_deref() == Some("idle"))
     }
 
     pub fn last_settled_state(&self) -> Option<&str> {
@@ -257,7 +331,10 @@ pub async fn subscribe(
 > {
     use crate::cli::bg_protocol::SubscribeEvent;
 
-    assert!(receiver_count >= 1, "subscribe requires receiver_count >= 1");
+    assert!(
+        receiver_count >= 1,
+        "subscribe requires receiver_count >= 1"
+    );
 
     let mut conn = UnixStream::connect(sock)
         .await
@@ -273,7 +350,9 @@ pub async fn subscribe(
     conn.write_all(b"\n")
         .await
         .map_err(|e| format!("subscribe newline: {}", e))?;
-    conn.flush().await.map_err(|e| format!("subscribe flush: {}", e))?;
+    conn.flush()
+        .await
+        .map_err(|e| format!("subscribe flush: {}", e))?;
 
     let (tx, first_rx) = broadcast::channel::<SubscribeEvent>(64);
     // Mint all requested receivers SYNCHRONOUSLY before spawning the reader
@@ -337,7 +416,9 @@ mod tests {
     #[test]
     fn rpc_request_serializes_one_line_no_trailing_newline() {
         use crate::cli::bg_protocol::Request;
-        let req = Request::Kill { short: "abc12345".to_string() };
+        let req = Request::Kill {
+            short: "abc12345".to_string(),
+        };
         let wire = req.to_wire();
         assert!(!wire.contains('\n'), "to_wire must not embed newlines");
         assert!(wire.starts_with('{') && wire.ends_with('}'));
@@ -487,5 +568,68 @@ mod tests {
             ..Default::default()
         });
         assert!(!det.is_settled());
+    }
+
+    #[test]
+    fn settle_detector_treats_working_idle_as_settled() {
+        // CC 2.1.150 emits `state:"working", tempo:"idle"` for open-ended
+        // assistant turns that the daemon's classifier interprets as
+        // "conversation continues but engine is quiescent". Without this rule,
+        // `wait_for_turn` hangs until timeout. Reproduced empirically on
+        // probe-01: `{"state":"working","detail":"Waiting.","tempo":"idle"}`.
+        let mut det = SettleDetector::new();
+        det.apply_patch(&StatePatch {
+            state: Some("working".to_string()),
+            tempo: Some("idle".to_string()),
+            detail: Some("Waiting.".to_string()),
+            ..Default::default()
+        });
+        assert!(det.is_settled());
+        assert_eq!(det.last_settled_state(), Some("working"));
+    }
+
+    #[test]
+    fn settle_detector_ignores_working_with_active_tempo() {
+        // Defensive: if CC ever emits `working+active` mid-turn, do NOT settle.
+        let mut det = SettleDetector::new();
+        det.apply_patch(&StatePatch {
+            state: Some("working".to_string()),
+            tempo: Some("active".to_string()),
+            ..Default::default()
+        });
+        assert!(!det.is_settled());
+    }
+
+    #[test]
+    fn settle_detector_ignores_working_without_tempo() {
+        // `working` alone (no tempo field) must not settle — only the explicit
+        // working+idle pair is the quiescent terminal shape.
+        let mut det = SettleDetector::new();
+        det.apply_patch(&StatePatch {
+            state: Some("working".to_string()),
+            ..Default::default()
+        });
+        assert!(!det.is_settled());
+    }
+
+    #[test]
+    fn settle_detector_resets_working_settle_on_active_tempo() {
+        // working+idle should reset on a subsequent active tempo just like
+        // done/blocked does, so the next settle is recognised as new.
+        let mut det = SettleDetector::new();
+        det.apply_patch(&StatePatch {
+            state: Some("working".to_string()),
+            tempo: Some("idle".to_string()),
+            ..Default::default()
+        });
+        assert!(det.is_settled());
+        det.apply_patch(&StatePatch {
+            tempo: Some("active".to_string()),
+            ..Default::default()
+        });
+        assert!(
+            !det.is_settled(),
+            "active tempo must clear prior working settle"
+        );
     }
 }

--- a/src-tauri/src/cli/bg_backend.rs
+++ b/src-tauri/src/cli/bg_backend.rs
@@ -87,6 +87,87 @@ pub async fn rpc(sock: &Path, req: Request) -> Result<OneShotReply, String> {
         .map_err(|e| format!("parse reply {:?}: {}", line, e))
 }
 
+/// Parse the `backgrounded · <short> [· <name>]` line emitted by
+/// `claude --bg`. Tolerates middle dot (·) and bullet (•) separators
+/// and optional name / idle-hint suffixes.
+///
+/// Returns the 8-hex `short` ID (= sessionId prefix) on success.
+pub fn parse_short_from_spawn(stdout: &str) -> Option<String> {
+    for line in stdout.lines() {
+        let trimmed = line.trim();
+        // Strip the "backgrounded " prefix and any separator char.
+        let rest = trimmed.strip_prefix("backgrounded")?.trim_start();
+        let after_sep = rest
+            .trim_start_matches(['·', '•', '-', ':'])
+            .trim_start();
+        // First whitespace-delimited token should be 8 hex chars.
+        let token: String = after_sep
+            .chars()
+            .take_while(|c| c.is_ascii_hexdigit())
+            .collect();
+        if token.len() == 8 {
+            return Some(token);
+        }
+    }
+    None
+}
+
+use crate::cli::pm_worker::SpawnArgs;
+use tokio::process::Command;
+
+/// Spawn a new bg-pinned worker via `claude --bg`. Returns the 8-hex `short`.
+///
+/// Requires CC >= 2.1.150 with the daemon running. The initial prompt is
+/// REQUIRED (idle-spawn + later `reply` was found unreliable in Phase 0).
+pub async fn spawn_bg(
+    args: &SpawnArgs,
+    session_id: &str,
+    worker_name: &str,
+    initial_prompt: &str,
+) -> Result<String, String> {
+    let mut cmd = Command::new("claude");
+    cmd.arg("--bg")
+        .arg("--session-id")
+        .arg(session_id)
+        .arg("--name")
+        .arg(worker_name)
+        .arg("--permission-mode")
+        .arg(&args.permission_mode);
+
+    if let Some(ref sp) = args.append_system_prompt {
+        cmd.arg("--append-system-prompt").arg(sp);
+    }
+    if let Some(ref model) = args.model {
+        cmd.arg("--model").arg(model);
+    }
+    for dir in &args.add_dirs {
+        cmd.arg("--add-dir").arg(dir);
+    }
+    cmd.arg(initial_prompt);
+    cmd.current_dir(&args.cwd);
+
+    let output = cmd
+        .output()
+        .await
+        .map_err(|e| format!("claude --bg spawn failed: {}", e))?;
+
+    if !output.status.success() {
+        return Err(format!(
+            "claude --bg exited {:?}: stderr={}",
+            output.status.code(),
+            String::from_utf8_lossy(&output.stderr)
+        ));
+    }
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    parse_short_from_spawn(&stdout).ok_or_else(|| {
+        format!(
+            "claude --bg did not emit 'backgrounded · <short>' line; stdout={:?}",
+            stdout
+        )
+    })
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -108,5 +189,36 @@ mod tests {
         let wire = req.to_wire();
         assert!(!wire.contains('\n'), "to_wire must not embed newlines");
         assert!(wire.starts_with('{') && wire.ends_with('}'));
+    }
+
+    #[test]
+    fn parse_backgrounded_line_with_name() {
+        let out = "backgrounded · 545fd354 · my-worker\n";
+        assert_eq!(parse_short_from_spawn(out).as_deref(), Some("545fd354"));
+    }
+
+    #[test]
+    fn parse_backgrounded_line_no_name() {
+        let out = "backgrounded · 545fd354\n";
+        assert_eq!(parse_short_from_spawn(out).as_deref(), Some("545fd354"));
+    }
+
+    #[test]
+    fn parse_backgrounded_line_idle_hint() {
+        let out = "backgrounded · 545fd354 (idle — send a prompt to start)\n";
+        assert_eq!(parse_short_from_spawn(out).as_deref(), Some("545fd354"));
+    }
+
+    #[test]
+    fn parse_backgrounded_line_unicode_bullet_variant() {
+        // Some terminals render the middle dot as •.
+        let out = "backgrounded • 545fd354\n";
+        assert_eq!(parse_short_from_spawn(out).as_deref(), Some("545fd354"));
+    }
+
+    #[test]
+    fn parse_backgrounded_missing_short_returns_none() {
+        let out = "some unrelated output\n";
+        assert!(parse_short_from_spawn(out).is_none());
     }
 }

--- a/src-tauri/src/cli/bg_backend.rs
+++ b/src-tauri/src/cli/bg_backend.rs
@@ -42,7 +42,7 @@ pub fn resolve_control_sock() -> Result<PathBuf, String> {
     ))
 }
 
-use crate::cli::bg_protocol::{OneShotReply, Request};
+use crate::cli::bg_protocol::{OneShotReply, Request, StatePatch};
 use std::path::Path;
 use std::time::Duration;
 use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
@@ -168,6 +168,120 @@ pub async fn spawn_bg(
     })
 }
 
+/// Tracks whether a worker has settled into a turn-end state (done or blocked).
+///
+/// Per Phase 0 findings: pid-only patches and `tempo:"active"` patches mid-turn
+/// must NOT count as settle. Only an explicit `state:"done"` or `state:"blocked"`
+/// transition is authoritative.
+#[derive(Debug, Default)]
+pub struct SettleDetector {
+    state: Option<String>,
+    tempo: Option<String>,
+    needs: Option<String>,
+    detail: Option<String>,
+}
+
+impl SettleDetector {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    pub fn apply_patch(&mut self, patch: &StatePatch) {
+        if let Some(s) = &patch.state {
+            self.state = Some(s.clone());
+        }
+        if let Some(t) = &patch.tempo {
+            self.tempo = Some(t.clone());
+        }
+        if let Some(n) = &patch.needs {
+            self.needs = Some(n.clone());
+        }
+        if let Some(d) = &patch.detail {
+            self.detail = Some(d.clone());
+        }
+    }
+
+    pub fn is_settled(&self) -> bool {
+        matches!(self.state.as_deref(), Some("done") | Some("blocked"))
+    }
+
+    pub fn last_settled_state(&self) -> Option<&str> {
+        self.state.as_deref()
+    }
+
+    pub fn needs(&self) -> Option<&str> {
+        self.needs.as_deref()
+    }
+
+    pub fn detail(&self) -> Option<&str> {
+        self.detail.as_deref()
+    }
+}
+
+use tokio::sync::broadcast;
+
+/// Open a dedicated control.sock connection and subscribe to `short`'s events.
+///
+/// Returns a broadcast receiver that emits `SubscribeEvent` (filtered: `Stream`
+/// frames are dropped silently — they're ANSI PTY redraws, not useful for c9watch).
+/// The reader task runs until the connection EOFs or the receiver is dropped.
+pub async fn subscribe(
+    sock: &std::path::Path,
+    short: &str,
+) -> Result<broadcast::Receiver<crate::cli::bg_protocol::SubscribeEvent>, String> {
+    use crate::cli::bg_protocol::SubscribeEvent;
+
+    let mut conn = UnixStream::connect(sock)
+        .await
+        .map_err(|e| format!("subscribe connect {}: {}", sock.display(), e))?;
+
+    let wire = Request::Subscribe {
+        short: short.to_string(),
+    }
+    .to_wire();
+    conn.write_all(wire.as_bytes())
+        .await
+        .map_err(|e| format!("subscribe write: {}", e))?;
+    conn.write_all(b"\n")
+        .await
+        .map_err(|e| format!("subscribe newline: {}", e))?;
+    conn.flush().await.map_err(|e| format!("subscribe flush: {}", e))?;
+
+    let (tx, rx) = broadcast::channel::<SubscribeEvent>(64);
+    let short_owned = short.to_string();
+
+    tokio::spawn(async move {
+        let mut reader = BufReader::new(conn);
+        let mut line = String::new();
+        loop {
+            line.clear();
+            match reader.read_line(&mut line).await {
+                Ok(0) => {
+                    eprintln!("[bg_backend] subscribe({}) EOF", short_owned);
+                    break;
+                }
+                Ok(_) => {}
+                Err(e) => {
+                    eprintln!("[bg_backend] subscribe({}) read err: {}", short_owned, e);
+                    break;
+                }
+            }
+            let ev = match serde_json::from_str::<SubscribeEvent>(line.trim()) {
+                Ok(e) => e,
+                Err(_) => continue, // skip unparseable frames silently
+            };
+            if matches!(ev, SubscribeEvent::Stream { .. }) {
+                continue; // discard PTY frames
+            }
+            if tx.send(ev).is_err() {
+                break; // receiver dropped
+            }
+        }
+    });
+
+    Ok(rx)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -220,5 +334,51 @@ mod tests {
     fn parse_backgrounded_missing_short_returns_none() {
         let out = "some unrelated output\n";
         assert!(parse_short_from_spawn(out).is_none());
+    }
+
+    #[test]
+    fn settle_detector_treats_done_as_settled() {
+        let mut det = SettleDetector::new();
+        det.apply_patch(&StatePatch {
+            state: Some("done".to_string()),
+            tempo: Some("idle".to_string()),
+            ..Default::default()
+        });
+        assert!(det.is_settled());
+        assert_eq!(det.last_settled_state(), Some("done"));
+    }
+
+    #[test]
+    fn settle_detector_treats_blocked_as_settled() {
+        let mut det = SettleDetector::new();
+        det.apply_patch(&StatePatch {
+            state: Some("blocked".to_string()),
+            tempo: Some("blocked".to_string()),
+            needs: Some("user input".to_string()),
+            ..Default::default()
+        });
+        assert!(det.is_settled());
+        assert_eq!(det.last_settled_state(), Some("blocked"));
+        assert_eq!(det.needs(), Some("user input"));
+    }
+
+    #[test]
+    fn settle_detector_ignores_pid_only_patches() {
+        let mut det = SettleDetector::new();
+        det.apply_patch(&StatePatch {
+            pid: Some(123),
+            ..Default::default()
+        });
+        assert!(!det.is_settled());
+    }
+
+    #[test]
+    fn settle_detector_ignores_active_tempo() {
+        let mut det = SettleDetector::new();
+        det.apply_patch(&StatePatch {
+            tempo: Some("active".to_string()),
+            ..Default::default()
+        });
+        assert!(!det.is_settled());
     }
 }

--- a/src-tauri/src/cli/bg_backend.rs
+++ b/src-tauri/src/cli/bg_backend.rs
@@ -95,9 +95,13 @@ pub async fn rpc(sock: &Path, req: Request) -> Result<OneShotReply, String> {
 pub fn parse_short_from_spawn(stdout: &str) -> Option<String> {
     for line in stdout.lines() {
         let trimmed = line.trim();
-        // Strip the "backgrounded " prefix and any separator char.
-        let rest = trimmed.strip_prefix("backgrounded")?.trim_start();
+        // Skip lines that don't start with the expected prefix — bg spawn may
+        // emit banners, blank lines, or other notices before the real line.
+        let Some(rest) = trimmed.strip_prefix("backgrounded") else {
+            continue;
+        };
         let after_sep = rest
+            .trim_start()
             .trim_start_matches(['·', '•', '-', ':'])
             .trim_start();
         // First whitespace-delimited token should be 8 hex chars.
@@ -306,6 +310,15 @@ mod tests {
     }
 
     #[test]
+    fn parse_backgrounded_skips_leading_noise() {
+        // Real spawns may emit blank lines, banners, or notices before the
+        // "backgrounded · <short>" line. Earlier impl returned None on first
+        // non-matching line — regression guard.
+        let out = "\n[notice] checking auth\n\nbackgrounded · 545fd354 · w\n";
+        assert_eq!(parse_short_from_spawn(out).as_deref(), Some("545fd354"));
+    }
+
+    #[test]
     fn parse_backgrounded_line_with_name() {
         let out = "backgrounded · 545fd354 · my-worker\n";
         assert_eq!(parse_short_from_spawn(out).as_deref(), Some("545fd354"));
@@ -370,6 +383,21 @@ mod tests {
             ..Default::default()
         });
         assert!(!det.is_settled());
+    }
+
+    #[test]
+    fn statepatch_deserializes_from_top_level_record() {
+        // wait_for_turn's snapshot path must accept `record.state` / `record.tempo`
+        // (the round-trip PoC shape), not just nested `record.currentState.*`.
+        let raw = serde_json::json!({
+            "state": "done",
+            "tempo": "idle",
+            "detail": "all set"
+        });
+        let p: crate::cli::bg_protocol::StatePatch = serde_json::from_value(raw).unwrap();
+        assert_eq!(p.state.as_deref(), Some("done"));
+        assert_eq!(p.tempo.as_deref(), Some("idle"));
+        assert_eq!(p.detail.as_deref(), Some("all set"));
     }
 
     #[test]

--- a/src-tauri/src/cli/bg_protocol.rs
+++ b/src-tauri/src/cli/bg_protocol.rs
@@ -33,7 +33,7 @@ pub struct OneShotReply {
     pub code: Option<String>,
 }
 
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Deserialize, Clone)]
 #[serde(tag = "type", rename_all = "lowercase")]
 pub enum SubscribeEvent {
     Snapshot {

--- a/src-tauri/src/cli/bg_protocol.rs
+++ b/src-tauri/src/cli/bg_protocol.rs
@@ -1,0 +1,144 @@
+//! Wire types for the CC daemon control.sock JSON-RPC protocol.
+//!
+//! Protocol: newline-delimited JSON over Unix socket. Every request and reply
+//! is one JSON object terminated by `\n`. Confirmed working against CC 2.1.150.
+
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Serialize, Deserialize, PartialEq)]
+#[serde(tag = "op", rename_all = "lowercase")]
+pub enum Request {
+    Subscribe { short: String },
+    Reply { short: String, text: String },
+    Kill { short: String },
+    Nudge { short: String },
+    Ping,
+}
+
+impl Request {
+    /// Wrap with `proto:1` and serialize as one JSON line (NO trailing newline —
+    /// caller appends `\n` before send).
+    pub fn to_wire(&self) -> String {
+        let mut v = serde_json::to_value(self).expect("Request always serializes");
+        v.as_object_mut().unwrap().insert("proto".to_string(), serde_json::json!(1));
+        serde_json::to_string(&v).expect("Value always serializes")
+    }
+}
+
+#[derive(Debug, Deserialize)]
+pub struct OneShotReply {
+    pub ok: bool,
+    pub op: Option<String>,
+    pub error: Option<String>,
+    pub code: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(tag = "type", rename_all = "lowercase")]
+pub enum SubscribeEvent {
+    Snapshot {
+        record: serde_json::Value,
+        #[serde(default)]
+        stream_tail: Vec<String>,
+    },
+    State {
+        patch: StatePatch,
+    },
+    Stream {
+        #[allow(dead_code)]
+        line: String,
+    },
+}
+
+#[derive(Debug, Deserialize, Default, Clone)]
+#[serde(default)]
+pub struct StatePatch {
+    pub state: Option<String>,
+    pub tempo: Option<String>,
+    pub needs: Option<String>,
+    pub detail: Option<String>,
+    pub pid: Option<u32>,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn subscribe_serializes_with_proto() {
+        let req = Request::Subscribe { short: "abc12345".to_string() };
+        let wire = req.to_wire();
+        let v: serde_json::Value = serde_json::from_str(&wire).unwrap();
+        assert_eq!(v["proto"], 1);
+        assert_eq!(v["op"], "subscribe");
+        assert_eq!(v["short"], "abc12345");
+    }
+
+    #[test]
+    fn reply_uses_text_field() {
+        let req = Request::Reply {
+            short: "abc12345".to_string(),
+            text: "go".to_string(),
+        };
+        let wire = req.to_wire();
+        let v: serde_json::Value = serde_json::from_str(&wire).unwrap();
+        assert_eq!(v["op"], "reply");
+        assert_eq!(v["text"], "go");
+        // Negative: must NOT serialize as "message" / "prompt" / "input"
+        // — those were rejected by the daemon during probing.
+        assert!(v.get("message").is_none());
+    }
+
+    #[test]
+    fn parse_kill_ok_reply() {
+        let reply: OneShotReply = serde_json::from_str(
+            r#"{"ok":true,"op":"kill"}"#
+        ).unwrap();
+        assert!(reply.ok);
+        assert_eq!(reply.op.as_deref(), Some("kill"));
+    }
+
+    #[test]
+    fn parse_error_reply() {
+        let reply: OneShotReply = serde_json::from_str(
+            r#"{"ok":false,"error":"malformed request: Invalid input","code":"EUNKNOWN"}"#
+        ).unwrap();
+        assert!(!reply.ok);
+        assert_eq!(reply.error.as_deref(), Some("malformed request: Invalid input"));
+    }
+
+    #[test]
+    fn parse_state_event_with_blocked() {
+        let raw = r#"{"type":"state","patch":{"state":"blocked","tempo":"blocked","needs":"user input"}}"#;
+        let ev: SubscribeEvent = serde_json::from_str(raw).unwrap();
+        match ev {
+            SubscribeEvent::State { patch } => {
+                assert_eq!(patch.state.as_deref(), Some("blocked"));
+                assert_eq!(patch.needs.as_deref(), Some("user input"));
+            }
+            _ => panic!("expected State event"),
+        }
+    }
+
+    #[test]
+    fn parse_pid_only_state_event() {
+        // From Phase 0: mid-turn the daemon sometimes emits pid-only patches.
+        // Must parse without error; state/tempo will be None.
+        let raw = r#"{"type":"state","patch":{"pid":28418}}"#;
+        let ev: SubscribeEvent = serde_json::from_str(raw).unwrap();
+        match ev {
+            SubscribeEvent::State { patch } => {
+                assert_eq!(patch.pid, Some(28418));
+                assert!(patch.state.is_none());
+            }
+            _ => panic!("expected State event"),
+        }
+    }
+
+    #[test]
+    fn parse_stream_event_discarded() {
+        let raw = r#"{"type":"stream","line":"[2J[H"}"#;
+        let ev: SubscribeEvent = serde_json::from_str(raw).unwrap();
+        assert!(matches!(ev, SubscribeEvent::Stream { .. }));
+    }
+}

--- a/src-tauri/src/cli/mod.rs
+++ b/src-tauri/src/cli/mod.rs
@@ -153,6 +153,10 @@ pub enum Commands {
         model: Option<String>,
         #[arg(long)]
         add_dir: Vec<String>,
+        /// Initial prompt sent at spawn time. REQUIRED for bg backend (CC >= 2.1.150).
+        /// PrintBackend ignores this — prompts come via `c9watch send` after spawn.
+        #[arg(long)]
+        prompt: Option<String>,
     },
 
     /// Send a message to a spawned worker session
@@ -267,6 +271,7 @@ pub fn run(cli: Cli) {
             permission_mode,
             model,
             add_dir,
+            prompt,
         } => (|| -> Result<(), String> {
             let resolved_cwd = match cwd {
                 Some(c) => c,
@@ -283,7 +288,7 @@ pub fn run(cli: Cli) {
                 model,
                 add_dirs: add_dir,
             };
-            pm::cmd_spawn(args, append_system_prompt_file, cli.pretty)
+            pm::cmd_spawn(args, append_system_prompt_file, prompt, cli.pretty)
         })(),
         Commands::Send {
             session_id,

--- a/src-tauri/src/cli/mod.rs
+++ b/src-tauri/src/cli/mod.rs
@@ -20,6 +20,7 @@ pub enum CostSortDir {
 pub mod adoption;
 pub mod bg_backend;
 pub mod bg_protocol;
+pub mod worker_backend;
 pub mod pm;
 pub mod pm_caller;
 pub mod pm_daemon;

--- a/src-tauri/src/cli/mod.rs
+++ b/src-tauri/src/cli/mod.rs
@@ -18,6 +18,7 @@ pub enum CostSortDir {
 }
 
 pub mod adoption;
+pub mod bg_backend;
 pub mod bg_protocol;
 pub mod pm;
 pub mod pm_caller;

--- a/src-tauri/src/cli/mod.rs
+++ b/src-tauri/src/cli/mod.rs
@@ -18,6 +18,7 @@ pub enum CostSortDir {
 }
 
 pub mod adoption;
+pub mod bg_protocol;
 pub mod pm;
 pub mod pm_caller;
 pub mod pm_daemon;

--- a/src-tauri/src/cli/pm.rs
+++ b/src-tauri/src/cli/pm.rs
@@ -134,6 +134,7 @@ fn daemon_rpc(request: &RpcRequest, timeout: Duration) -> Result<serde_json::Val
 pub fn cmd_spawn(
     args: SpawnArgs,
     append_system_prompt_file: Option<String>,
+    initial_prompt: Option<String>,
     pretty: bool,
 ) -> Result<(), String> {
     ensure_daemon()?;
@@ -173,6 +174,7 @@ pub fn cmd_spawn(
         add_dirs: args.add_dirs,
         spawned_by,
         pm_pid,
+        initial_prompt,
     };
 
     let response = daemon_rpc(&request, Duration::from_secs(30))?;

--- a/src-tauri/src/cli/pm_daemon.rs
+++ b/src-tauri/src/cli/pm_daemon.rs
@@ -1,6 +1,7 @@
 use crate::cli::pm_fs;
 use crate::cli::pm_rpc::RpcRequest;
-use crate::cli::pm_worker::{SpawnArgs, SpawnContext, WorkerHandle};
+use crate::cli::pm_worker::{AnyWorkerHandle, BgWorkerHandle, SpawnArgs, SpawnContext, WorkerHandle};
+use crate::cli::worker_backend::{select_backend, BackendKind};
 use std::collections::HashMap;
 use std::sync::Arc;
 use std::time::Duration;
@@ -11,7 +12,7 @@ use tokio::sync::Mutex;
 const DEFAULT_MAX_WORKERS: usize = 16;
 
 struct DaemonState {
-    workers: HashMap<String, WorkerHandle>,
+    workers: HashMap<String, AnyWorkerHandle>,
 }
 
 fn err_response(code: &str) -> serde_json::Value {
@@ -253,15 +254,28 @@ async fn handle_spawn(
     let spawned_by = ctx.spawned_by.clone();
     let canonical_cwd = args.cwd.clone();
 
-    // Spawn the worker
-    let worker = match WorkerHandle::spawn(session_id.clone(), args, ctx).await {
-        Ok(w) => w,
-        Err(e) => return err_response(&e),
+    // Spawn the worker via the selected backend. PrintBackend is the legacy
+    // path; BgBackend uses `claude --bg` + control.sock RPC.
+    let worker: AnyWorkerHandle = match select_backend() {
+        BackendKind::Bg => {
+            // Task 10 will add a proper `initial_prompt` field to
+            // RpcRequest::Spawn. For now, auto-inject "ready" as a stopgap
+            // so the existing CLI surface keeps working with the bg backend.
+            let initial_prompt = "ready".to_string();
+            match BgWorkerHandle::spawn(session_id.clone(), args, ctx, initial_prompt).await {
+                Ok(w) => AnyWorkerHandle::Bg(w),
+                Err(e) => return err_response(&e),
+            }
+        }
+        BackendKind::Print => match WorkerHandle::spawn(session_id.clone(), args, ctx).await {
+            Ok(w) => AnyWorkerHandle::Print(w),
+            Err(e) => return err_response(&e),
+        },
     };
 
-    let pid = worker.meta.pid;
-    let worker_name = worker.meta.name.clone();
-    let spawned_at = worker.meta.spawned_at.clone();
+    let pid = worker.meta().pid;
+    let worker_name = worker.meta().name.clone();
+    let spawned_at = worker.meta().spawned_at.clone();
 
     // Insert into state while holding the lock across the cap check so two
     // concurrent spawns cannot both read "count < max" and both proceed (H4).
@@ -334,7 +348,10 @@ async fn handle_send(
 
     // Send the message under the lock, then release it before awaiting the
     // turn result so other RPCs aren't blocked for up to `timeout_ms`.
-    let (rx_opt, callback_inbox) = {
+    //
+    // For Bg backend: no mpsc receiver to take — `wait_for_turn` consumes the
+    // subscribe broadcast directly. We branch below.
+    let (rx_opt, callback_inbox, is_bg) = {
         let mut st = state.lock().await;
         let worker = match st.workers.get_mut(&full_id) {
             Some(w) => w,
@@ -344,7 +361,8 @@ async fn handle_send(
             return err_response(&e);
         }
         let callback_inbox = callback_inbox_hint(&full_id);
-        let rx = if wait && timeout_ms > 0 {
+        let is_bg = matches!(worker, AnyWorkerHandle::Bg(_));
+        let rx = if wait && timeout_ms > 0 && !is_bg {
             match worker.take_result_receiver() {
                 Some(r) => Some(r),
                 None => {
@@ -356,7 +374,7 @@ async fn handle_send(
         } else {
             None
         };
-        (rx, callback_inbox)
+        (rx, callback_inbox, is_bg)
     };
 
     if !wait || timeout_ms == 0 {
@@ -368,11 +386,65 @@ async fn handle_send(
         });
     }
 
-    // rx_opt is Some here because wait && timeout_ms > 0
-    let mut rx = rx_opt.expect("rx must be Some when wait && timeout_ms > 0");
+    let timeout = Duration::from_millis(timeout_ms);
+
+    if is_bg {
+        // Bg backend: there is no mpsc receiver — `wait_for_turn` consumes
+        // events from the broadcast subscribe channel that lives on the
+        // BgWorkerHandle. To avoid holding the daemon state lock across a
+        // potentially long await (which would block all other RPCs for up
+        // to `timeout_ms`), the wait_for_turn future runs UNDER the lock.
+        //
+        // This is a known concern: we accept that Bg --wait serializes the
+        // daemon during the wait. Acceptable because the bg worker can only
+        // service one prompt at a time anyway, so concurrent --wait against
+        // the same worker would race regardless. Print backend remains lock-
+        // free via the receiver-take pattern.
+        let mut st = state.lock().await;
+        let worker = match st.workers.get_mut(&full_id) {
+            Some(w) => w,
+            None => return err_response("WORKER_CRASHED"),
+        };
+        let result = worker.wait_for_turn(timeout).await;
+        let still_alive = worker.is_alive();
+        drop(st);
+
+        return match result {
+            Ok(turn) => serde_json::json!({
+                "ok": true,
+                "sessionId": full_id,
+                "sent": true,
+                "turnCompleted": true,
+                "assistantText": turn.assistant_text,
+                "endedAt": turn.ended_at,
+                "callbackInbox": callback_inbox,
+            }),
+            Err(e) if e == "WAIT_TIMEOUT" && !still_alive => serde_json::json!({
+                "ok": false,
+                "error": "WORKER_CRASHED",
+                "sessionId": full_id,
+                "callbackInbox": callback_inbox,
+            }),
+            Err(e) if e == "WAIT_TIMEOUT" => serde_json::json!({
+                "ok": true,
+                "sessionId": full_id,
+                "sent": true,
+                "turnCompleted": false,
+                "callbackInbox": callback_inbox,
+            }),
+            Err(e) => serde_json::json!({
+                "ok": false,
+                "error": e,
+                "sessionId": full_id,
+            }),
+        };
+    }
+
+    // Print backend: existing receiver-based wait path.
+    // rx_opt is Some here because wait && timeout_ms > 0 && !is_bg
+    let mut rx = rx_opt.expect("rx must be Some when wait && timeout_ms > 0 && !is_bg");
 
     // Await the turn result WITHOUT holding the state lock
-    let timeout = Duration::from_millis(timeout_ms);
     let turn_result = tokio::time::timeout(timeout, rx.recv()).await;
 
     // Return the receiver (and peek worker liveness) so the worker can be used
@@ -440,14 +512,15 @@ async fn handle_list(state: Arc<Mutex<DaemonState>>) -> serde_json::Value {
         .iter_mut()
         .map(|(session_id, worker)| {
             let alive = worker.is_alive();
+            let meta = worker.meta();
             serde_json::json!({
                 "sessionId": session_id,
-                "pid": worker.meta.pid,
-                "name": worker.meta.name,
-                "cwd": worker.meta.cwd,
-                "spawnedAt": worker.meta.spawned_at,
-                "spawnedBy": worker.meta.spawned_by,
-                "pmPid": worker.meta.pm_pid,
+                "pid": meta.pid,
+                "name": meta.name,
+                "cwd": meta.cwd,
+                "spawnedAt": meta.spawned_at,
+                "spawnedBy": meta.spawned_by,
+                "pmPid": meta.pm_pid,
                 "alive": alive,
             })
         })
@@ -544,7 +617,7 @@ async fn shutdown_daemon(state: Arc<Mutex<DaemonState>>) -> ! {
 /// - 0 matches → WORKER_NOT_FOUND error.
 /// - 2+ matches → AMBIGUOUS_SESSION_ID error.
 fn resolve_worker_id(
-    workers: &HashMap<String, WorkerHandle>,
+    workers: &HashMap<String, AnyWorkerHandle>,
     prefix: &str,
 ) -> Result<String, String> {
     resolve_worker_id_from_keys(workers.keys().map(|k| k.as_str()), prefix)
@@ -595,19 +668,16 @@ async fn handle_workers_all(
         .iter_mut()
         .map(|(session_id, worker)| {
             let alive = worker.is_alive();
-            let status = resolve_status(
-                &worker.meta,
-                caller_pm_pid,
-                caller_pm_session_id.as_deref(),
-            );
+            let meta = worker.meta();
+            let status = resolve_status(meta, caller_pm_pid, caller_pm_session_id.as_deref());
             serde_json::json!({
                 "sessionId": session_id,
-                "pid": worker.meta.pid,
-                "name": worker.meta.name,
-                "cwd": worker.meta.cwd,
-                "spawnedAt": worker.meta.spawned_at,
-                "spawnedBy": worker.meta.spawned_by,
-                "pmPid": worker.meta.pm_pid,
+                "pid": meta.pid,
+                "name": meta.name,
+                "cwd": meta.cwd,
+                "spawnedAt": meta.spawned_at,
+                "spawnedBy": meta.spawned_by,
+                "pmPid": meta.pm_pid,
                 "alive": alive,
                 "status": status.as_str(),
             })
@@ -710,7 +780,7 @@ async fn handle_inbox_read(
                 .iter()
                 .filter_map(|(id, w)| {
                     let status = resolve_status(
-                        &w.meta,
+                        w.meta(),
                         caller_pm_pid,
                         Some(&caller_pm_session_id),
                     );

--- a/src-tauri/src/cli/pm_daemon.rs
+++ b/src-tauri/src/cli/pm_daemon.rs
@@ -1,7 +1,7 @@
 use crate::cli::pm_fs;
 use crate::cli::pm_rpc::RpcRequest;
 use crate::cli::pm_worker::{AnyWorkerHandle, BgWorkerHandle, SpawnArgs, SpawnContext, WorkerHandle};
-use crate::cli::worker_backend::{select_backend, BackendKind};
+use crate::cli::worker_backend::{select_backend, validate_initial_prompt, BackendKind};
 use std::collections::HashMap;
 use std::sync::Arc;
 use std::time::Duration;
@@ -139,6 +139,7 @@ async fn handle_connection(
             add_dirs,
             spawned_by,
             pm_pid,
+            initial_prompt,
         } => {
             let args = SpawnArgs {
                 cwd,
@@ -149,7 +150,7 @@ async fn handle_connection(
                 add_dirs,
             };
             let ctx = SpawnContext { spawned_by, pm_pid };
-            handle_spawn(state, args, ctx, max_workers).await
+            handle_spawn(state, args, ctx, initial_prompt, max_workers).await
         }
         RpcRequest::Send {
             session_id,
@@ -225,6 +226,7 @@ async fn handle_spawn(
     state: Arc<Mutex<DaemonState>>,
     mut args: SpawnArgs,
     ctx: SpawnContext,
+    initial_prompt: Option<String>,
     max_workers: usize,
 ) -> serde_json::Value {
     // Validate and canonicalize --cwd + each --add-dir before acquiring the
@@ -254,15 +256,20 @@ async fn handle_spawn(
     let spawned_by = ctx.spawned_by.clone();
     let canonical_cwd = args.cwd.clone();
 
+    // Validate the initial prompt against the selected backend. Bg backend
+    // requires a non-empty prompt; Print backend ignores it.
+    let backend = select_backend();
+    let resolved_prompt = match validate_initial_prompt(backend, initial_prompt) {
+        Ok(p) => p,
+        Err(e) => return err_response(&e),
+    };
+
     // Spawn the worker via the selected backend. PrintBackend is the legacy
     // path; BgBackend uses `claude --bg` + control.sock RPC.
-    let worker: AnyWorkerHandle = match select_backend() {
+    let worker: AnyWorkerHandle = match backend {
         BackendKind::Bg => {
-            // Task 10 will add a proper `initial_prompt` field to
-            // RpcRequest::Spawn. For now, auto-inject "ready" as a stopgap
-            // so the existing CLI surface keeps working with the bg backend.
-            let initial_prompt = "ready".to_string();
-            match BgWorkerHandle::spawn(session_id.clone(), args, ctx, initial_prompt).await {
+            let prompt = resolved_prompt.expect("validate_initial_prompt guarantees Some for Bg");
+            match BgWorkerHandle::spawn(session_id.clone(), args, ctx, prompt).await {
                 Ok(w) => AnyWorkerHandle::Bg(w),
                 Err(e) => return err_response(&e),
             }

--- a/src-tauri/src/cli/pm_daemon.rs
+++ b/src-tauri/src/cli/pm_daemon.rs
@@ -1,6 +1,8 @@
 use crate::cli::pm_fs;
 use crate::cli::pm_rpc::RpcRequest;
-use crate::cli::pm_worker::{AnyWorkerHandle, BgWorkerHandle, SpawnArgs, SpawnContext, WorkerHandle};
+use crate::cli::pm_worker::{
+    AnyWorkerHandle, BgWorkerHandle, SpawnArgs, SpawnContext, WorkerHandle,
+};
 use crate::cli::worker_backend::{select_backend, validate_initial_prompt, BackendKind};
 use std::collections::HashMap;
 use std::sync::Arc;
@@ -96,11 +98,7 @@ pub async fn run_daemon() -> Result<(), String> {
 
 // ── Connection handler ────────────────────────────────────────────────────────
 
-async fn handle_connection(
-    stream: UnixStream,
-    state: Arc<Mutex<DaemonState>>,
-    max_workers: usize,
-) {
+async fn handle_connection(stream: UnixStream, state: Arc<Mutex<DaemonState>>, max_workers: usize) {
     let (read_half, mut write_half) = tokio::io::split(stream);
     let mut reader = BufReader::new(read_half);
     let mut line = String::new();
@@ -166,7 +164,16 @@ async fn handle_connection(
             force,
             caller_pm_session_id,
             caller_pm_pid,
-        } => handle_adopt(state, session_id, force, caller_pm_session_id, caller_pm_pid).await,
+        } => {
+            handle_adopt(
+                state,
+                session_id,
+                force,
+                caller_pm_session_id,
+                caller_pm_pid,
+            )
+            .await
+        }
         RpcRequest::WorkersAll {
             caller_pm_session_id,
             caller_pm_pid,
@@ -283,6 +290,12 @@ async fn handle_spawn(
     let pid = worker.meta().pid;
     let worker_name = worker.meta().name.clone();
     let spawned_at = worker.meta().spawned_at.clone();
+    // Bg backend rewrites session_id to CC's actual UUID inside spawn (CC
+    // ignores `--session-id` for bg sessions). From here on, the meta's
+    // session_id is canonical — use it for the state map key and the
+    // response. The pre-spawn `session_id` (still owned by us) was only a
+    // placeholder for the Bg path; the Print path still uses it unchanged.
+    let effective_session_id = worker.meta().session_id.clone();
 
     // Insert into state while holding the lock across the cap check so two
     // concurrent spawns cannot both read "count < max" and both proceed (H4).
@@ -294,7 +307,7 @@ async fn handle_spawn(
             let _ = w.kill().await;
             return err_response("TOO_MANY_WORKERS");
         }
-        st.workers.insert(session_id.clone(), worker);
+        st.workers.insert(effective_session_id.clone(), worker);
     }
 
     // Wait for worker readiness (first stdout event) before returning.
@@ -307,7 +320,7 @@ async fn handle_spawn(
     // is held only for the duration of that single .await.
     let ready_result = {
         let mut st = state.lock().await;
-        if let Some(worker) = st.workers.get_mut(&session_id) {
+        if let Some(worker) = st.workers.get_mut(&effective_session_id) {
             worker.wait_ready(Duration::from_secs(15)).await
         } else {
             Err("Worker disappeared immediately after insert".to_string())
@@ -317,17 +330,17 @@ async fn handle_spawn(
     if let Err(e) = ready_result {
         // Worker failed to initialize — clean up
         let mut st = state.lock().await;
-        if let Some(mut w) = st.workers.remove(&session_id) {
+        if let Some(mut w) = st.workers.remove(&effective_session_id) {
             let _ = w.kill().await;
         }
         return err_response(&format!("SPAWN_FAILED: {}", e));
     }
 
-    let callback_inbox = callback_inbox_hint(&session_id);
+    let callback_inbox = callback_inbox_hint(&effective_session_id);
 
     serde_json::json!({
         "ok": true,
-        "sessionId": session_id,
+        "sessionId": effective_session_id,
         "pid": pid,
         "name": worker_name,
         "cwd": canonical_cwd,
@@ -507,7 +520,13 @@ async fn handle_list(state: Arc<Mutex<DaemonState>>) -> serde_json::Value {
     let dead: Vec<String> = st
         .workers
         .iter_mut()
-        .filter_map(|(id, worker)| if worker.is_alive() { None } else { Some(id.clone()) })
+        .filter_map(|(id, worker)| {
+            if worker.is_alive() {
+                None
+            } else {
+                Some(id.clone())
+            }
+        })
         .collect();
     for id in dead {
         st.workers.remove(&id);
@@ -567,15 +586,15 @@ fn cleanup_worker_dir(session_id: &str) {
         Ok(dir) => {
             if let Err(e) = std::fs::remove_dir_all(&dir) {
                 if e.kind() != std::io::ErrorKind::NotFound {
-                    eprintln!(
-                        "[pm_daemon] Failed to remove worker dir {:?}: {}",
-                        dir, e
-                    );
+                    eprintln!("[pm_daemon] Failed to remove worker dir {:?}: {}", dir, e);
                 }
             }
         }
         Err(e) => {
-            eprintln!("[pm_daemon] Cannot resolve worker dir for {}: {}", session_id, e);
+            eprintln!(
+                "[pm_daemon] Cannot resolve worker dir for {}: {}",
+                session_id, e
+            );
         }
     }
 }
@@ -594,7 +613,10 @@ async fn shutdown_daemon(state: Arc<Mutex<DaemonState>>) -> ! {
         let mut ids = Vec::with_capacity(st.workers.len());
         for (id, mut worker) in st.workers.drain() {
             if let Err(e) = worker.kill().await {
-                eprintln!("[pm_daemon] Failed to kill worker {} during shutdown: {}", id, e);
+                eprintln!(
+                    "[pm_daemon] Failed to kill worker {} during shutdown: {}",
+                    id, e
+                );
             }
             ids.push(id);
         }
@@ -786,11 +808,8 @@ async fn handle_inbox_read(
             st.workers
                 .iter()
                 .filter_map(|(id, w)| {
-                    let status = resolve_status(
-                        w.meta(),
-                        caller_pm_pid,
-                        Some(&caller_pm_session_id),
-                    );
+                    let status =
+                        resolve_status(w.meta(), caller_pm_pid, Some(&caller_pm_session_id));
                     if status == WorkerStatus::OwnedByYou {
                         Some(id.clone())
                     } else {
@@ -1045,7 +1064,11 @@ mod tests {
             "expected 'does not exist', got: {}",
             err
         );
-        assert!(err.contains("/this/path/definitely/does/not/exist/h5test"), "path should appear in error: {}", err);
+        assert!(
+            err.contains("/this/path/definitely/does/not/exist/h5test"),
+            "path should appear in error: {}",
+            err
+        );
     }
 
     #[test]
@@ -1115,16 +1138,14 @@ mod tests {
 
         rt.block_on(async {
             // Step 1: bind socket
-            let _listener = UnixListener::bind(&sock_path)
-                .expect("bind Unix socket");
+            let _listener = UnixListener::bind(&sock_path).expect("bind Unix socket");
 
             // Assert: socket exists, pid file does NOT yet
             assert!(sock_path.exists(), "socket must exist after bind");
             assert!(!pid_path.exists(), "pid file must not exist before write");
 
             // Step 2: write pid file
-            fs::write(&pid_path, std::process::id().to_string())
-                .expect("write pid file");
+            fs::write(&pid_path, std::process::id().to_string()).expect("write pid file");
 
             // Assert: both now exist in the correct causal order
             assert!(sock_path.exists(), "socket still exists after pid write");

--- a/src-tauri/src/cli/pm_inbox.rs
+++ b/src-tauri/src/cli/pm_inbox.rs
@@ -30,6 +30,10 @@ pub struct InboxEvent {
     pub result_excerpt: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub error_message: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub awaiting_needs: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub awaiting_detail: Option<String>,
 }
 
 #[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
@@ -38,6 +42,7 @@ pub enum EventStatus {
     Done,
     Error,
     Crashed,
+    Awaiting,
 }
 
 /// Fields that vary between normal turn-end outcomes (success or error)
@@ -71,6 +76,8 @@ impl InboxEvent {
             total_cost_usd: tr.total_cost_usd,
             result_excerpt: tr.result_excerpt,
             error_message: tr.error_message,
+            awaiting_needs: None,
+            awaiting_detail: None,
         }
     }
 
@@ -88,6 +95,33 @@ impl InboxEvent {
             total_cost_usd: None,
             result_excerpt: None,
             error_message: Some(error_message),
+            awaiting_needs: None,
+            awaiting_detail: None,
+        }
+    }
+
+    /// Worker bg session transitioned to `state:"blocked"` — waiting on user input.
+    /// Specific to the bg backend; print backend never emits this.
+    pub fn awaiting(
+        worker_session_id: &str,
+        spawned_by: &str,
+        needs: String,
+        detail: Option<String>,
+    ) -> Self {
+        Self {
+            event_id: new_event_id(),
+            session_id: worker_session_id.to_string(),
+            spawned_by: spawned_by.to_string(),
+            status: EventStatus::Awaiting,
+            finished_at: Utc::now().to_rfc3339(),
+            duration_ms: None,
+            num_turns: None,
+            stop_reason: None,
+            total_cost_usd: None,
+            result_excerpt: None,
+            error_message: None,
+            awaiting_needs: Some(needs),
+            awaiting_detail: detail,
         }
     }
 }
@@ -258,6 +292,8 @@ mod tests {
             total_cost_usd: Some(0.01),
             result_excerpt: Some("ok".to_string()),
             error_message: None,
+            awaiting_needs: None,
+            awaiting_detail: None,
         }
     }
 
@@ -354,5 +390,21 @@ mod tests {
         let char_count = t.chars().count();
         assert_eq!(char_count, EXCERPT_LIMIT + 1); // +1 for the ellipsis
         assert!(t.ends_with('…'));
+    }
+
+    #[test]
+    fn awaiting_event_serializes_with_needs() {
+        let w = TestWorker::new();
+        let ev = InboxEvent::awaiting(
+            w.id(),
+            "session-pm-abc",
+            "user input on file overwrite".to_string(),
+            Some("waiting for confirmation".to_string()),
+        );
+        let json = serde_json::to_string(&ev).unwrap();
+        assert!(json.contains("\"awaiting\""), "status missing: {}", json);
+        assert!(json.contains("user input on file overwrite"));
+        assert!(json.contains("waiting for confirmation"));
+        assert_eq!(ev.status, EventStatus::Awaiting);
     }
 }

--- a/src-tauri/src/cli/pm_rpc.rs
+++ b/src-tauri/src/cli/pm_rpc.rs
@@ -22,6 +22,8 @@ pub enum RpcRequest {
         spawned_by: Option<String>,
         #[serde(rename = "pmPid", default)]
         pm_pid: Option<u32>,
+        #[serde(rename = "initialPrompt", default)]
+        initial_prompt: Option<String>,
     },
     #[serde(rename = "send")]
     Send {
@@ -145,6 +147,7 @@ mod tests {
             add_dirs: vec![],
             spawned_by: Some("pm-session-abc".to_string()),
             pm_pid: Some(42),
+            initial_prompt: None,
         };
         let json = serde_json::to_string(&req).expect("serialize should succeed");
         assert!(json.contains("\"op\":\"spawn\""), "should contain op:spawn, got: {}", json);

--- a/src-tauri/src/cli/pm_worker.rs
+++ b/src-tauri/src/cli/pm_worker.rs
@@ -279,7 +279,6 @@ pub struct BgWorkerHandle {
     events_rx: Option<tokio::sync::broadcast::Receiver<SubscribeEvent>>,
     #[allow(dead_code)]
     ready_fired: bool,
-    inbox_ctx: Option<InboxContext>,
 }
 
 impl BgWorkerHandle {
@@ -328,13 +327,24 @@ impl BgWorkerHandle {
             spawned_by: pm.clone(),
         });
 
+        // Spawn a long-lived settle-watcher that fans out inbox events on every
+        // turn end regardless of whether a `--wait` caller is listening. Without
+        // this, PM-owned bg workers only emit Done/Awaiting events when a `send
+        // --wait` happens to be in flight — spawn-time prompts and non-waiting
+        // sends would silently miss completions.
+        if let Some(ref ctx) = inbox_ctx {
+            let watcher_rx = events_rx.resubscribe();
+            let ctx = ctx.clone();
+            let short_owned = short.clone();
+            tokio::spawn(settle_watcher_task(watcher_rx, ctx, short_owned));
+        }
+
         Ok(BgWorkerHandle {
             meta,
             short,
             sock_path,
             events_rx: Some(events_rx),
             ready_fired: false,
-            inbox_ctx,
         })
     }
 
@@ -417,9 +427,13 @@ impl BgWorkerHandle {
     }
 
     fn build_turn_result(&self, det: &SettleDetector) -> TurnResult {
+        // Inbox event emission lives in `settle_watcher_task`, which has a
+        // dedicated subscribe-receiver and fires on EVERY settle (not just
+        // when a `--wait` caller is listening). This function only constructs
+        // the TurnResult for the optional `--wait` consumer.
         let assistant_text = det.detail().map(String::from).unwrap_or_default();
-        let tr = TurnResult {
-            assistant_text: assistant_text.clone(),
+        TurnResult {
+            assistant_text,
             ended_at: Utc::now().to_rfc3339(),
             subtype: det.last_settled_state().map(String::from),
             is_error: false,
@@ -428,48 +442,7 @@ impl BgWorkerHandle {
             stop_reason: det.last_settled_state().map(String::from),
             total_cost_usd: None,
             result_text: det.detail().map(String::from),
-        };
-        if let Some(ref ctx) = self.inbox_ctx {
-            use crate::cli::pm_inbox;
-            let ev = match det.last_settled_state() {
-                Some("blocked") => {
-                    let needs = det.needs().unwrap_or("user input").to_string();
-                    pm_inbox::InboxEvent::awaiting(
-                        &ctx.session_id,
-                        &ctx.spawned_by,
-                        needs,
-                        det.detail().map(String::from),
-                    )
-                }
-                _ => {
-                    // Normal turn end (done) or unrecognized settle — emit a
-                    // Done event mirroring the print backend's contract so PM
-                    // inbox listeners see the worker completed a turn.
-                    let excerpt = if assistant_text.is_empty() {
-                        None
-                    } else {
-                        Some(pm_inbox::truncate_excerpt(&assistant_text))
-                    };
-                    pm_inbox::InboxEvent::from_turn_result(
-                        &ctx.session_id,
-                        &ctx.spawned_by,
-                        pm_inbox::TurnResult {
-                            status: pm_inbox::EventStatus::Done,
-                            duration_ms: None,
-                            num_turns: None,
-                            stop_reason: det.last_settled_state().map(String::from),
-                            total_cost_usd: None,
-                            result_excerpt: excerpt,
-                            error_message: None,
-                        },
-                    )
-                }
-            };
-            if let Err(e) = pm_inbox::write_event(&ev) {
-                eprintln!("[pm_worker bg] inbox write: {}", e);
-            }
         }
-        tr
     }
 
     pub async fn wait_ready(&mut self, _timeout: Duration) -> Result<(), String> {
@@ -508,6 +481,104 @@ impl BgWorkerHandle {
             let _ = Command::new("claude").arg("rm").arg(&short).output().await;
         });
         Ok(())
+    }
+}
+
+/// Long-lived task: drains a dedicated subscribe-receiver and emits an inbox
+/// event (Done or Awaiting) on every settle transition. Runs for the worker's
+/// lifetime; exits when the subscribe stream EOFs (worker killed) or the
+/// channel lags out. Only spawned when the worker has a `spawned_by` PM.
+async fn settle_watcher_task(
+    mut rx: tokio::sync::broadcast::Receiver<SubscribeEvent>,
+    ctx: InboxContext,
+    short: String,
+) {
+    use crate::cli::pm_inbox;
+    let mut det = SettleDetector::new();
+    // Tracks the last state the detector reported as settled, so we only emit
+    // on transitions INTO a settled state (not while staying settled).
+    let mut last_emitted: Option<String> = None;
+    loop {
+        let ev = match rx.recv().await {
+            Ok(e) => e,
+            Err(tokio::sync::broadcast::error::RecvError::Closed) => break,
+            Err(tokio::sync::broadcast::error::RecvError::Lagged(n)) => {
+                eprintln!(
+                    "[pm_worker bg/{}] settle_watcher lagged {} events; resetting detector",
+                    short, n
+                );
+                det = SettleDetector::new();
+                last_emitted = None;
+                continue;
+            }
+        };
+        match ev {
+            SubscribeEvent::Snapshot { ref record, .. } => {
+                let nested = record.get("currentState").and_then(|v| {
+                    serde_json::from_value::<crate::cli::bg_protocol::StatePatch>(v.clone()).ok()
+                });
+                let from_record = serde_json::from_value::<crate::cli::bg_protocol::StatePatch>(
+                    record.clone(),
+                )
+                .ok();
+                if let Some(p) = nested {
+                    det.apply_patch(&p);
+                }
+                if let Some(p) = from_record {
+                    det.apply_patch(&p);
+                }
+            }
+            SubscribeEvent::State { ref patch } => {
+                det.apply_patch(patch);
+            }
+            SubscribeEvent::Stream { .. } => continue,
+        }
+        let current = det.last_settled_state().map(String::from);
+        if !det.is_settled() {
+            // Left the settled state — arm re-detection so the NEXT settle fires.
+            last_emitted = None;
+            continue;
+        }
+        if last_emitted == current {
+            // Same settle as before; don't re-emit.
+            continue;
+        }
+        let ev_to_write = match current.as_deref() {
+            Some("blocked") => {
+                let needs = det.needs().unwrap_or("user input").to_string();
+                pm_inbox::InboxEvent::awaiting(
+                    &ctx.session_id,
+                    &ctx.spawned_by,
+                    needs,
+                    det.detail().map(String::from),
+                )
+            }
+            _ => {
+                let assistant_text = det.detail().map(String::from).unwrap_or_default();
+                let excerpt = if assistant_text.is_empty() {
+                    None
+                } else {
+                    Some(pm_inbox::truncate_excerpt(&assistant_text))
+                };
+                pm_inbox::InboxEvent::from_turn_result(
+                    &ctx.session_id,
+                    &ctx.spawned_by,
+                    pm_inbox::TurnResult {
+                        status: pm_inbox::EventStatus::Done,
+                        duration_ms: None,
+                        num_turns: None,
+                        stop_reason: current.clone(),
+                        total_cost_usd: None,
+                        result_excerpt: excerpt,
+                        error_message: None,
+                    },
+                )
+            }
+        };
+        if let Err(e) = pm_inbox::write_event(&ev_to_write) {
+            eprintln!("[pm_worker bg/{}] settle_watcher inbox write: {}", short, e);
+        }
+        last_emitted = current;
     }
 }
 

--- a/src-tauri/src/cli/pm_worker.rs
+++ b/src-tauri/src/cli/pm_worker.rs
@@ -380,11 +380,26 @@ impl BgWorkerHandle {
 
             match ev {
                 SubscribeEvent::Snapshot { record, .. } => {
-                    if let Some(patch) = record.get("currentState").and_then(|v| {
-                        serde_json::from_value::<crate::cli::bg_protocol::StatePatch>(v.clone())
-                            .ok()
-                    }) {
-                        det.apply_patch(&patch);
+                    // Try nested `currentState` object first (some daemon versions
+                    // wrap state under it); fall back to top-level fields on the
+                    // record itself (`record.state`, `record.tempo`, ...), which
+                    // is what the round-trip PoC observed and what the integration
+                    // test exercises.
+                    let nested = record
+                        .get("currentState")
+                        .and_then(|v| {
+                            serde_json::from_value::<crate::cli::bg_protocol::StatePatch>(v.clone())
+                                .ok()
+                        });
+                    let from_record = serde_json::from_value::<crate::cli::bg_protocol::StatePatch>(
+                        record.clone(),
+                    )
+                    .ok();
+                    if let Some(p) = nested {
+                        det.apply_patch(&p);
+                    }
+                    if let Some(p) = from_record {
+                        det.apply_patch(&p);
                     }
                     if det.is_settled() {
                         return Ok(self.build_turn_result(&det));
@@ -402,8 +417,9 @@ impl BgWorkerHandle {
     }
 
     fn build_turn_result(&self, det: &SettleDetector) -> TurnResult {
+        let assistant_text = det.detail().map(String::from).unwrap_or_default();
         let tr = TurnResult {
-            assistant_text: String::new(),
+            assistant_text: assistant_text.clone(),
             ended_at: Utc::now().to_rfc3339(),
             subtype: det.last_settled_state().map(String::from),
             is_error: false,
@@ -413,20 +429,44 @@ impl BgWorkerHandle {
             total_cost_usd: None,
             result_text: det.detail().map(String::from),
         };
-        if det.last_settled_state() == Some("blocked") {
-            if let Some(ref ctx) = self.inbox_ctx {
-                if let Some(needs) = det.needs() {
-                    use crate::cli::pm_inbox;
-                    let ev = pm_inbox::InboxEvent::awaiting(
+        if let Some(ref ctx) = self.inbox_ctx {
+            use crate::cli::pm_inbox;
+            let ev = match det.last_settled_state() {
+                Some("blocked") => {
+                    let needs = det.needs().unwrap_or("user input").to_string();
+                    pm_inbox::InboxEvent::awaiting(
                         &ctx.session_id,
                         &ctx.spawned_by,
-                        needs.to_string(),
+                        needs,
                         det.detail().map(String::from),
-                    );
-                    if let Err(e) = pm_inbox::write_event(&ev) {
-                        eprintln!("[pm_worker bg] inbox awaiting write: {}", e);
-                    }
+                    )
                 }
+                _ => {
+                    // Normal turn end (done) or unrecognized settle — emit a
+                    // Done event mirroring the print backend's contract so PM
+                    // inbox listeners see the worker completed a turn.
+                    let excerpt = if assistant_text.is_empty() {
+                        None
+                    } else {
+                        Some(pm_inbox::truncate_excerpt(&assistant_text))
+                    };
+                    pm_inbox::InboxEvent::from_turn_result(
+                        &ctx.session_id,
+                        &ctx.spawned_by,
+                        pm_inbox::TurnResult {
+                            status: pm_inbox::EventStatus::Done,
+                            duration_ms: None,
+                            num_turns: None,
+                            stop_reason: det.last_settled_state().map(String::from),
+                            total_cost_usd: None,
+                            result_excerpt: excerpt,
+                            error_message: None,
+                        },
+                    )
+                }
+            };
+            if let Err(e) = pm_inbox::write_event(&ev) {
+                eprintln!("[pm_worker bg] inbox write: {}", e);
             }
         }
         tr

--- a/src-tauri/src/cli/pm_worker.rs
+++ b/src-tauri/src/cli/pm_worker.rs
@@ -184,7 +184,7 @@ impl WorkerHandle {
     }
 
     /// Send a user message to the worker's stdin.
-    pub async fn send_message(&self, text: &str) -> Result<(), String> {
+    pub async fn send_message(&mut self, text: &str) -> Result<(), String> {
         let (ack_tx, ack_rx) = oneshot::channel();
         self.stdin_tx
             .send(StdinMessage {
@@ -353,7 +353,23 @@ impl BgWorkerHandle {
         })
     }
 
-    pub async fn send_message(&self, text: &str) -> Result<(), String> {
+    pub async fn send_message(&mut self, text: &str) -> Result<(), String> {
+        // Drain any stale settle events buffered from prior turns (spawn-time
+        // prompt, earlier non-waiting sends). Otherwise the next wait_for_turn
+        // could immediately return a stale Done for the previous turn instead
+        // of waiting for the one we're about to send. Worker is idle right
+        // now (it just settled), so no NEW events can land between drain and
+        // RPC send — drain is safe and complete here.
+        if let Some(rx) = self.events_rx.as_mut() {
+            loop {
+                match rx.try_recv() {
+                    Ok(_) => continue,
+                    Err(tokio::sync::broadcast::error::TryRecvError::Empty) => break,
+                    Err(tokio::sync::broadcast::error::TryRecvError::Lagged(_)) => continue,
+                    Err(tokio::sync::broadcast::error::TryRecvError::Closed) => break,
+                }
+            }
+        }
         let reply = bg_backend::rpc(
             &self.sock_path,
             Request::Reply {
@@ -602,7 +618,7 @@ impl AnyWorkerHandle {
         }
     }
 
-    pub async fn send_message(&self, text: &str) -> Result<(), String> {
+    pub async fn send_message(&mut self, text: &str) -> Result<(), String> {
         match self {
             Self::Print(h) => h.send_message(text).await,
             Self::Bg(h) => h.send_message(text).await,

--- a/src-tauri/src/cli/pm_worker.rs
+++ b/src-tauri/src/cli/pm_worker.rs
@@ -300,11 +300,19 @@ impl BgWorkerHandle {
             .clone()
             .unwrap_or_else(|| format!("c9w-{}", &session_id[..8.min(session_id.len())]));
 
-        let short =
-            bg_backend::spawn_bg(&args, &session_id, &worker_name, &initial_prompt).await?;
+        let info = bg_backend::spawn_bg(&args, &session_id, &worker_name, &initial_prompt).await?;
+        let short = info.short;
+        // CC daemon assigns its own sessionId to bg-pinned sessions, ignoring
+        // the `--session-id` flag we passed. The detector matches sessions by
+        // CC's sessionId (from `claude agents --json`), so we MUST use it as
+        // the worker's identity everywhere downstream — meta.json,
+        // workers/<dir>, inbox/<dir>, and the daemon state map. The
+        // pre-generated `session_id` was a placeholder; from here on,
+        // `effective_session_id` is canonical.
+        let effective_session_id = info.cc_session_id;
 
         let meta = WorkerMeta {
-            session_id: session_id.clone(),
+            session_id: effective_session_id.clone(),
             // bg workers are daemon-managed; the CC daemon owns the actual PTY
             // pid. We can't take ownership of the subprocess here, so leave
             // pid=0 and rely on `claude agents --json` for live pid lookup
@@ -326,7 +334,7 @@ impl BgWorkerHandle {
         pm_fs::write_worker_meta(&meta)?;
 
         let inbox_ctx = ctx.spawned_by.as_ref().map(|pm| InboxContext {
-            session_id: session_id.clone(),
+            session_id: effective_session_id.clone(),
             spawned_by: pm.clone(),
         });
 
@@ -341,9 +349,7 @@ impl BgWorkerHandle {
         let events_rx = receivers.remove(0);
 
         if let Some(ref ctx) = inbox_ctx {
-            let watcher_rx = receivers
-                .pop()
-                .expect("subscribe(2) returned <2 receivers");
+            let watcher_rx = receivers.pop().expect("subscribe(2) returned <2 receivers");
             let ctx = ctx.clone();
             let short_owned = short.clone();
             tokio::spawn(settle_watcher_task(watcher_rx, ctx, short_owned));
@@ -432,10 +438,11 @@ impl BgWorkerHandle {
                         serde_json::from_value::<crate::cli::bg_protocol::StatePatch>(v.clone())
                             .ok()
                     });
-                    let from_record = serde_json::from_value::<crate::cli::bg_protocol::StatePatch>(
-                        record.clone(),
-                    )
-                    .ok();
+                    let from_record =
+                        serde_json::from_value::<crate::cli::bg_protocol::StatePatch>(
+                            record.clone(),
+                        )
+                        .ok();
                     if let Some(p) = nested {
                         patches.push(p);
                     }
@@ -568,10 +575,9 @@ async fn settle_watcher_task(
                 let nested = record.get("currentState").and_then(|v| {
                     serde_json::from_value::<crate::cli::bg_protocol::StatePatch>(v.clone()).ok()
                 });
-                let from_record = serde_json::from_value::<crate::cli::bg_protocol::StatePatch>(
-                    record.clone(),
-                )
-                .ok();
+                let from_record =
+                    serde_json::from_value::<crate::cli::bg_protocol::StatePatch>(record.clone())
+                        .ok();
                 if let Some(p) = nested {
                     det.apply_patch(&p);
                 }
@@ -722,7 +728,9 @@ async fn stdin_writer_task(
         let line = match serde_json::to_string(&envelope) {
             Ok(s) => s,
             Err(e) => {
-                let _ = msg.ack.send(Err(format!("Failed to serialize message: {}", e)));
+                let _ = msg
+                    .ack
+                    .send(Err(format!("Failed to serialize message: {}", e)));
                 continue;
             }
         };
@@ -773,7 +781,10 @@ async fn stdout_tee_task(
     let mut log_file = match log_file {
         Ok(f) => Some(f),
         Err(e) => {
-            eprintln!("[pm_worker] Failed to open stdout log {:?}: {}", log_path, e);
+            eprintln!(
+                "[pm_worker] Failed to open stdout log {:?}: {}",
+                log_path, e
+            );
             None
         }
     };
@@ -830,13 +841,25 @@ async fn stdout_tee_task(
                 }
             }
             "result" => {
-                let subtype = event.get("subtype").and_then(|v| v.as_str()).map(String::from);
-                let is_error = event.get("is_error").and_then(|v| v.as_bool()).unwrap_or(false);
+                let subtype = event
+                    .get("subtype")
+                    .and_then(|v| v.as_str())
+                    .map(String::from);
+                let is_error = event
+                    .get("is_error")
+                    .and_then(|v| v.as_bool())
+                    .unwrap_or(false);
                 let duration_ms = event.get("duration_ms").and_then(|v| v.as_u64());
                 let num_turns = event.get("num_turns").and_then(|v| v.as_u64());
-                let stop_reason = event.get("stop_reason").and_then(|v| v.as_str()).map(String::from);
+                let stop_reason = event
+                    .get("stop_reason")
+                    .and_then(|v| v.as_str())
+                    .map(String::from);
                 let total_cost_usd = event.get("total_cost_usd").and_then(|v| v.as_f64());
-                let result_text = event.get("result").and_then(|v| v.as_str()).map(String::from);
+                let result_text = event
+                    .get("result")
+                    .and_then(|v| v.as_str())
+                    .map(String::from);
 
                 let result = TurnResult {
                     assistant_text: std::mem::take(&mut assistant_buf),
@@ -855,14 +878,14 @@ async fn stdout_tee_task(
 
                 if let Some(ref ctx) = inbox {
                     use crate::cli::pm_inbox::{self, EventStatus, InboxEvent, TurnResult};
-                    let status = if is_error || subtype.as_deref().map(|s| s != "success").unwrap_or(false) {
+                    let status = if is_error
+                        || subtype.as_deref().map(|s| s != "success").unwrap_or(false)
+                    {
                         EventStatus::Error
                     } else {
                         EventStatus::Done
                     };
-                    let excerpt = result_text
-                        .as_ref()
-                        .map(|s| pm_inbox::truncate_excerpt(s));
+                    let excerpt = result_text.as_ref().map(|s| pm_inbox::truncate_excerpt(s));
                     let err_msg = if matches!(status, EventStatus::Error) {
                         // Prefer the result `subtype` (e.g. "error_during_execution",
                         // "error_max_turns") since `stop_reason` is typically only
@@ -952,7 +975,10 @@ async fn stderr_tee_task(stderr: tokio::process::ChildStderr, log_path: PathBuf)
     let mut log_file = match log_file {
         Ok(f) => Some(f),
         Err(e) => {
-            eprintln!("[pm_worker] Failed to open stderr log {:?}: {}", log_path, e);
+            eprintln!(
+                "[pm_worker] Failed to open stderr log {:?}: {}",
+                log_path, e
+            );
             None
         }
     };

--- a/src-tauri/src/cli/pm_worker.rs
+++ b/src-tauri/src/cli/pm_worker.rs
@@ -279,6 +279,11 @@ pub struct BgWorkerHandle {
     events_rx: Option<tokio::sync::broadcast::Receiver<SubscribeEvent>>,
     #[allow(dead_code)]
     ready_fired: bool,
+    /// Set by `send_message` after the reply RPC. Tells `wait_for_turn` to
+    /// ignore any settled patches that arrive before it sees a fresh
+    /// `tempo:"active"|"running"` transition — those settles belong to the
+    /// previous turn, not the one this caller just sent.
+    awaiting_new_turn: bool,
 }
 
 impl BgWorkerHandle {
@@ -350,16 +355,17 @@ impl BgWorkerHandle {
             sock_path,
             events_rx: Some(events_rx),
             ready_fired: false,
+            awaiting_new_turn: false,
         })
     }
 
     pub async fn send_message(&mut self, text: &str) -> Result<(), String> {
         // Drain any stale settle events buffered from prior turns (spawn-time
-        // prompt, earlier non-waiting sends). Otherwise the next wait_for_turn
-        // could immediately return a stale Done for the previous turn instead
-        // of waiting for the one we're about to send. Worker is idle right
-        // now (it just settled), so no NEW events can land between drain and
-        // RPC send — drain is safe and complete here.
+        // prompt, earlier non-waiting sends). Drain alone isn't sufficient
+        // because the prior turn could settle AFTER drain but BEFORE the
+        // worker enters active for the new turn — so we ALSO arm a gate on
+        // wait_for_turn that requires observing a fresh tempo:active|running
+        // transition before any settle is accepted as belonging to this send.
         if let Some(rx) = self.events_rx.as_mut() {
             loop {
                 match rx.try_recv() {
@@ -384,13 +390,20 @@ impl BgWorkerHandle {
                 reply.error.unwrap_or_default()
             ));
         }
+        self.awaiting_new_turn = true;
         Ok(())
     }
 
     /// Wait for the next settle (done or blocked). Drains pid-only/active
     /// patches via SettleDetector. Returns `WAIT_TIMEOUT` error string on
     /// timeout, mirroring the print backend's contract.
+    ///
+    /// When `self.awaiting_new_turn` is true (set by `send_message`), any
+    /// settle that arrives before a fresh `tempo:active|running` transition
+    /// is treated as belonging to the previous turn and discarded — the
+    /// gate prevents a stale prior settle from being misreported.
     pub async fn wait_for_turn(&mut self, timeout: Duration) -> Result<TurnResult, String> {
+        let mut gate_pending = self.awaiting_new_turn;
         let rx = self
             .events_rx
             .as_mut()
@@ -409,40 +422,57 @@ impl BgWorkerHandle {
 
             self.ready_fired = true;
 
+            // Extract any StatePatch payloads from this event so we can both
+            // (a) update the detector and (b) inspect the tempo field for the
+            // post-send active-gate check.
+            let mut patches: Vec<crate::cli::bg_protocol::StatePatch> = Vec::new();
             match ev {
                 SubscribeEvent::Snapshot { record, .. } => {
-                    // Try nested `currentState` object first (some daemon versions
-                    // wrap state under it); fall back to top-level fields on the
-                    // record itself (`record.state`, `record.tempo`, ...), which
-                    // is what the round-trip PoC observed and what the integration
-                    // test exercises.
-                    let nested = record
-                        .get("currentState")
-                        .and_then(|v| {
-                            serde_json::from_value::<crate::cli::bg_protocol::StatePatch>(v.clone())
-                                .ok()
-                        });
+                    let nested = record.get("currentState").and_then(|v| {
+                        serde_json::from_value::<crate::cli::bg_protocol::StatePatch>(v.clone())
+                            .ok()
+                    });
                     let from_record = serde_json::from_value::<crate::cli::bg_protocol::StatePatch>(
                         record.clone(),
                     )
                     .ok();
                     if let Some(p) = nested {
-                        det.apply_patch(&p);
+                        patches.push(p);
                     }
                     if let Some(p) = from_record {
-                        det.apply_patch(&p);
-                    }
-                    if det.is_settled() {
-                        return Ok(self.build_turn_result(&det));
+                        patches.push(p);
                     }
                 }
-                SubscribeEvent::State { patch } => {
-                    det.apply_patch(&patch);
-                    if det.is_settled() {
-                        return Ok(self.build_turn_result(&det));
+                SubscribeEvent::State { patch } => patches.push(patch),
+                SubscribeEvent::Stream { .. } => continue,
+            }
+
+            // Lower the gate as soon as we see the worker enter the new turn.
+            if gate_pending {
+                for p in &patches {
+                    if let Some(t) = p.tempo.as_deref() {
+                        if matches!(t, "active" | "running") {
+                            gate_pending = false;
+                            break;
+                        }
                     }
                 }
-                SubscribeEvent::Stream { .. } => {} // filtered upstream, but be safe
+            }
+
+            for p in &patches {
+                det.apply_patch(p);
+            }
+
+            if det.is_settled() && !gate_pending {
+                self.awaiting_new_turn = false;
+                return Ok(self.build_turn_result(&det));
+            }
+
+            // While the gate is still pending, any settle we observed is a
+            // STALE prior turn — clear it so the detector can re-arm on the
+            // real settle that follows the upcoming active transition.
+            if det.is_settled() && gate_pending {
+                det = SettleDetector::new();
             }
         }
     }

--- a/src-tauri/src/cli/pm_worker.rs
+++ b/src-tauri/src/cli/pm_worker.rs
@@ -256,6 +256,290 @@ impl WorkerHandle {
     }
 }
 
+// ── Bg backend handle ─────────────────────────────────────────────────────────
+
+use crate::cli::bg_backend::{self, SettleDetector};
+use crate::cli::bg_protocol::{Request, SubscribeEvent};
+
+/// Worker handle backed by `claude --bg` + control.sock RPC.
+///
+/// Lifecycle:
+/// - `spawn` → `claude --bg <prompt>` subprocess returns short, then we open
+///   a dedicated subscribe connection.
+/// - `send_message` → one-shot `reply` RPC on a fresh connection.
+/// - `wait_for_turn` → consume subscribe events until SettleDetector reports
+///   settled (`done` or `blocked`).
+/// - `kill` → one-shot `kill` RPC + fallback `claude rm` subprocess for
+///   jobs-dir cleanup.
+pub struct BgWorkerHandle {
+    pub meta: WorkerMeta,
+    #[allow(dead_code)]
+    short: String,
+    sock_path: std::path::PathBuf,
+    events_rx: Option<tokio::sync::broadcast::Receiver<SubscribeEvent>>,
+    #[allow(dead_code)]
+    ready_fired: bool,
+    inbox_ctx: Option<InboxContext>,
+}
+
+impl BgWorkerHandle {
+    pub async fn spawn(
+        session_id: String,
+        args: SpawnArgs,
+        ctx: SpawnContext,
+        initial_prompt: String,
+    ) -> Result<Self, String> {
+        let sock_path = bg_backend::resolve_control_sock()?;
+
+        let worker_name = args
+            .name
+            .clone()
+            .unwrap_or_else(|| format!("c9w-{}", &session_id[..8.min(session_id.len())]));
+
+        let short =
+            bg_backend::spawn_bg(&args, &session_id, &worker_name, &initial_prompt).await?;
+
+        let meta = WorkerMeta {
+            session_id: session_id.clone(),
+            // bg workers are daemon-managed; the CC daemon owns the actual PTY
+            // pid. We can't take ownership of the subprocess here, so leave
+            // pid=0 and rely on `claude agents --json` for live pid lookup
+            // (see detector refactor PR #107).
+            pid: 0,
+            name: args.name.clone(),
+            cwd: args.cwd.clone(),
+            spawned_at: Utc::now().to_rfc3339(),
+            spawned_by: ctx.spawned_by.clone(),
+            pm_pid: ctx.pm_pid,
+            spawn_args: PersistedSpawnArgs {
+                append_system_prompt: args.append_system_prompt,
+                permission_mode: args.permission_mode,
+                model: args.model,
+                add_dirs: args.add_dirs,
+            },
+            stopped_at: None,
+        };
+        pm_fs::write_worker_meta(&meta)?;
+
+        let events_rx = bg_backend::subscribe(&sock_path, &short).await?;
+
+        let inbox_ctx = ctx.spawned_by.as_ref().map(|pm| InboxContext {
+            session_id: session_id.clone(),
+            spawned_by: pm.clone(),
+        });
+
+        Ok(BgWorkerHandle {
+            meta,
+            short,
+            sock_path,
+            events_rx: Some(events_rx),
+            ready_fired: false,
+            inbox_ctx,
+        })
+    }
+
+    pub async fn send_message(&self, text: &str) -> Result<(), String> {
+        let reply = bg_backend::rpc(
+            &self.sock_path,
+            Request::Reply {
+                short: self.short.clone(),
+                text: text.to_string(),
+            },
+        )
+        .await?;
+        if !reply.ok {
+            return Err(format!(
+                "daemon rejected reply: {}",
+                reply.error.unwrap_or_default()
+            ));
+        }
+        Ok(())
+    }
+
+    /// Wait for the next settle (done or blocked). Drains pid-only/active
+    /// patches via SettleDetector. Returns `WAIT_TIMEOUT` error string on
+    /// timeout, mirroring the print backend's contract.
+    pub async fn wait_for_turn(&mut self, timeout: Duration) -> Result<TurnResult, String> {
+        let rx = self
+            .events_rx
+            .as_mut()
+            .ok_or_else(|| "events_rx not available".to_string())?;
+        let mut det = SettleDetector::new();
+        let deadline = tokio::time::Instant::now() + timeout;
+
+        loop {
+            let remaining = deadline
+                .checked_duration_since(tokio::time::Instant::now())
+                .ok_or_else(|| "WAIT_TIMEOUT".to_string())?;
+            let ev = tokio::time::timeout(remaining, rx.recv())
+                .await
+                .map_err(|_| "WAIT_TIMEOUT".to_string())?
+                .map_err(|e| format!("event channel closed: {}", e))?;
+
+            self.ready_fired = true;
+
+            match ev {
+                SubscribeEvent::Snapshot { record, .. } => {
+                    if let Some(patch) = record.get("currentState").and_then(|v| {
+                        serde_json::from_value::<crate::cli::bg_protocol::StatePatch>(v.clone())
+                            .ok()
+                    }) {
+                        det.apply_patch(&patch);
+                    }
+                    if det.is_settled() {
+                        return Ok(self.build_turn_result(&det));
+                    }
+                }
+                SubscribeEvent::State { patch } => {
+                    det.apply_patch(&patch);
+                    if det.is_settled() {
+                        return Ok(self.build_turn_result(&det));
+                    }
+                }
+                SubscribeEvent::Stream { .. } => {} // filtered upstream, but be safe
+            }
+        }
+    }
+
+    fn build_turn_result(&self, det: &SettleDetector) -> TurnResult {
+        let tr = TurnResult {
+            assistant_text: String::new(),
+            ended_at: Utc::now().to_rfc3339(),
+            subtype: det.last_settled_state().map(String::from),
+            is_error: false,
+            duration_ms: None,
+            num_turns: None,
+            stop_reason: det.last_settled_state().map(String::from),
+            total_cost_usd: None,
+            result_text: det.detail().map(String::from),
+        };
+        if det.last_settled_state() == Some("blocked") {
+            if let Some(ref ctx) = self.inbox_ctx {
+                if let Some(needs) = det.needs() {
+                    use crate::cli::pm_inbox;
+                    let ev = pm_inbox::InboxEvent::awaiting(
+                        &ctx.session_id,
+                        &ctx.spawned_by,
+                        needs.to_string(),
+                        det.detail().map(String::from),
+                    );
+                    if let Err(e) = pm_inbox::write_event(&ev) {
+                        eprintln!("[pm_worker bg] inbox awaiting write: {}", e);
+                    }
+                }
+            }
+        }
+        tr
+    }
+
+    pub async fn wait_ready(&mut self, _timeout: Duration) -> Result<(), String> {
+        // Bg workers are ready as soon as `claude --bg` returns the short.
+        // The subscribe stream will emit the initial snapshot ~immediately.
+        Ok(())
+    }
+
+    pub fn is_alive(&self) -> bool {
+        // Cheap heuristic: the subscribe broadcast channel is still open.
+        // When the reader task drops `tx`, `is_closed` reports true.
+        self.events_rx
+            .as_ref()
+            .map(|rx| !rx.is_closed())
+            .unwrap_or(false)
+    }
+
+    pub async fn kill(&mut self) -> Result<(), String> {
+        let reply = bg_backend::rpc(
+            &self.sock_path,
+            Request::Kill {
+                short: self.short.clone(),
+            },
+        )
+        .await?;
+        if !reply.ok {
+            eprintln!(
+                "[pm_worker bg] kill RPC rejected: {}",
+                reply.error.unwrap_or_default()
+            );
+        }
+        // Parallel subprocess `claude rm` for jobs-dir cleanup (no daemon
+        // equivalent). Best-effort; ignore errors.
+        let short = self.short.clone();
+        tokio::spawn(async move {
+            let _ = Command::new("claude").arg("rm").arg(&short).output().await;
+        });
+        Ok(())
+    }
+}
+
+// ── Backend-agnostic wrapper ──────────────────────────────────────────────────
+
+pub enum AnyWorkerHandle {
+    Print(WorkerHandle),
+    Bg(BgWorkerHandle),
+}
+
+impl AnyWorkerHandle {
+    pub fn meta(&self) -> &WorkerMeta {
+        match self {
+            Self::Print(h) => &h.meta,
+            Self::Bg(h) => &h.meta,
+        }
+    }
+
+    pub async fn send_message(&self, text: &str) -> Result<(), String> {
+        match self {
+            Self::Print(h) => h.send_message(text).await,
+            Self::Bg(h) => h.send_message(text).await,
+        }
+    }
+
+    pub async fn wait_for_turn(&mut self, timeout: Duration) -> Result<TurnResult, String> {
+        match self {
+            Self::Print(h) => h.wait_for_turn(timeout).await,
+            Self::Bg(h) => h.wait_for_turn(timeout).await,
+        }
+    }
+
+    pub async fn wait_ready(&mut self, timeout: Duration) -> Result<(), String> {
+        match self {
+            Self::Print(h) => h.wait_ready(timeout).await,
+            Self::Bg(h) => h.wait_ready(timeout).await,
+        }
+    }
+
+    pub fn is_alive(&mut self) -> bool {
+        match self {
+            Self::Print(h) => h.is_alive(),
+            Self::Bg(h) => h.is_alive(),
+        }
+    }
+
+    pub async fn kill(&mut self) -> Result<(), String> {
+        match self {
+            Self::Print(h) => h.kill().await,
+            Self::Bg(h) => h.kill().await,
+        }
+    }
+
+    /// Result-receiver methods only apply to the Print backend (Bg uses event
+    /// stream subscription via `wait_for_turn` instead). Bg returns None so
+    /// callers can branch on `matches!(handle, AnyWorkerHandle::Bg(_))` and
+    /// avoid the receiver-take dance.
+    pub fn take_result_receiver(&mut self) -> Option<mpsc::Receiver<TurnResult>> {
+        match self {
+            Self::Print(h) => h.take_result_receiver(),
+            Self::Bg(_) => None,
+        }
+    }
+
+    pub fn return_result_receiver(&mut self, rx: mpsc::Receiver<TurnResult>) {
+        match self {
+            Self::Print(h) => h.return_result_receiver(rx),
+            Self::Bg(_) => {} // no-op
+        }
+    }
+}
+
 // ── Internal tasks ───────────────────────────────────────────────────────────
 
 /// Reads StdinMessages from the channel and writes stream-json user envelopes

--- a/src-tauri/src/cli/pm_worker.rs
+++ b/src-tauri/src/cli/pm_worker.rs
@@ -320,20 +320,25 @@ impl BgWorkerHandle {
         };
         pm_fs::write_worker_meta(&meta)?;
 
-        let events_rx = bg_backend::subscribe(&sock_path, &short).await?;
-
         let inbox_ctx = ctx.spawned_by.as_ref().map(|pm| InboxContext {
             session_id: session_id.clone(),
             spawned_by: pm.clone(),
         });
 
-        // Spawn a long-lived settle-watcher that fans out inbox events on every
-        // turn end regardless of whether a `--wait` caller is listening. Without
-        // this, PM-owned bg workers only emit Done/Awaiting events when a `send
-        // --wait` happens to be in flight — spawn-time prompts and non-waiting
-        // sends would silently miss completions.
+        // Mint two receivers up-front when a PM is attached: one for the
+        // long-lived settle watcher, one for `wait_for_turn` callers. Tokio
+        // broadcast receivers do NOT replay older messages, so both must
+        // exist before any event lands — otherwise a fast initial snapshot
+        // could slip past the second subscriber.
+        let receiver_count = if inbox_ctx.is_some() { 2 } else { 1 };
+        let (_tx, mut receivers) =
+            bg_backend::subscribe(&sock_path, &short, receiver_count).await?;
+        let events_rx = receivers.remove(0);
+
         if let Some(ref ctx) = inbox_ctx {
-            let watcher_rx = events_rx.resubscribe();
+            let watcher_rx = receivers
+                .pop()
+                .expect("subscribe(2) returned <2 receivers");
             let ctx = ctx.clone();
             let short_owned = short.clone();
             tokio::spawn(settle_watcher_task(watcher_rx, ctx, short_owned));

--- a/src-tauri/src/cli/worker_backend.rs
+++ b/src-tauri/src/cli/worker_backend.rs
@@ -64,6 +64,29 @@ fn parse_version_ge(ver: &str, min: (u32, u32, u32)) -> bool {
     (parts[0], parts[1], parts[2]) >= min
 }
 
+/// Validate the initial prompt against the selected backend.
+///
+/// - Bg backend: requires a non-empty prompt — returns it
+/// - Print backend: ignores the prompt (returns None)
+///
+/// Returns Err with "INITIAL_PROMPT_REQUIRED" prefix when bg backend has no prompt.
+pub fn validate_initial_prompt(
+    kind: BackendKind,
+    initial_prompt: Option<String>,
+) -> Result<Option<String>, String> {
+    match kind {
+        BackendKind::Bg => match initial_prompt {
+            Some(p) if !p.trim().is_empty() => Ok(Some(p)),
+            _ => Err(
+                "INITIAL_PROMPT_REQUIRED: the bg backend requires --prompt at spawn time. \
+                 Pass one via `c9watch spawn --prompt \"<text>\"` or set C9WATCH_WORKER_BACKEND=print"
+                    .to_string(),
+            ),
+        },
+        BackendKind::Print => Ok(None),
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -92,5 +115,47 @@ mod tests {
         assert!(!parse_version_ge("garbage", (2, 1, 150)));
         assert!(!parse_version_ge("2.1", (2, 1, 150)));
         assert!(!parse_version_ge("", (2, 1, 150)));
+    }
+}
+
+#[cfg(test)]
+mod backend_gating_tests {
+    use super::*;
+
+    /// Logic-only test: when backend is Bg, validate_initial_prompt must reject None.
+    /// When backend is Print, it accepts None.
+    #[test]
+    fn validate_initial_prompt_bg_rejects_none() {
+        let result = validate_initial_prompt(BackendKind::Bg, None);
+        assert!(result.is_err());
+        assert!(result.unwrap_err().contains("INITIAL_PROMPT_REQUIRED"));
+    }
+
+    #[test]
+    fn validate_initial_prompt_bg_rejects_empty_string() {
+        let result = validate_initial_prompt(BackendKind::Bg, Some("   ".to_string()));
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn validate_initial_prompt_bg_accepts_real_text() {
+        let result = validate_initial_prompt(BackendKind::Bg, Some("do the thing".to_string()));
+        assert!(result.is_ok());
+        assert_eq!(result.unwrap().as_deref(), Some("do the thing"));
+    }
+
+    #[test]
+    fn validate_initial_prompt_print_accepts_none() {
+        let result = validate_initial_prompt(BackendKind::Print, None);
+        assert!(result.is_ok());
+        assert!(result.unwrap().is_none());
+    }
+
+    #[test]
+    fn validate_initial_prompt_print_accepts_any_value() {
+        let result = validate_initial_prompt(BackendKind::Print, Some("ignored".to_string()));
+        assert!(result.is_ok());
+        // Print backend ignores the prompt — return None to signal that.
+        assert!(result.unwrap().is_none());
     }
 }

--- a/src-tauri/src/cli/worker_backend.rs
+++ b/src-tauri/src/cli/worker_backend.rs
@@ -1,0 +1,96 @@
+//! Backend selection and trait for PM workers.
+//!
+//! Two backends exist:
+//! - [`BackendKind::Bg`]: spawn via `claude --bg`, control.sock RPC.
+//!   Required for CC >= 2.1.150 to stay on Pro/Max subscription quota
+//!   after 2026-06-15 (Agent SDK billing split).
+//! - [`BackendKind::Print`]: spawn via `claude --print` stream-json.
+//!   Legacy path, kept as fallback for older CC versions and as escape
+//!   hatch if the bg path breaks.
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum BackendKind {
+    Bg,
+    Print,
+}
+
+/// Select the appropriate backend based on env override, CC version, and
+/// daemon socket availability.
+///
+/// Precedence:
+/// 1. `C9WATCH_WORKER_BACKEND=bg|print` env var (explicit user choice)
+/// 2. `C9WATCH_WORKER_BACKEND=auto` or unset → probe + auto-detect
+/// 3. Auto: Bg if `claude --version` >= 2.1.150 AND control.sock exists, else Print
+pub fn select_backend() -> BackendKind {
+    match std::env::var("C9WATCH_WORKER_BACKEND").as_deref() {
+        Ok("bg") => return BackendKind::Bg,
+        Ok("print") => return BackendKind::Print,
+        Ok("auto") | Err(_) => {} // fall through to auto-detect
+        Ok(other) => {
+            eprintln!(
+                "[worker_backend] unknown C9WATCH_WORKER_BACKEND={:?}, falling back to auto",
+                other
+            );
+        }
+    }
+
+    if version_supports_bg() && crate::cli::bg_backend::resolve_control_sock().is_ok() {
+        BackendKind::Bg
+    } else {
+        BackendKind::Print
+    }
+}
+
+/// Returns true if `claude --version` reports >= 2.1.150 (when `--bg` shipped).
+fn version_supports_bg() -> bool {
+    let output = match std::process::Command::new("claude")
+        .arg("--version")
+        .output()
+    {
+        Ok(o) => o,
+        Err(_) => return false,
+    };
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    // Format: "2.1.150 (Claude Code)\n"
+    let ver = stdout.split_whitespace().next().unwrap_or("");
+    parse_version_ge(ver, (2, 1, 150))
+}
+
+fn parse_version_ge(ver: &str, min: (u32, u32, u32)) -> bool {
+    let parts: Vec<u32> = ver.split('.').take(3).filter_map(|s| s.parse().ok()).collect();
+    if parts.len() != 3 {
+        return false;
+    }
+    (parts[0], parts[1], parts[2]) >= min
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn version_ge_handles_exact_match() {
+        assert!(parse_version_ge("2.1.150", (2, 1, 150)));
+    }
+
+    #[test]
+    fn version_ge_handles_newer() {
+        assert!(parse_version_ge("2.1.151", (2, 1, 150)));
+        assert!(parse_version_ge("2.2.0", (2, 1, 150)));
+        assert!(parse_version_ge("3.0.0", (2, 1, 150)));
+    }
+
+    #[test]
+    fn version_ge_rejects_older() {
+        assert!(!parse_version_ge("2.1.149", (2, 1, 150)));
+        assert!(!parse_version_ge("2.0.999", (2, 1, 150)));
+        assert!(!parse_version_ge("1.9.9", (2, 1, 150)));
+    }
+
+    #[test]
+    fn version_ge_rejects_malformed() {
+        assert!(!parse_version_ge("garbage", (2, 1, 150)));
+        assert!(!parse_version_ge("2.1", (2, 1, 150)));
+        assert!(!parse_version_ge("", (2, 1, 150)));
+    }
+}

--- a/src-tauri/tests/bg_round_trip.rs
+++ b/src-tauri/tests/bg_round_trip.rs
@@ -1,0 +1,303 @@
+//! End-to-end smoke test for the `claude --bg` + `control.sock` JSON-RPC stack.
+//!
+//! Requires `claude >= 2.1.150` on PATH. Runs only via:
+//!     cargo test --test bg_round_trip -- --ignored --nocapture
+//!
+//! Validates: spawn → subscribe → snapshot → turn-1 settled → reply →
+//! turn-2 settled → claude stop → claude rm → no residue.
+//!
+//! Safety: spawns in /tmp, names sessions `c9watch-bg-poc-<pid>`, and a
+//! Drop guard always runs `claude stop` + `claude rm` even on panic.
+
+use std::process::{Command, Stdio};
+use std::time::Duration;
+
+use anyhow::{anyhow, bail, Context, Result};
+use regex::Regex;
+use serde_json::{json, Value};
+use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
+use tokio::net::UnixStream;
+use tokio::time::{timeout, Instant};
+
+const SETTLE_TIMEOUT: Duration = Duration::from_secs(25);
+const TOTAL_BUDGET: Duration = Duration::from_secs(55);
+const QUIET_WINDOW: Duration = Duration::from_millis(1500);
+
+/// RAII guard: stop + rm the bg session on Drop unless disarmed.
+struct StopGuard {
+    short: String,
+    disarmed: bool,
+}
+impl StopGuard {
+    fn new(short: String) -> Self { Self { short, disarmed: false } }
+    fn disarm(&mut self) { self.disarmed = true; }
+}
+impl Drop for StopGuard {
+    fn drop(&mut self) {
+        if self.disarmed { return; }
+        eprintln!("[guard] cleaning up {}", self.short);
+        let _ = Command::new("claude").arg("stop").arg(&self.short).status();
+        let _ = Command::new("claude").arg("rm").arg(&self.short).status();
+    }
+}
+
+/// End-to-end smoke test for the `claude --bg` + control.sock JSON-RPC stack.
+///
+/// Requires `claude >= 2.1.150` on PATH. Runs only via:
+///     cargo test --test bg_round_trip -- --ignored --nocapture
+///
+/// Validates: spawn → subscribe → snapshot → turn-1 settled → reply →
+/// turn-2 settled → claude stop → claude rm → no residue.
+#[tokio::test]
+#[ignore]
+async fn bg_round_trip_end_to_end() -> anyhow::Result<()> {
+    let started = std::time::Instant::now();
+    tokio::time::timeout(TOTAL_BUDGET, bg_round_trip_inner())
+        .await
+        .map_err(|_| anyhow::anyhow!("{:?} budget exceeded", TOTAL_BUDGET))??;
+    println!("[done] total {:.2}s", started.elapsed().as_secs_f32());
+    Ok(())
+}
+
+async fn bg_round_trip_inner() -> Result<()> {
+    let socket = resolve_socket().context("step 1: resolve daemon socket")?;
+    println!("[socket] {}", socket);
+
+    let name = format!("c9watch-bg-poc-{}", std::process::id());
+    let (short, model) = spawn_bg(&name).context("step 2: spawn `claude --bg`")?;
+    println!("[spawn] short={} name={} model={}", short, name, model);
+
+    assert!(short.len() == 8, "expected 8-hex short, got {}", short);
+    assert!(
+        short.chars().all(|c| c.is_ascii_hexdigit()),
+        "short must be hex, got {}",
+        short
+    );
+
+    let mut guard = StopGuard::new(short.clone());
+
+    let stream = UnixStream::connect(&socket).await
+        .with_context(|| format!("step 3: connect to {}", socket))?;
+    let (rd, mut wr) = stream.into_split();
+    let mut reader = BufReader::new(rd).lines();
+    println!("[connect] unix stream open");
+
+    write_line(&mut wr, &json!({"proto":1,"op":"subscribe","short":short}))
+        .await.context("step 4: write subscribe")?;
+    println!("[subscribe] sent");
+
+    drain_initial_snapshot(&mut reader).await.context("step 4a: drain snapshot")?;
+
+    // Turn 1: the prompt we passed at spawn. Subscribing here catches the
+    // mid-flight active→idle state patch reliably (verified manually).
+    let d1 = wait_for_idle(&mut reader, &short, "turn-1").await
+        .context("step 5: wait for turn-1 idle")?;
+    println!("[turn-1 detail] {:?}", d1);
+
+    // Turn 2: send via the `reply` verb. Field is `text` (not message/prompt).
+    write_line(&mut wr, &json!({
+        "proto":1, "op":"reply", "short":short,
+        "text":"now say DONE in all caps and nothing else"
+    })).await.context("step 6: write turn-2 reply")?;
+    println!("[send] turn-2 reply sent");
+
+    let d2 = wait_for_idle(&mut reader, &short, "turn-2").await
+        .context("step 7: wait for turn-2 idle")?;
+    println!("[turn-2 detail] {:?}", d2);
+
+    let stop = Command::new("claude").arg("stop").arg(&short).status()
+        .context("step 8a: `claude stop`")?;
+    println!("[stop] exit={}", stop.code().unwrap_or(-1));
+    assert_eq!(stop.code().unwrap_or(-1), 0, "claude stop failed");
+
+    let rm = Command::new("claude").arg("rm").arg(&short).status()
+        .context("step 8b: `claude rm`")?;
+    println!("[rm] exit={}", rm.code().unwrap_or(-1));
+    assert_eq!(rm.code().unwrap_or(-1), 0, "claude rm failed");
+
+    if let Some(s) = current_status(&short)? {
+        bail!("step 9: session {} still listed with status={}", short, s);
+    }
+    guard.disarm();
+    println!("[verify] session gone");
+    Ok(())
+}
+
+async fn write_line<W>(w: &mut W, v: &Value) -> Result<()>
+where W: tokio::io::AsyncWrite + Unpin {
+    w.write_all(format!("{}\n", v).as_bytes()).await?;
+    Ok(())
+}
+
+fn resolve_socket() -> Result<String> {
+    let uid = unsafe { libc::getuid() };
+    let parent = format!("/tmp/cc-daemon-{}", uid);
+    let mut hits = Vec::new();
+    for e in std::fs::read_dir(&parent)
+        .with_context(|| format!("read_dir {} — is CC daemon running?", parent))?
+        .flatten()
+    {
+        let p = e.path().join("control.sock");
+        if p.exists() { hits.push(p.to_string_lossy().into_owned()); }
+    }
+    match hits.len() {
+        0 => bail!("no control.sock under {} (CC >= 2.1.145 required)", parent),
+        1 => Ok(hits.remove(0)),
+        n => bail!("expected 1 host-id subdir under {}, found {}: {:?}", parent, n, hits),
+    }
+}
+
+/// Spawn `claude --bg --name <name> --model <m> "<prompt>"` in /tmp.
+/// Tries haiku, then sonnet. Empirically (CC 2.1.150) spawning idle and
+/// then sending the first `reply` over control.sock does NOT trigger the
+/// worker reliably — spawning with a prompt gives a known turn-1.
+fn spawn_bg(name: &str) -> Result<(String, String)> {
+    let prompt = "respond with the single word: ok";
+    for model in ["haiku", "sonnet"] {
+        let out = Command::new("claude")
+            .args(["--bg", "--name", name, "--model", model, prompt])
+            .current_dir("/tmp")
+            .stdout(Stdio::piped()).stderr(Stdio::piped())
+            .output().with_context(|| format!("spawn claude --bg --model {}", model))?;
+        if !out.status.success() {
+            eprintln!("[spawn] model={} rejected: {}", model,
+                String::from_utf8_lossy(&out.stderr).trim());
+            continue;
+        }
+        let stdout = String::from_utf8_lossy(&out.stdout);
+        let short = parse_short(&stdout)
+            .with_context(|| format!("parse short (model={}):\n{}", model, stdout))?;
+        return Ok((short, model.to_string()));
+    }
+    bail!("no model accepted (tried haiku, sonnet)")
+}
+
+fn parse_short(stdout: &str) -> Result<String> {
+    // "backgrounded · <8hex> [· name]" or with "(idle ...)" suffix.
+    let re = Regex::new(r"backgrounded\s*[·•]\s*([0-9a-f]{8})").unwrap();
+    stdout.lines()
+        .find_map(|l| re.captures(l).map(|c| c[1].to_string()))
+        .ok_or_else(|| anyhow!("no `backgrounded · <short>` line found"))
+}
+
+async fn drain_initial_snapshot<R>(reader: &mut tokio::io::Lines<BufReader<R>>) -> Result<()>
+where R: tokio::io::AsyncRead + Unpin {
+    let deadline = Instant::now() + Duration::from_secs(5);
+    loop {
+        let rem = deadline.checked_duration_since(Instant::now())
+            .ok_or_else(|| anyhow!("snapshot not received within 5s"))?;
+        let line = match timeout(rem, reader.next_line()).await {
+            Ok(Ok(Some(l))) => l,
+            Ok(Ok(None)) => bail!("EOF before snapshot"),
+            Ok(Err(e)) => bail!("read error: {}", e),
+            Err(_) => bail!("snapshot not received within 5s"),
+        };
+        let v: Value = match serde_json::from_str(&line) { Ok(v) => v, Err(_) => continue };
+        if v.get("type").and_then(|x| x.as_str()) == Some("snapshot") {
+            let tempo = v.pointer("/record/tempo").and_then(|x| x.as_str()).unwrap_or("?");
+            let state = v.pointer("/record/state").and_then(|x| x.as_str()).unwrap_or("?");
+            println!("[event] initial snapshot tempo={} state={}", tempo, state);
+            return Ok(());
+        }
+    }
+}
+
+/// Race three turn-end signals; whichever fires first wins.
+/// 1. `state` patch with done/blocked/idle (push subscription)
+/// 2. Stream silence after PTY activity (also via subscription)
+/// 3. `claude agents --json` poll: busy→idle transition (out-of-band)
+async fn wait_for_idle<R>(
+    reader: &mut tokio::io::Lines<BufReader<R>>,
+    short: &str, label: &str,
+) -> Result<Option<String>>
+where R: tokio::io::AsyncRead + Unpin {
+    tokio::select! {
+        r = stream_or_state(reader, label) => r,
+        r = poll_idle(short, label) => r,
+    }
+}
+
+/// Drives the reader: returns on settled state patch OR stream-quiet.
+async fn stream_or_state<R>(
+    reader: &mut tokio::io::Lines<BufReader<R>>, label: &str,
+) -> Result<Option<String>>
+where R: tokio::io::AsyncRead + Unpin {
+    let mut saw_stream = false;
+    let mut frames = 0u32;
+    let deadline = Instant::now() + SETTLE_TIMEOUT;
+    loop {
+        if Instant::now() >= deadline { bail!("{}: stream_or_state timeout", label); }
+        match timeout(QUIET_WINDOW, reader.next_line()).await {
+            Ok(Ok(Some(line))) => {
+                let v: Value = match serde_json::from_str(&line) { Ok(v) => v, Err(_) => continue };
+                match v.get("type").and_then(|x| x.as_str()) {
+                    Some("stream") => {
+                        if !saw_stream { println!("[stream] {} first frame seen", label); }
+                        saw_stream = true; frames += 1;
+                    }
+                    Some("state") => {
+                        let p = v.get("patch").cloned().unwrap_or(Value::Null);
+                        let st = p.get("state").and_then(|x| x.as_str());
+                        let te = p.get("tempo").and_then(|x| x.as_str());
+                        if matches!(st, Some("done") | Some("blocked"))
+                            || matches!(te, Some("idle") | Some("blocked"))
+                        {
+                            let d = p.get("detail").and_then(|x| x.as_str()).map(|s| s.to_string());
+                            println!("[{} complete via state] state={:?} tempo={:?}", label, st, te);
+                            return Ok(d);
+                        }
+                    }
+                    _ => {}
+                }
+            }
+            Ok(Ok(None)) => bail!("{}: EOF on control.sock", label),
+            Ok(Err(e)) => bail!("{}: read error: {}", label, e),
+            Err(_) => {
+                if saw_stream {
+                    println!("[{} complete via stream-quiet] frames={} silence={:?}",
+                        label, frames, QUIET_WINDOW);
+                    return Ok(None);
+                }
+            }
+        }
+    }
+}
+
+/// Poll `claude agents --json` every 250ms; require a busy→idle transition.
+async fn poll_idle(short: &str, label: &str) -> Result<Option<String>> {
+    let deadline = Instant::now() + SETTLE_TIMEOUT;
+    let mut last = String::new();
+    let mut saw_busy = false;
+    loop {
+        if Instant::now() >= deadline {
+            bail!("{}: poll_idle timeout (last={})", label, last);
+        }
+        let status = current_status(short)?;
+        let disp = status.clone().unwrap_or_else(|| "<absent>".into());
+        if disp != last { println!("[poll] {} status={}", label, disp); last = disp.clone(); }
+        match status.as_deref() {
+            Some("busy") | Some("running") | Some("active") => saw_busy = true,
+            Some("idle") | Some("blocked") | Some("done") if saw_busy => {
+                println!("[{} complete via poll] status={}", label, disp);
+                return Ok(None);
+            }
+            _ => {}
+        }
+        tokio::time::sleep(Duration::from_millis(250)).await;
+    }
+}
+
+/// Returns `status` field of the agents entry whose sessionId starts with `short`.
+fn current_status(short: &str) -> Result<Option<String>> {
+    let out = Command::new("claude").args(["agents", "--json"]).output()
+        .context("run `claude agents --json`")?;
+    if !out.status.success() {
+        bail!("claude agents --json failed: {}", String::from_utf8_lossy(&out.stderr));
+    }
+    let arr: Value = serde_json::from_str(&String::from_utf8_lossy(&out.stdout))
+        .context("parse agents json")?;
+    Ok(arr.as_array().and_then(|a| a.iter().find(|e| {
+        e.get("sessionId").and_then(|x| x.as_str())
+            .map(|s| s.starts_with(short)).unwrap_or(false)
+    })).and_then(|e| e.get("status").and_then(|x| x.as_str()).map(|s| s.to_string())))
+}


### PR DESCRIPTION
## Summary

Adds a `bg` PM worker backend that spawns workers via the hidden `claude --bg` flag instead of `claude --print`. Workers stay on the user's Pro/Max subscription quota after Anthropic's 2026-06-15 Agent SDK billing split (`-p` / SDK / GitHub Actions move onto a separate \$20 / \$100 / \$200 credit pool at full API rates).

- New `BackendKind::{Bg, Print}` enum + `select_backend()` (env override + version + socket probe)
- Existing `WorkerHandle` becomes the `Print` arm of `AnyWorkerHandle` (unchanged behavior)
- New `BgWorkerHandle`: spawn via `claude --bg`, dedicated control.sock UDS subscription per worker, one-shot `rpc()` helper for `reply` / `kill` / `nudge` / `ping`
- Auto-detect: CC >= 2.1.150 AND control.sock exists → bg; else print
- Escape hatch: \`C9WATCH_WORKER_BACKEND=bg|print|auto\`
- New \`c9watch spawn --prompt <text>\` flag — REQUIRED on bg backend (idle-spawn + later reply was unreliable per Phase 0)
- New \`EventStatus::Awaiting\` + \`InboxEvent::awaiting()\` for bg workers entering \`state:blocked\` (turn ended waiting on user input — distinct from done/crashed)
- Integration test \`tests/bg_round_trip.rs\` (gated by \`#[ignore]\` — requires \`claude\` on PATH)
- Operator notes at \`docs/notes/pm-bg-backend.md\`

Plan + investigation: see \`docs/superpowers/plans/2026-05-24-pm-bg-refactor.md\`. Phase 0 PoC + Probe B both green before this PR was opened.

## Test plan

- [x] \`cargo test --features cli --no-default-features\` passes (lib + 5 new worker_backend gating tests + 4 SettleDetector tests + 7 bg_protocol tests + 7 bg_backend tests = 317 total)
- [x] \`cargo test --test bg_round_trip -- --ignored\` passes on dev machine (~7s round-trip)
- [ ] Manual: \`C9WATCH_WORKER_BACKEND=bg c9watch spawn --cwd /tmp --prompt \"say ok\"\` → worker appears in \`claude agents --json\` as \`kind:background\`
- [ ] Manual: \`c9watch send <id> \"follow-up\" --wait\` → worker processes turn, inbox event fires
- [ ] Manual: \`c9watch stop <id>\` → worker disappears from \`claude agents --json\`, jobs dir cleaned via \`claude rm\` subprocess
- [ ] Manual: \`C9WATCH_WORKER_BACKEND=print c9watch spawn --cwd /tmp\` (no prompt) → succeeds with legacy path
- [ ] Manual: \`C9WATCH_WORKER_BACKEND=bg c9watch spawn --cwd /tmp\` (no prompt) → clean \`INITIAL_PROMPT_REQUIRED\` error
- [ ] Dogfood: real PM session end-to-end with backend=bg, confirm cost lands on subscription quota not Agent SDK credit

## Known concerns / follow-ups

1. **\`handle_send\` holds daemon state mutex across \`wait_for_turn\` on Bg backend.** Serializes other RPCs during a pending \`--wait\`. Acceptable for current single-PM dogfooding; revisit if concurrent \`--wait\`s become common.
2. **\`BgWorkerHandle::is_alive()\` is a heuristic** (\`broadcast::Receiver::is_closed\`). Can briefly report alive after daemon kills the worker. Print backend's \`Child::try_wait\` is more authoritative. Follow-up could poll \`claude agents --json\`.
3. **\`BgWorkerHandle.meta.pid = 0\`** — bg workers are daemon-managed. Real pid is recoverable via \`claude agents --json\` (already wired in PR #107). Any code comparing \`meta.pid\` to a sysinfo pid will not match for bg workers.
4. **Frontend TypeScript types not yet updated** for the \`Awaiting\` EventStatus + \`awaitingNeeds\`/\`awaitingDetail\` fields. Dashboard will render bg-blocked events generically until a follow-up frontend PR lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)