### PR TITLE
docs: add Codex monitoring implementation TODO

### DIFF
--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -1,0 +1,30 @@
+# Product TODO
+
+## Codex native monitoring
+
+Do not begin the implementation tasks below until the native-mechanism investigation is
+complete. First determine whether Codex provides a supported interface comparable to
+`claude --agents`—through the Codex CLI, App Server, hooks, notifications, or another
+structured event mechanism—and whether it works for both Codex App and Codex CLI sessions.
+
+**Decision (2026-07-13): use a hybrid architecture.** Codex has no external equivalent to
+`claude --agents --json`, and a separate App Server cannot observe another process's
+in-memory live state. Keep cached/incremental rollout polling as the zero-configuration
+source of truth for Codex App and CLI sessions. Add optional, user-installed Codex lifecycle
+hooks for low-latency session and subagent start/stop signals, then reconcile hook events
+with rollout metadata for hierarchy, recovery, history, and tokens. Do not attach to Codex
+Desktop's private IPC socket.
+
+- [x] Investigate the Codex native solution first and document whether it can replace or
+  strengthen rollout-file polling for live root-session and subagent monitoring. Verdict:
+  hooks strengthen polling, but no supported native mechanism replaces it for arbitrary
+  existing Codex App and CLI sessions.
+- [ ] Revise the design with explicit `provider`, `surface`, and `agent_kind` fields.
+- [ ] Implement the shared cached rollout parser and App/CLI detector, if still required
+  after the native-mechanism investigation.
+- [ ] Add visible `CLAUDE CODE` and `CODEX` badges plus a shared, persisted
+  `All | Claude Code | Codex` provider filter across all tabs.
+- [ ] Add Codex subagent grouping, with normal subagents nested under their parent and
+  internal guardian/review agents hidden by default.
+- [ ] Extend HISTORY and COST so their provider filters operate on real Claude Code and
+  Codex data rather than acting as cosmetic filters.


### PR DESCRIPTION
## Summary

- Record the native Codex monitoring investigation as the prerequisite for implementation
- Document the hybrid decision: cached rollout polling plus optional lifecycle hooks
- Track provider/surface/agent-kind design, App/CLI detection, badges and filters, subagent grouping, and HISTORY/COST work

## Investigation verdict

Codex does not expose an external equivalent to `claude --agents --json`. App Server cannot attach to arbitrary existing App or CLI runtimes, so cached rollout polling remains the zero-configuration baseline. Optional Codex lifecycle hooks can strengthen it with low-latency session and subagent events.

## Test plan

- [x] `git diff --check`
- [x] Confirm only `docs/TODO.md` is added
