### PR TITLE
feat: focus exact Supacode tab and surface when opening a session

### DIFF
--- a/src-tauri/src/actions.rs
+++ b/src-tauri/src/actions.rs
@@ -19,6 +19,13 @@ pub fn open_session(pid: u32, project_path: String) -> Result<(), String> {
         app_name, project_name, project_path
     ));
 
+    // Supacode: the session's env carries its worktree/tab/surface IDs,
+    // so we can focus the exact surface via the bundled `supacode` CLI (macOS only)
+    #[cfg(target_os = "macos")]
+    if app_name == "supacode" {
+        return focus_supacode_session(pid);
+    }
+
     // iTerm2: use tty matching to focus the correct tab (macOS only)
     #[cfg(target_os = "macos")]
     if app_name == "iTerm" || app_name == "iTerm2" {
@@ -121,6 +128,109 @@ fn get_session_tty(pid: u32) -> Option<String> {
         current_pid = ppid;
     }
     None
+}
+
+/// Read a single environment variable from a running process via `ps eww`.
+/// Only visible for processes owned by the current user, which is the case
+/// for the Claude sessions c9watch monitors.
+#[cfg(target_os = "macos")]
+fn get_process_env(pid: u32, key: &str) -> Option<String> {
+    let output = Command::new("ps")
+        .arg("eww")
+        .arg("-o")
+        .arg("command=")
+        .arg("-p")
+        .arg(pid.to_string())
+        .output()
+        .ok()?;
+    let raw = String::from_utf8_lossy(&output.stdout);
+    let prefix = format!("{}=", key);
+    // `ps eww` appends env as space-separated KEY=VALUE words. Supacode IDs are
+    // URL-encoded / UUIDs, so they never contain spaces.
+    raw.split_whitespace()
+        .find_map(|word| word.strip_prefix(prefix.as_str()).map(|v| v.to_string()))
+}
+
+/// Locate the `supacode` CLI bundled with the app
+#[cfg(target_os = "macos")]
+fn get_supacode_cli() -> Option<String> {
+    let paths = [
+        "/Applications/supacode.app/Contents/Resources/bin/supacode",
+        "/usr/local/bin/supacode",
+    ];
+    paths
+        .iter()
+        .find(|p| std::path::Path::new(p).exists())
+        .map(|p| p.to_string())
+}
+
+/// Focus the exact Supacode tab + surface owning a Claude session.
+///
+/// Supacode injects SUPACODE_WORKTREE_ID / SUPACODE_TAB_ID / SUPACODE_SURFACE_ID
+/// into every surface's shell, so the Claude process's own environment says
+/// exactly where it lives. The bundled `supacode` CLI does the focusing.
+#[cfg(target_os = "macos")]
+fn focus_supacode_session(pid: u32) -> Result<(), String> {
+    let worktree = get_process_env(pid, "SUPACODE_WORKTREE_ID");
+    let tab = get_process_env(pid, "SUPACODE_TAB_ID");
+    let surface = get_process_env(pid, "SUPACODE_SURFACE_ID");
+
+    crate::debug_log::log_info(&format!(
+        "[open_session] Supacode coords for PID {}: worktree={:?} tab={:?} surface={:?}",
+        pid, worktree, tab, surface
+    ));
+
+    // Bring the app to the front first so the focused surface is visible
+    activate_app_fallback("supacode")?;
+
+    let (Some(worktree), Some(tab)) = (worktree, tab) else {
+        // Env not visible (or an older Supacode without the vars) —
+        // app-level activation is the best we can do
+        return Ok(());
+    };
+
+    let Some(cli) = get_supacode_cli() else {
+        crate::debug_log::log_error("[open_session] Supacode CLI not found");
+        return Ok(());
+    };
+
+    let mut tab_cmd = Command::new(&cli);
+    tab_cmd
+        .arg("tab")
+        .arg("focus")
+        .arg("--worktree")
+        .arg(&worktree)
+        .arg("--tab")
+        .arg(&tab)
+        .arg("--timeout")
+        .arg("5");
+    if let Err(e) = tab_cmd.output() {
+        crate::debug_log::log_error(&format!("[open_session] supacode tab focus failed: {}", e));
+        return Ok(());
+    }
+
+    if let Some(surface) = surface {
+        let mut surface_cmd = Command::new(&cli);
+        surface_cmd
+            .arg("surface")
+            .arg("focus")
+            .arg("--worktree")
+            .arg(&worktree)
+            .arg("--tab")
+            .arg(&tab)
+            .arg("--surface")
+            .arg(&surface)
+            .arg("--timeout")
+            .arg("5");
+        if let Err(e) = surface_cmd.output() {
+            crate::debug_log::log_error(&format!(
+                "[open_session] supacode surface focus failed: {}",
+                e
+            ));
+        }
+    }
+
+    Ok(())
 }
 
 /// Focus the correct iTerm2 tab/session by matching tty
