### PR TITLE
feat: disable PM orchestration by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+- **PM orchestration is now disabled by default.** Claude Code and Codex
+  provide native agent spawning, so c9watch's own PM/worker orchestration is
+  opt-in. Normal builds omit the PM CLI subcommands (`spawn`, `send`,
+  `workers`, `inbox`, `adopt`, `daemon`) and hide the dashboard's
+  HUMANS/WORKERS toggle, WORKER/PM badges, worker title prefix, and Workers
+  panel. All sessions still show normally — records with legacy `workerOf`
+  metadata render as ordinary sessions — and the native Subagents panel is
+  unchanged. The implementation is preserved, not removed:
+  - Enable the CLI with the `pm-orchestration` Cargo feature:
+    `cargo build --no-default-features --features cli,pm-orchestration`.
+  - Enable the dashboard UI by setting `PM_ORCHESTRATION_ENABLED = true` in
+    `src/lib/feature-flags.ts`.
+
 ### Added
 - PM-orchestration `bg` backend: spawn workers via `claude --bg` instead of
   `claude --print`. Workers stay on Pro/Max subscription quota after

--- a/README.md
+++ b/README.md
@@ -145,12 +145,26 @@ c9watch cost --daily
 c9watch cost --session abc12345 --pretty
 c9watch cost --session-prefix abc
 
