### PR TITLE
feat(actions): exact-window/tab focus for macOS Terminal.app via tty matching

### DIFF
--- a/.all-contributorsrc
+++ b/.all-contributorsrc
@@ -85,6 +85,15 @@
       "contributions": [
         "code"
       ]
+    },
+    {
+      "login": "jeff-carey",
+      "name": "Jeff Carey",
+      "avatar_url": "https://github.com/jeff-carey.png",
+      "profile": "https://github.com/jeff-carey",
+      "contributions": [
+        "code"
+      ]
     }
   ],
   "contributorsPerLine": 7,

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -25,6 +25,7 @@ We appreciate all contributions, big and small. Thank you to the following peopl
 - **Grimmer Kang** ([@grimmerk](https://github.com/grimmerk)) - Add list item numbers to history session rows ([#50](https://github.com/minchenlee/c9watch/pull/50))
 - **Grimmer Kang** ([@grimmerk](https://github.com/grimmerk)) - Multi-word AND search in history ([#51](https://github.com/minchenlee/c9watch/pull/51))
 - **Grimmer Kang** ([@grimmerk](https://github.com/grimmerk)) - Custom title and ACTIVE badge in history ([#52](https://github.com/minchenlee/c9watch/pull/52))
+- **Jeff Carey** ([@jeff-carey](https://github.com/jeff-carey)) - Added exact Terminal.app window and tab focusing via TTY matching ([#109](https://github.com/minchenlee/c9watch/pull/109))
 
 ### Performance
 

--- a/README.md
+++ b/README.md
@@ -287,6 +287,7 @@ Thanks to these wonderful people who have contributed to c9watch:
     </tr>
     <tr>
       <td align="center" valign="top" width="14.28%"><a href="https://github.com/ajonesw"><img src="https://github.com/ajonesw.png?s=100" width="100px;" alt="Alex Jones-Wolsey"/><br /><sub><b>Alex Jones-Wolsey</b></sub></a><br /><a href="#code-ajonesw" title="Code">💻</a></td>
+      <td align="center" valign="top" width="14.28%"><a href="https://github.com/jeff-carey"><img src="https://github.com/jeff-carey.png?s=100" width="100px;" alt="Jeff Carey"/><br /><sub><b>Jeff Carey</b></sub></a><br /><a href="#code-jeff-carey" title="Code">💻</a></td>
     </tr>
   </tbody>
 </table>

--- a/src-tauri/src/actions.rs
+++ b/src-tauri/src/actions.rs
@@ -25,6 +25,12 @@ pub fn open_session(pid: u32, project_path: String) -> Result<(), String> {
         return focus_iterm2_session(pid);
     }
 
+    // macOS Terminal.app: use tty matching to focus the correct tab (macOS only)
+    #[cfg(target_os = "macos")]
+    if app_name == "Terminal" {
+        return focus_terminal_session(pid);
+    }
+
     // JetBrains IDEs: use URL scheme to focus the correct project window
     if is_jetbrains_ide(&app_name) {
         return focus_jetbrains_window(&app_name, &project_path);
@@ -167,6 +173,81 @@ fn focus_iterm2_session(pid: u32) -> Result<(), String> {
     Ok(())
 }
 
+/// Focus the correct macOS Terminal.app tab by matching tty
+///
+/// Terminal.app tabs expose their tty (e.g. "/dev/ttys004") in the scripting
+/// dictionary, so the exact tab can be selected instead of just activating
+/// the app. Unlike iTerm2 there is no session layer — windows contain tabs.
+/// `miniaturized` is a native window property here, so no Accessibility
+/// permission is needed to restore a Dock-minimized window.
+///
+/// Ordering matters: select the tab and raise its window (referenced by a
+/// stable window id, not the loop variable) BEFORE calling `activate`. Calling
+/// `activate` first surfaces whatever window was already frontmost, and a
+/// subsequent raise of a background window does not reliably re-order the
+/// display — so a session in a non-frontmost window would be missed.
+#[cfg(target_os = "macos")]
+fn focus_terminal_session(pid: u32) -> Result<(), String> {
+    let tty = get_session_tty(pid);
+    crate::debug_log::log_info(&format!(
+        "[open_session] Terminal tty for PID {}: {:?}",
+        pid, tty
+    ));
+
+    let Some(tty) = tty else {
+        // No tty found — fall back to app activation
+        return activate_app_fallback("Terminal");
+    };
+
+    // AppleScript: find the tab by tty, select it, raise its window by id,
+    // then activate the app last.
+    let script = format!(
+        r#"
+        tell application "Terminal"
+            set targetWinId to missing value
+            repeat with w in windows
+                repeat with t in tabs of w
+                    if tty of t ends with "{tty}" then
+                        set selected of t to true
+                        set targetWinId to id of w
+                        exit repeat
+                    end if
+                end repeat
+                if targetWinId is not missing value then exit repeat
+            end repeat
+            if targetWinId is missing value then return "not found"
+            try
+                if miniaturized of (window id targetWinId) then set miniaturized of (window id targetWinId) to false
+            end try
+            set index of (window id targetWinId) to 1
+            set frontmost of (window id targetWinId) to true
+            activate
+            return "found"
+        end tell
+        "#,
+        tty = tty
+    );
+
+    let output = Command::new("osascript")
+        .arg("-e")
+        .arg(&script)
+        .output()
+        .map_err(|e| format!("Failed to run AppleScript: {}", e))?;
+
+    let result = String::from_utf8_lossy(&output.stdout).trim().to_string();
+    crate::debug_log::log_info(&format!(
+        "[open_session] Terminal tty match result: {}",
+        result
+    ));
+
+    if result != "found" {
+        // Tab no longer exists (or tty changed) — fall back to app activation
+        return activate_app_fallback("Terminal");
+    }
+
+    Ok(())
+}
+
 /// Focus the correct JetBrains IDE project window using the IDE's URL scheme.
 ///
 /// JetBrains IDEs register custom URL schemes (e.g., phpstorm://, idea://) that
@@ -250,8 +331,9 @@ fn activate_app_fallback(app_name: &str) -> Result<(), String> {
     // so we use System Events to set AXMinimized to false.
     //
     // This fallback is used by terminals without a dedicated code path or CLI:
-    // Ghostty, Alacritty, kitty, Warp, Hyper, WezTerm, macOS Terminal, etc.
-    // (iTerm2 has its own focus_iterm2_session; VS Code/Cursor/Zed use CLI.)
+    // Ghostty, Alacritty, kitty, Warp, Hyper, WezTerm, etc.
+    // (iTerm2 and macOS Terminal have their own tty-matching focus functions;
+    // VS Code/Cursor/Zed use CLI.)
     //
     // Notes:
     // - Unminimizes ALL windows of the app, not just the target one.


### PR DESCRIPTION
## Description

Gives macOS **Terminal.app** exact window/tab focus when you click a session, matching the treatment `focus_iterm2_session` already provides for iTerm2. Previously, Terminal.app sessions fell through to `activate_app_fallback`, which raises the app but can't select the specific window/tab hosting the session — so with several Terminal windows open you land on whichever was last focused instead of the one you clicked.

## Type of Change

- [x] New feature (non-breaking change that adds functionality)

## Motivation and Context

Terminal.app tabs expose their `tty` in the scripting dictionary (just like iTerm2 sessions), and `get_session_tty()` already resolves a session's tty. So the exact tab can be selected rather than only bringing the app forward. This closes the gap for users whose sessions run in stock Terminal.app windows.

No linked issue.

## How It Works

- New `focus_terminal_session(pid)`: resolve the session tty via the existing `get_session_tty` walker, then AppleScript over `windows`/`tabs` matching `tty of t ends with "<tty>"`.
- **Ordering is load-bearing.** Select the tab and raise its window *by a stable window id* (not the `repeat` loop variable), then call `activate` **last**. Calling `activate` first surfaces whatever window was already frontmost, and a later raise of a background window does not reliably re-order the display — so a session in a non-frontmost window would be missed. (This was a real bug in an earlier revision, caught by measuring the frontmost window before/after.)
- Minimized windows are restored via Terminal's native `miniaturized` property — no Accessibility permission required (unlike the `AXMinimized` path in `activate_app_fallback`).
- Falls back to `activate_app_fallback("Terminal")` when no tty is found or no tab matches.

## How Has This Been Tested?

- [x] Tested production build (`npm run tauri build`)
- [x] Tested on macOS (version: 15 / Darwin 24.6, Apple Silicon)

Driven through the real `open_session` path against Claude Code sessions living in **separate** Terminal.app windows, asserting the target window actually becomes frontmost (frontmost window id `before → after` changed to the target). A nonexistent tty cleanly returns `not found` and triggers the existing fallback.

## Screenshots (if applicable)

N/A — this is focus behavior rather than a UI change; verified by the before/after frontmost-window check described above.

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have run `cargo fmt` and `cargo clippy` on Rust code
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] My commit messages follow the Conventional Commits format

## Additional Notes

- macOS-only change; no frontend/UI changes.
- First use sends Apple events to Terminal, so macOS shows the standard "control Terminal.app" Automation consent prompt on first focus — same as the existing iTerm2 path.
- `cargo fmt`/`clippy`: my additions introduce no new findings. I deliberately did **not** reformat pre-existing formatting in `actions.rs` unrelated to this change, to keep the diff focused.
- Known follow-up (not addressed here): when Automation consent is denied, `osascript` fails and focus silently no-ops — the `focus_iterm2_session` path has the same behavior. Surfacing that as an actionable error would be a nice separate improvement.