@@ -796,6 +906,12 @@ fn get_app_name(comm: &str) -> Option<&'static str> {
         if comm_lower.contains(".app/") || comm_lower.contains(".app") {
             if comm_lower.contains("zed.app") {
                 return Some("Zed");
+            }
+            // Supacode's surfaces run under a zmx helper that re-parents to
+            // launchd, but its binary path still lives inside supacode.app.
+            // Must be checked BEFORE VS Code: "supacode.app" contains "code.app".
+            if comm_lower.contains("supacode.app") {
+                return Some("supacode");
             }
             if comm_lower.contains("visual studio code.app") || comm_lower.contains("code.app") {
                 return Some("Visual Studio Code");


### PR DESCRIPTION
## Description

Adds support for [Supacode](https://supacode.app) to the open button: clicking open on a Supacode-hosted session now brings Supacode to the front and focuses the exact tab and pane that owns the session.

It also fixes a substring collision: `supacode.app` matches the `code.app` check in `get_app_name`, so sessions running inside Supacode were detected as Visual Studio Code and the open button activated the wrong app (or failed silently when VS Code was not installed).

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Code refactoring
- [ ] Other (please describe):

## Motivation and Context

Supacode surfaces run under a `zmx` helper process that re-parents to launchd, so the parent-app walk in `find_parent_app` can never reach the Supacode GUI process. Combined with the `code.app` substring collision, Supacode users currently get no useful open behaviour at all.

How it works: Supacode injects `SUPACODE_WORKTREE_ID` / `SUPACODE_TAB_ID` / `SUPACODE_SURFACE_ID` into every surface's shell, so the Claude process's own environment says exactly where it lives. `focus_supacode_session` reads them with `ps eww -p <pid>` and calls the `supacode` CLI bundled with the app (`tab focus` + `surface focus`) to jump to the exact pane. If the env vars or the CLI are missing (e.g. an older Supacode version), it falls back to app-level activation.

## How Has This Been Tested?

- [ ] Tested in development mode (`npm run tauri dev`)
- [x] Tested production build (`npm run tauri build`)
- [x] Tested on macOS (version: 26, Apple Silicon)
- [ ] Tested on Linux (distro: )
- [ ] Tested on Windows (version: )

Tested with ~16 live Claude Code sessions spread across Supacode worktree tabs: open now focuses the exact tab and pane of the clicked session. Sessions hosted in other terminals/IDEs are unaffected (the new branch only triggers when the process walk resolves to `supacode.app`).

## Screenshots (if applicable)

No UI changes.

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have run `cargo fmt` and `cargo clippy` on Rust code
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] I have updated the documentation accordingly
- [x] My commit messages follow the [Conventional Commits](https://www.conventionalcommits.org/) format

## Additional Notes

- `cargo fmt` on current `main` reformats ~26 pre-existing files, so I kept that churn out of this PR; the added code itself is fmt-clean and clippy-clean.
- Docs checkbox left unticked because no user-facing docs mention per-terminal focus behaviour; happy to add a README note if you'd like one.