-# PM orchestration: spawn and manage child worker sessions
+# PM orchestration (opt-in — see note below): spawn and manage child workers
 c9watch spawn --name my-worker --cwd ../my-worktree --append-system-prompt "..."
 c9watch send <session-id> --message "do this task"
 c9watch workers
 c9watch inbox --pretty
 ```
+
+> **PM orchestration is disabled by default.** Claude Code and Codex now
+> provide native agent spawning, so c9watch's own PM/worker orchestration is
+> opt-in. The `spawn`, `send`, `workers`, `inbox`, and `adopt` subcommands
+> (and their dashboard affordances) are hidden in normal builds. Build with
+> the Cargo feature to enable them:
+>
+> ```bash
+> cargo build --release --no-default-features --features cli,pm-orchestration
+> ```
+>
+> To also surface the WORKER/PM badges and Workers panel in the dashboard,
+> set `PM_ORCHESTRATION_ENABLED = true` in `src/lib/feature-flags.ts` before
+> building the GUI.
 
 Use `--pretty` on any command for human-readable JSON. The `watch` command streams newline-delimited JSON events (`started`, `status_changed`, `stopped`) for real-time monitoring.
 
@@ -177,11 +191,7 @@ See [SKILLS.md](SKILLS.md) for more install options.
 - **Memory viewer** -- Browse and inspect Claude Code memory files with a two-panel layout and quick Claude command access
 - **Cost tracker** -- Track Claude Code spending with daily, per-project, and per-model breakdowns; click any session to preview the conversation; sort by date or cost
 - **CLI for agents** -- `c9watch list`, `view`, `history`, `search`, `stop`, `watch`, `cost` commands for scriptable session management and agent-to-agent monitoring
-- **PM orchestration** -- Spawn, message, and manage child Claude Code "worker" sessions from a parent "PM" session via `c9watch spawn`, `send`, `workers`, `adopt`, `inbox`, `tasks`. WORKER and PM badges visible on session cards; PMs show a Workers panel in the overlay
-- **PM-orchestration on subscription quota** — c9watch workers run as
-  `claude --bg` background-pinned sessions, billed against your Pro/Max
-  chat quota (not the separate Agent SDK credit pool that took effect
-  2026-06-15). Falls back to legacy `--print` mode on older CC.
+- **PM orchestration** _(disabled by default)_ -- Spawn, message, and manage child Claude Code "worker" sessions from a parent "PM" session via `c9watch spawn`, `send`, `workers`, `adopt`, `inbox`, `tasks`. WORKER and PM badges on session cards and a Workers panel in the overlay. Now that Claude Code and Codex spawn agents natively, this is opt-in: build the CLI with `--features cli,pm-orchestration` and set `PM_ORCHESTRATION_ENABLED = true` in `src/lib/feature-flags.ts` for the dashboard. Workers run as `claude --bg` background-pinned sessions, billed against your Pro/Max chat quota (not the separate Agent SDK credit pool that took effect 2026-06-15), falling back to legacy `--print` mode on older CC.
 - **Subagent visibility** -- Detect and display Task-tool subagents spawned inside any session, with click-to-preview transcripts
 - **Entry animations** -- Staggered cascade transitions across tabs and overlay panels for fluid navigation
 - **Token distance visualizer** -- See your token usage as a rice stack towering past 22 real-world landmarks, with animated stacking, native share sheet, and Instagram-ready PNG export

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -34,6 +34,10 @@ gui = [
     "dep:tauri-nspanel",
 ]
 cli = ["dep:clap", "dep:regex", "dep:tokio"]
+# PM/worker orchestration (spawn/send/workers/inbox/adopt/daemon). Opt-in only —
+# Claude Code and Codex now provide native agent spawning, so this is excluded
+# from `default`. Build with `--features pm-orchestration` to expose it.
+pm-orchestration = ["cli"]
 
 [build-dependencies]
 tauri-build = { version = "2", features = [], optional = true }

--- a/src-tauri/src/cli/mod.rs
+++ b/src-tauri/src/cli/mod.rs
@@ -127,8 +127,16 @@ pub enum Commands {
     /// matches a live PM worker's session id (exact or unique prefix), the
     /// worker is stopped. Otherwise, a numeric target is treated as a PID
     /// and the corresponding Claude process is killed.
+    #[cfg(feature = "pm-orchestration")]
     Stop {
         /// Worker session id/prefix (preferred) or numeric PID for regular sessions
+        target: String,
+    },
+
+    /// Stop a session by PID (kills the corresponding Claude process).
+    #[cfg(not(feature = "pm-orchestration"))]
+    Stop {
+        /// Numeric PID of the session's Claude process
         target: String,
     },
 

--- a/src-tauri/src/cli/mod.rs
+++ b/src-tauri/src/cli/mod.rs
@@ -17,16 +17,28 @@ pub enum CostSortDir {
     Desc,
 }
 
+// PM/worker orchestration modules — opt-in only. Compiled out of default builds.
+#[cfg(feature = "pm-orchestration")]
 pub mod adoption;
+#[cfg(feature = "pm-orchestration")]
 pub mod bg_backend;
+#[cfg(feature = "pm-orchestration")]
 pub mod bg_protocol;
+#[cfg(feature = "pm-orchestration")]
 pub mod worker_backend;
+#[cfg(feature = "pm-orchestration")]
 pub mod pm;
+#[cfg(feature = "pm-orchestration")]
 pub mod pm_caller;
+#[cfg(feature = "pm-orchestration")]
 pub mod pm_daemon;
+#[cfg(feature = "pm-orchestration")]
 pub mod pm_fs;
+#[cfg(feature = "pm-orchestration")]
 pub mod pm_inbox;
+#[cfg(feature = "pm-orchestration")]
 pub mod pm_rpc;
+#[cfg(feature = "pm-orchestration")]
 pub mod pm_worker;
 
 #[derive(Parser)]
@@ -146,6 +158,7 @@ pub enum Commands {
     },
 
     /// Spawn a new worker session managed by c9watch
+    #[cfg(feature = "pm-orchestration")]
     Spawn {
         #[arg(long)]
         cwd: Option<String>,
@@ -168,6 +181,7 @@ pub enum Commands {
     },
 
     /// Send a message to a spawned worker session
+    #[cfg(feature = "pm-orchestration")]
     Send {
         session_id: String,
         #[arg(long)]
@@ -183,6 +197,7 @@ pub enum Commands {
     },
 
     /// List workers spawned by c9watch
+    #[cfg(feature = "pm-orchestration")]
     Workers {
         /// Include workers owned by other PMs (adds a status column per entry)
         #[arg(long)]
@@ -190,6 +205,7 @@ pub enum Commands {
     },
 
     /// List callback events from workers owned by this PM session
+    #[cfg(feature = "pm-orchestration")]
     Inbox {
         /// Remove events after listing
         #[arg(long)]
@@ -203,6 +219,7 @@ pub enum Commands {
     },
 
     /// Adopt an existing worker as owned by this PM session
+    #[cfg(feature = "pm-orchestration")]
     Adopt {
         /// Worker session id or unique prefix
         session_id: String,
@@ -241,6 +258,7 @@ pub enum Commands {
     },
 
     /// [hidden] Run the PM daemon
+    #[cfg(feature = "pm-orchestration")]
     #[command(hide = true)]
     Daemon,
 }
@@ -280,6 +298,7 @@ pub fn run(cli: Cli) {
             changes_only,
         } => cmd_watch(interval, project.as_deref(), compact, changes_only),
         Commands::Tasks { session_id } => cmd_tasks(&session_id, cli.pretty),
+        #[cfg(feature = "pm-orchestration")]
         Commands::Spawn {
             cwd,
             name,
@@ -307,6 +326,7 @@ pub fn run(cli: Cli) {
             };
             pm::cmd_spawn(args, append_system_prompt_file, prompt, cli.pretty)
         })(),
+        #[cfg(feature = "pm-orchestration")]
         Commands::Send {
             session_id,
             message,
@@ -315,14 +335,18 @@ pub fn run(cli: Cli) {
             wait,
             timeout,
         } => pm::cmd_send(session_id, message, stdin, file, wait, timeout, cli.pretty),
+        #[cfg(feature = "pm-orchestration")]
         Commands::Workers { all } => pm::cmd_workers(all, cli.pretty),
+        #[cfg(feature = "pm-orchestration")]
         Commands::Inbox { consume, clear, worker } => {
             pm::cmd_inbox(consume, clear, worker, cli.pretty)
         }
+        #[cfg(feature = "pm-orchestration")]
         Commands::Adopt { session_id, force } => pm::cmd_adopt(session_id, force, cli.pretty),
         Commands::Cost { daily, weekly, project, since, sort, sort_dir, session, session_prefix } => {
             cmd_cost(daily, weekly, project.as_deref(), since.as_deref(), sort, sort_dir, session.as_deref(), session_prefix.as_deref(), cli.pretty)
         }
+        #[cfg(feature = "pm-orchestration")]
         Commands::Daemon => {
             match tokio::runtime::Runtime::new() {
                 Ok(rt) => rt.block_on(pm_daemon::run_daemon()),
@@ -576,6 +600,7 @@ fn cmd_stop(target: &str, pretty: bool) -> Result<(), String> {
     // previously parse as PID and SIGKILL an arbitrary OS process. Ask the
     // daemon for a worker match first; only fall back to PID if no worker
     // matches AND the target parses as u32.
+    #[cfg(feature = "pm-orchestration")]
     if let Some(worker_id) = try_resolve_worker(target) {
         return pm::cmd_stop(worker_id, pretty);
     }
@@ -592,7 +617,15 @@ fn cmd_stop(target: &str, pretty: bool) -> Result<(), String> {
 
     // Not numeric, no worker match — fall through to PM so it can surface
     // WORKER_NOT_FOUND (after starting the daemon if needed).
-    pm::cmd_stop(target.to_string(), pretty)
+    #[cfg(feature = "pm-orchestration")]
+    return pm::cmd_stop(target.to_string(), pretty);
+
+    // Without PM orchestration a non-numeric target can't refer to anything.
+    #[cfg(not(feature = "pm-orchestration"))]
+    Err(format!(
+        "invalid stop target '{}': expected a numeric PID",
+        target
+    ))
 }
 
 /// If the PM daemon is already running and has exactly one worker whose
@@ -603,6 +636,7 @@ fn cmd_stop(target: &str, pretty: bool) -> Result<(), String> {
 ///
 /// This function never starts the daemon: if the daemon isn't running there
 /// can't be any workers to match against, so PID-based stop is safe.
+#[cfg(feature = "pm-orchestration")]
 fn try_resolve_worker(target: &str) -> Option<String> {
     use std::time::Duration;
     let sock_path = pm_fs::daemon_sock_path().ok()?;

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -10,11 +10,16 @@ fn main() {
         let args: Vec<String> = std::env::args().collect();
         if args.len() > 1 {
             let first = args[1].as_str();
-            let known_commands = [
+            #[allow(unused_mut)]
+            let mut known_commands: Vec<&str> = vec![
                 "list", "status", "self", "view", "history", "search", "stop", "watch", "tasks",
-                "spawn", "send", "workers", "inbox", "adopt", "cost", "daemon",
-                "help",
+                "cost", "help",
             ];
+            // PM/worker orchestration subcommands are opt-in only.
+            #[cfg(feature = "pm-orchestration")]
+            known_commands.extend_from_slice(&[
+                "spawn", "send", "workers", "inbox", "adopt", "daemon",
+            ]);
             let is_cli = known_commands.contains(&first)
                 || first == "--help"
                 || first == "-h"

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -10,16 +10,15 @@ fn main() {
         let args: Vec<String> = std::env::args().collect();
         if args.len() > 1 {
             let first = args[1].as_str();
-            #[allow(unused_mut)]
-            let mut known_commands: Vec<&str> = vec![
+            // Always route PM command names through Clap. When the
+            // `pm-orchestration` feature is disabled their variants are absent,
+            // so Clap reports an unknown command instead of falling through and
+            // unexpectedly launching the GUI.
+            let known_commands = [
                 "list", "status", "self", "view", "history", "search", "stop", "watch", "tasks",
+                "spawn", "send", "workers", "inbox", "adopt", "daemon",
                 "cost", "help",
             ];
-            // PM/worker orchestration subcommands are opt-in only.
-            #[cfg(feature = "pm-orchestration")]
-            known_commands.extend_from_slice(&[
-                "spawn", "send", "workers", "inbox", "adopt", "daemon",
-            ]);
             let is_cli = known_commands.contains(&first)
                 || first == "--help"
                 || first == "-h"

--- a/src/lib/components/ExpandedCardOverlay.svelte
+++ b/src/lib/components/ExpandedCardOverlay.svelte
@@ -45,6 +45,7 @@
 	import { sessionCostMap, costMode } from '$lib/stores/cost';
 	import { workersByPm, expandedSessionId } from '$lib/stores/sessions';
 	import { visibleSubagentsBySession } from '$lib/stores/subagents';
+	import { PM_ORCHESTRATION_ENABLED } from '$lib/feature-flags';
 	import { formatCost, formatTokens, formatCostOrTokens, modelDisplayName } from '$lib/cost-utils';
 	import { formatTimeSince, formatDurationMs } from '$lib/time-utils';
 	import { getSessionStatusColor, getSessionStatusLabel, getSubagentStatusColor, getSubagentStatusLabel, getWorkerStatusColor, getWorkerStatusLabel } from '$lib/status-utils';
@@ -174,8 +175,12 @@
 	let resolvedWorkers = $derived(
 		$workersByPm.get(session.workerOf ?? session.id) ?? []
 	);
-	let isPm = $derived(!session.workerOf && resolvedWorkers.length > 0);
-	let showWorkersPanel = $derived(resolvedWorkers.length > 0);
+	let isPm = $derived(
+		PM_ORCHESTRATION_ENABLED && !session.workerOf && resolvedWorkers.length > 0
+	);
+	let showWorkersPanel = $derived(
+		PM_ORCHESTRATION_ENABLED && resolvedWorkers.length > 0
+	);
 
 	let mySubagents = $derived($visibleSubagentsBySession.get(session.id) ?? []);
 	let hasSubagents = $derived(mySubagents.length > 0);
@@ -317,7 +322,7 @@
 								onmouseleave={tipLeave}
 								onmousemove={tipMove}
 							>{session.customTitle || session.summary || session.firstPrompt || 'New Session'}</h2>
-							{#if session.workerOf}
+							{#if PM_ORCHESTRATION_ENABLED && session.workerOf}
 								<!-- svelte-ignore a11y_no_static_element_interactions -->
 								<span
 									class="worker-badge"

--- a/src/lib/components/SessionCard.svelte
+++ b/src/lib/components/SessionCard.svelte
@@ -4,6 +4,7 @@
 	import { sessionCostMap, costMode } from '$lib/stores/cost';
 	import { workersByPm } from '$lib/stores/sessions';
 	import { formatCostOrTokens } from '$lib/cost-utils';
+	import { PM_ORCHESTRATION_ENABLED } from '$lib/feature-flags';
 
 	interface Props {
 		session: Session;
@@ -166,7 +167,7 @@
 >
 	<!-- Card Content -->
 	<div class="card-body">
-		{#if workersView && session.workerOf}
+		{#if PM_ORCHESTRATION_ENABLED && workersView && session.workerOf}
 			<!-- svelte-ignore a11y_no_static_element_interactions -->
 			<div
 				class="pm-prefix"
@@ -218,7 +219,7 @@
 		<div class="stats-row">
 			<div class="badge-group">
 				<span class="session-name-badge">{session.sessionName}</span>
-				{#if session.workerOf && !workersView}
+				{#if PM_ORCHESTRATION_ENABLED && session.workerOf && !workersView}
 					<!-- svelte-ignore a11y_no_static_element_interactions -->
 					<span
 						class="worker-badge"
@@ -227,7 +228,7 @@
 						onmousemove={tipMove}
 					>WORKER</span>
 				{/if}
-				{#if isPm}
+				{#if PM_ORCHESTRATION_ENABLED && isPm}
 					<!-- svelte-ignore a11y_no_static_element_interactions -->
 					<span
 						class="pm-badge"

--- a/src/lib/feature-flags.ts
+++ b/src/lib/feature-flags.ts
@@ -1,0 +1,21 @@
+/**
+ * Centralized frontend feature flags.
+ *
+ * These are compile-time constants intentionally set to their shipping
+ * defaults. Flip a flag here (and rebuild) to opt into the corresponding
+ * behavior — there is no runtime UI toggle.
+ */
+
+/**
+ * PM/worker orchestration UI (HUMANS/WORKERS toggle, WORKER/PM badges,
+ * worker title prefix, and the Workers side panel).
+ *
+ * Disabled by default: Claude Code and Codex now provide native agent
+ * spawning, so c9watch focuses on monitoring rather than presenting its own
+ * orchestration workflow. When off, every session is still shown normally —
+ * sessions carrying legacy `workerOf` metadata render as ordinary sessions —
+ * and the native Subagents panel is unaffected.
+ *
+ * Pairs with the Rust `pm-orchestration` Cargo feature, which gates the CLI.
+ */
+export const PM_ORCHESTRATION_ENABLED = false;

--- a/src/routes/(app)/+page.svelte
+++ b/src/routes/(app)/+page.svelte
@@ -12,6 +12,7 @@
 	} from '$lib/stores/sessions';
 	import { getConversation, stopSession, openSession } from '$lib/api';
 	import { isDemoMode, toggleDemoMode } from '$lib/demo';
+	import { PM_ORCHESTRATION_ENABLED } from '$lib/feature-flags';
 	import { isTauri } from '$lib/ws';
 	import StatusBar from '$lib/components/StatusBar.svelte';
 	import SessionCard from '$lib/components/SessionCard.svelte';
@@ -253,10 +254,14 @@
 		});
 	}
 
+	// With PM orchestration disabled, show every session — legacy `workerOf`
+	// records render as ordinary sessions and the HUMANS/WORKERS split is gone.
 	let filteredSessions = $derived(
-		sessions.filter((s) =>
-			sessionFilter === 'workers' ? !!s.workerOf : !s.workerOf
-		)
+		!PM_ORCHESTRATION_ENABLED
+			? sessions
+			: sessions.filter((s) =>
+					sessionFilter === 'workers' ? !!s.workerOf : !s.workerOf
+				)
 	);
 
 	let projectGroups = $derived(groupByProjectAndStatus(filteredSessions));
@@ -490,6 +495,7 @@
 						</button>
 					{/if}
 					<div class="header-spacer"></div>
+					{#if PM_ORCHESTRATION_ENABLED}
 					<div class="view-toggle">
 						<button
 							type="button"
@@ -518,6 +524,7 @@
 							</svg>
 						</button>
 					</div>
+					{/if}
 					<div class="view-toggle">
 						<button
 							class="toggle-btn"

--- a/src/routes/(app)/+page.svelte
+++ b/src/routes/(app)/+page.svelte
@@ -71,7 +71,10 @@
 				isCompact = true;
 			}
 			const savedFilter = localStorage.getItem('sessionFilter');
-			if (savedFilter === 'humans' || savedFilter === 'workers') {
+			if (
+				PM_ORCHESTRATION_ENABLED &&
+				(savedFilter === 'humans' || savedFilter === 'workers')
+			) {
 				sessionFilter = savedFilter;
 			}
 		}
@@ -590,7 +593,7 @@
 						</div>
 					</div>
 					<div class="empty-content">
-						{#if sessionFilter === 'workers'}
+						{#if PM_ORCHESTRATION_ENABLED && sessionFilter === 'workers'}
 							<h2>No Workers Spawned</h2>
 							<p>Spawn a worker from a Claude Code session with <code>c9watch spawn</code></p>
 							<div class="empty-hint">


### PR DESCRIPTION
## Summary

- Add an opt-in Rust `pm-orchestration` Cargo feature, disabled in normal builds
- Compile PM-only modules and CLI commands only when the feature is enabled
- Add a centralized frontend flag, disabled by default
- Hide the HUMANS/WORKERS toggle, PM/WORKER badges, worker prefix, and Workers panel
- Continue showing every session normally, including records with legacy `workerOf` metadata
- Preserve native Claude Code and Codex subagent visibility
- Document how to opt back into the preserved PM implementation

## Why

Claude Code and Codex now support native agent spawning, so c9watch's custom PM/worker orchestration is no longer important enough to ship in the default product surface. PR #108 was merged first to preserve its completed `claude --bg` backend; this PR keeps that implementation available for opt-in builds rather than deleting it.

## Opt-in

CLI:

```bash
cargo build --release --no-default-features --features cli,pm-orchestration
```

Dashboard UI: set `PM_ORCHESTRATION_ENABLED = true` in `src/lib/feature-flags.ts` before building.

## Test plan

- [x] Default CLI tests: 240 passed, 0 failed
- [x] Default CLI help omits PM commands and describes `stop` as PID-only
- [x] Opt-in `cli,pm-orchestration` tests: 333 passed, 0 failed
- [x] Opt-in CLI help retains PM commands and worker-aware `stop`
- [x] `svelte-check`: 0 errors; 3 unrelated pre-existing warnings
- [x] Independent simplify review: PASS after fixing default `stop --help`
- [x] `git diff --check main..HEAD`
