### PR TITLE
fix: preserve Codex CLI search metadata and prefixes

### DIFF
--- a/src-tauri/src/cli/mod.rs
+++ b/src-tauri/src/cli/mod.rs
@@ -510,7 +510,35 @@ fn cmd_search(
     if query.trim().is_empty() {
         return Err("Search query cannot be empty".to_string());
     }
-    let hits = session::deep_search(query, case_sensitive, whole_word)?;
+    let home_dir = dirs::home_dir().ok_or("Failed to get home directory")?;
+    let output = cmd_search_output(
+        &home_dir,
+        query,
+        project_filter,
+        limit,
+        case_sensitive,
+        whole_word,
+    )?;
+    print_json(&output, pretty)
+}
+
+fn cmd_search_output(
+    home_dir: &std::path::Path,
+    query: &str,
+    project_filter: Option<&str>,
+    limit: usize,
+    case_sensitive: bool,
+    whole_word: bool,
+) -> Result<serde_json::Value, String> {
+    if query.trim().is_empty() {
+        return Err("Search query cannot be empty".to_string());
+    }
+    let hits = session::history::deep_search_under(
+        home_dir,
+        query,
+        case_sensitive,
+        whole_word,
+    )?;
 
     let enriched: Vec<serde_json::Value> = hits
         .into_iter()
@@ -524,7 +552,7 @@ fn cmd_search(
         "hits": enriched,
         "truncated": enriched.len() == limit,
     });
-    print_json(&output, pretty)
+    Ok(output)
 }
 
 /// Identify the calling agent's own session by walking up the PID tree
@@ -1689,21 +1717,45 @@ mod session_formatter_tests {
     }
 
     #[test]
-    fn codex_search_hit_metadata_keeps_real_project_and_modified_timestamp() {
-        let value = enrich_search_hit(session::DeepSearchHit {
-            session_id: "codex-search".to_string(),
-            snippet: "search marker".to_string(),
-            project_path: Some("/tmp/codex-project".to_string()),
-            modified: Some("2026-07-13T02:03:04+00:00".to_string()),
-            provider: "codex".to_string(),
-            surface: Some("cli".to_string()),
-            agent_kind: "root".to_string(),
-        });
+    fn codex_rollout_search_wiring_attaches_metadata_and_filters_project() {
+        let home = tempfile::tempdir().unwrap();
+        let sessions = home.path().join(".codex/sessions/2026/07/13");
+        std::fs::create_dir_all(&sessions).unwrap();
+        std::fs::write(
+            sessions.join("rollout-codex-search.jsonl"),
+            concat!(
+                r#"{"timestamp":"2026-07-13T02:03:04Z","type":"session_meta","payload":{"id":"codex-search","cwd":"/tmp/codex-project","source":"cli","originator":"codex-tui"}}"#,
+                "\n",
+                r#"{"timestamp":"2026-07-13T02:03:04Z","type":"event_msg","payload":{"type":"user_message","message":"search wiring marker"}}"#,
+            ),
+        )
+        .unwrap();
 
-        assert_eq!(value["projectPath"], "/tmp/codex-project");
-        assert_eq!(value["modified"], "2026-07-13T02:03:04+00:00");
-        assert!(search_hit_matches_project(&value, Some("codex-project")));
-        assert!(!search_hit_matches_project(&value, Some("other-project")));
+        let matching = cmd_search_output(
+            home.path(),
+            "search wiring marker",
+            Some("codex-project"),
+            20,
+            false,
+            false,
+        )
+        .unwrap();
+        let hits = matching["hits"].as_array().unwrap();
+        assert_eq!(hits.len(), 1);
+        assert_eq!(hits[0]["sessionId"], "codex-search");
+        assert_eq!(hits[0]["projectPath"], "/tmp/codex-project");
+        assert_eq!(hits[0]["modified"], "2026-07-13T02:03:04+00:00");
+
+        let nonmatching = cmd_search_output(
+            home.path(),
+            "search wiring marker",
+            Some("other-project"),
+            20,
+            false,
+            false,
+        )
+        .unwrap();
+        assert!(nonmatching["hits"].as_array().unwrap().is_empty());
     }
 
     #[test]

--- a/src-tauri/src/cli/mod.rs
+++ b/src-tauri/src/cli/mod.rs
@@ -515,14 +515,7 @@ fn cmd_search(
     let enriched: Vec<serde_json::Value> = hits
         .into_iter()
         .map(|hit| enrich_search_hit(hit))
-        .filter(|hit| match project_filter {
-            Some(filter) => hit
-                .get("projectPath")
-                .and_then(|p| p.as_str())
-                .map(|p| p.contains(filter))
-                .unwrap_or(false),
-            None => true,
-        })
+        .filter(|hit| search_hit_matches_project(hit, project_filter))
         .take(limit)
         .collect();
 
@@ -1340,12 +1333,38 @@ fn enrich_history_entry(entry: session::HistoryEntry) -> serde_json::Value {
 }
 
 fn enrich_search_hit(hit: session::DeepSearchHit) -> serde_json::Value {
-    let (project_path_encoded, modified) = find_session_metadata(&hit.session_id);
+    let (project_path, modified) = if hit.provider.eq_ignore_ascii_case("codex") {
+        (hit.project_path.clone(), hit.modified.clone())
+    } else {
+        let (project_path_encoded, modified) = find_session_metadata(&hit.session_id);
 
-    // Decode the encoded project path back to a real filesystem path
-    // e.g. "-Users-liminchen-Documents-GitHub-c9watch" -> "/Users/liminchen/Documents/GitHub/c9watch"
-    let project_path = project_path_encoded.map(|encoded| decode_project_path(&encoded));
+        // Decode the encoded project path back to a real filesystem path
+        // e.g. "-Users-liminchen-Documents-GitHub-c9watch" -> "/Users/liminchen/Documents/GitHub/c9watch"
+        (
+            project_path_encoded.map(|encoded| decode_project_path(&encoded)),
+            modified,
+        )
+    };
 
+    format_search_hit(hit, project_path, modified)
+}
+
+fn search_hit_matches_project(hit: &serde_json::Value, project_filter: Option<&str>) -> bool {
+    match project_filter {
+        Some(filter) => hit
+            .get("projectPath")
+            .and_then(|path| path.as_str())
+            .map(|path| path.contains(filter))
+            .unwrap_or(false),
+        None => true,
+    }
+}
+
+fn format_search_hit(
+    hit: session::DeepSearchHit,
+    project_path: Option<String>,
+    modified: Option<String>,
+) -> serde_json::Value {
     serde_json::json!({
         "sessionId": hit.session_id,
         "snippet": strip_system_tags(&hit.snippet),
@@ -1531,6 +1550,13 @@ fn resolve_session_id_lightweight(prefix: &str) -> Result<String, String> {
     }
 
     let home_dir = dirs::home_dir().ok_or("Failed to get home directory")?;
+    resolve_session_id_lightweight_under(prefix, &home_dir)
+}
+
+fn resolve_session_id_lightweight_under(
+    prefix: &str,
+    home_dir: &std::path::Path,
+) -> Result<String, String> {
     let projects_dir = home_dir.join(".claude").join("projects");
 
     let mut matches: Vec<String> = Vec::new();
@@ -1559,6 +1585,16 @@ fn resolve_session_id_lightweight(prefix: &str) -> Result<String, String> {
         }
     }
 
+    matches.extend(session::codex_session_ids(home_dir, prefix));
+
+    resolve_session_id_matches(prefix, matches)
+}
+
+fn resolve_session_id_matches(prefix: &str, matches: Vec<String>) -> Result<String, String> {
+    let mut matches = matches;
+    matches.sort();
+    matches.dedup();
+
     match matches.len() {
         0 => {
             // If it looks like a full UUID, let it through (might be a valid ID
@@ -1567,14 +1603,14 @@ fn resolve_session_id_lightweight(prefix: &str) -> Result<String, String> {
                 Ok(prefix.to_string())
             } else {
                 Err(format!(
-                    "No session found matching prefix '{}'",
+                    "No session found matching prefix '{}' across Claude Code and Codex",
                     prefix
                 ))
             }
         }
         1 => Ok(matches.into_iter().next().unwrap()),
         n => Err(format!(
-            "Ambiguous session ID prefix '{}' matches {} sessions",
+            "Ambiguous session ID prefix '{}' matches {} sessions across Claude Code and Codex",
             prefix, n
         )),
     }
@@ -1640,6 +1676,8 @@ mod session_formatter_tests {
         let value = enrich_search_hit(session::DeepSearchHit {
             session_id: "search-session".to_string(),
             snippet: "matching text".to_string(),
+            project_path: Some("/tmp/codex-project".to_string()),
+            modified: Some("2026-07-13T02:03:04+00:00".to_string()),
             provider: "codex".to_string(),
             surface: Some("cli".to_string()),
             agent_kind: "subagent".to_string(),
@@ -1648,6 +1686,77 @@ mod session_formatter_tests {
         assert_eq!(value["provider"], "codex");
         assert_eq!(value["surface"], "cli");
         assert_eq!(value["agentKind"], "subagent");
+    }
+
+    #[test]
+    fn codex_search_hit_metadata_keeps_real_project_and_modified_timestamp() {
+        let value = enrich_search_hit(session::DeepSearchHit {
+            session_id: "codex-search".to_string(),
+            snippet: "search marker".to_string(),
+            project_path: Some("/tmp/codex-project".to_string()),
+            modified: Some("2026-07-13T02:03:04+00:00".to_string()),
+            provider: "codex".to_string(),
+            surface: Some("cli".to_string()),
+            agent_kind: "root".to_string(),
+        });
+
+        assert_eq!(value["projectPath"], "/tmp/codex-project");
+        assert_eq!(value["modified"], "2026-07-13T02:03:04+00:00");
+        assert!(search_hit_matches_project(&value, Some("codex-project")));
+        assert!(!search_hit_matches_project(&value, Some("other-project")));
+    }
+
+    #[test]
+    fn session_prefix_resolves_unique_codex_id() {
+        let home = tempfile::tempdir().unwrap();
+        let sessions = home.path().join(".codex/sessions/2026/07/13");
+        std::fs::create_dir_all(&sessions).unwrap();
+        std::fs::write(
+            sessions.join("rollout-codex-unique.jsonl"),
+            r#"{"timestamp":"2026-07-13T02:03:04Z","type":"session_meta","payload":{"id":"codex-unique-thread","cwd":"/tmp/codex","source":"cli","originator":"codex-tui"}}"#,
+        )
+        .unwrap();
+
+        assert_eq!(
+            resolve_session_id_lightweight_under("codex-unique", home.path()).unwrap(),
+            "codex-unique-thread"
+        );
+    }
+
+    #[test]
+    fn session_prefix_reports_ambiguity_across_providers() {
+        let home = tempfile::tempdir().unwrap();
+        let claude_project = home.path().join(".claude/projects/project");
+        std::fs::create_dir_all(&claude_project).unwrap();
+        std::fs::write(
+            claude_project.join("shared-claude-session.jsonl"),
+            "",
+        )
+        .unwrap();
+        let codex_sessions = home.path().join(".codex/sessions/2026/07/13");
+        std::fs::create_dir_all(&codex_sessions).unwrap();
+        std::fs::write(
+            codex_sessions.join("rollout-shared-codex.jsonl"),
+            r#"{"timestamp":"2026-07-13T02:03:04Z","type":"session_meta","payload":{"id":"shared-codex-thread","cwd":"/tmp/codex","source":"cli","originator":"codex-tui"}}"#,
+        )
+        .unwrap();
+
+        let error = resolve_session_id_lightweight_under("shared", home.path()).unwrap_err();
+
+        assert!(error.contains("Ambiguous session ID prefix 'shared'"));
+        assert!(error.contains("matches 2 sessions"));
+        assert!(error.contains("Claude Code and Codex"));
+    }
+
+    #[test]
+    fn session_prefix_reports_no_match_across_providers() {
+        let home = tempfile::tempdir().unwrap();
+        let error = resolve_session_id_lightweight_under("missing", home.path()).unwrap_err();
+
+        assert_eq!(
+            error,
+            "No session found matching prefix 'missing' across Claude Code and Codex"
+        );
     }
 
     #[test]

--- a/src-tauri/src/session/history.rs
+++ b/src-tauri/src/session/history.rs
@@ -193,6 +193,10 @@ pub struct DeepSearchHit {
     pub session_id: String,
     /// Up to 200 chars of context around the first keyword match, from the matching line.
     pub snippet: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub project_path: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub modified: Option<String>,
     #[serde(default = "default_provider")]
     pub provider: String,
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -203,6 +207,27 @@ pub struct DeepSearchHit {
 
 fn default_agent_kind() -> String {
     "root".to_string()
+}
+
+fn codex_snapshot_metadata(
+    snapshot: &super::codex_archive::CodexRolloutSnapshot,
+) -> (Option<String>, Option<String>) {
+    let project_path = (!snapshot.cwd.is_empty()).then(|| snapshot.cwd.clone());
+    let timestamp_ms = snapshot.updated_at_ms.max(snapshot.created_at_ms);
+    let modified = (timestamp_ms > 0)
+        .then(|| chrono::DateTime::from_timestamp_millis(timestamp_ms as i64))
+        .flatten()
+        .map(|datetime| datetime.to_rfc3339())
+        .or_else(|| {
+            std::fs::metadata(&snapshot.path)
+                .and_then(|metadata| metadata.modified())
+                .ok()
+                .map(|time| {
+                    let datetime: chrono::DateTime<chrono::Utc> = time.into();
+                    datetime.to_rfc3339()
+                })
+        });
+    (project_path, modified)
 }
 
 /// Returns true if `haystack` contains `needle` according to the given mode flags.
@@ -407,6 +432,8 @@ pub fn deep_search(
                             guard.push(DeepSearchHit {
                                 session_id,
                                 snippet,
+                                project_path: None,
+                                modified: None,
                                 provider: default_provider(),
                                 surface: Some("claudeCode".to_string()),
                                 agent_kind: default_agent_kind(),
@@ -460,9 +487,12 @@ pub fn deep_search(
                     };
                     let snippet = extract_snippet(&text, &normalized, query_norm.as_str());
                     if !snippet.is_empty() {
+                        let (project_path, modified) = codex_snapshot_metadata(snapshot);
                         matched.lock().unwrap().push(DeepSearchHit {
                             session_id: snapshot.thread_id.clone(),
                             snippet,
+                            project_path,
+                            modified,
                             provider: "codex".to_string(),
                             surface: Some(snapshot.surface.clone()),
                             agent_kind: snapshot.agent_kind.clone(),
@@ -708,6 +738,36 @@ mod tests {
         assert!(!entries
             .iter()
             .any(|entry| entry.session_id == "guardian-history"));
+    }
+
+    #[test]
+    fn codex_deep_search_hit_carries_snapshot_project_and_modified_metadata() {
+        let home = tempfile::tempdir().unwrap();
+        let rollout = home.path().join("rollout-search.jsonl");
+        std::fs::write(
+            &rollout,
+            concat!(
+                r#"{"timestamp":"2026-07-13T02:03:04Z","type":"session_meta","payload":{"id":"codex-search","cwd":"/tmp/codex-project","source":"cli","originator":"codex-tui"}}"#,
+                "\n",
+                r#"{"timestamp":"2026-07-13T02:03:04Z","type":"event_msg","payload":{"type":"user_message","message":"search marker"}}"#,
+            ),
+        )
+        .unwrap();
+
+        let snapshot = crate::session::codex_archive::scan_rollout(&rollout).unwrap();
+        let (project_path, modified) = codex_snapshot_metadata(&snapshot);
+        let hit = DeepSearchHit {
+            session_id: snapshot.thread_id,
+            snippet: "search marker".to_string(),
+            project_path,
+            modified,
+            provider: "codex".to_string(),
+            surface: Some(snapshot.surface),
+            agent_kind: snapshot.agent_kind,
+        };
+
+        assert_eq!(hit.project_path.as_deref(), Some("/tmp/codex-project"));
+        assert_eq!(hit.modified.as_deref(), Some("2026-07-13T02:03:04+00:00"));
     }
 
     // ── phrase_match ────────────────────────────────────────────────

--- a/src-tauri/src/session/history.rs
+++ b/src-tauri/src/session/history.rs
@@ -1,6 +1,6 @@
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 
 /// A raw line from ~/.claude/history.jsonl
 #[derive(Debug, Clone, Deserialize)]
@@ -357,6 +357,15 @@ pub fn deep_search(
     whole_word: bool,
 ) -> Result<Vec<DeepSearchHit>, String> {
     let home_dir = dirs::home_dir().ok_or("Failed to get home directory")?;
+    deep_search_under(&home_dir, query, case_sensitive, whole_word)
+}
+
+pub(crate) fn deep_search_under(
+    home_dir: &Path,
+    query: &str,
+    case_sensitive: bool,
+    whole_word: bool,
+) -> Result<Vec<DeepSearchHit>, String> {
     let projects_dir = home_dir.join(".claude").join("projects");
 
     let query_norm = if case_sensitive {
@@ -738,36 +747,6 @@ mod tests {
         assert!(!entries
             .iter()
             .any(|entry| entry.session_id == "guardian-history"));
-    }
-
-    #[test]
-    fn codex_deep_search_hit_carries_snapshot_project_and_modified_metadata() {
-        let home = tempfile::tempdir().unwrap();
-        let rollout = home.path().join("rollout-search.jsonl");
-        std::fs::write(
-            &rollout,
-            concat!(
-                r#"{"timestamp":"2026-07-13T02:03:04Z","type":"session_meta","payload":{"id":"codex-search","cwd":"/tmp/codex-project","source":"cli","originator":"codex-tui"}}"#,
-                "\n",
-                r#"{"timestamp":"2026-07-13T02:03:04Z","type":"event_msg","payload":{"type":"user_message","message":"search marker"}}"#,
-            ),
-        )
-        .unwrap();
-
-        let snapshot = crate::session::codex_archive::scan_rollout(&rollout).unwrap();
-        let (project_path, modified) = codex_snapshot_metadata(&snapshot);
-        let hit = DeepSearchHit {
-            session_id: snapshot.thread_id,
-            snippet: "search marker".to_string(),
-            project_path,
-            modified,
-            provider: "codex".to_string(),
-            surface: Some(snapshot.surface),
-            agent_kind: snapshot.agent_kind,
-        };
-
-        assert_eq!(hit.project_path.as_deref(), Some("/tmp/codex-project"));
-        assert_eq!(hit.modified.as_deref(), Some("2026-07-13T02:03:04+00:00"));
     }
 
     // ── phrase_match ────────────────────────────────────────────────

--- a/src-tauri/src/session/mod.rs
+++ b/src-tauri/src/session/mod.rs
@@ -33,6 +33,14 @@ pub mod cost;
 mod codex_archive;
 pub use cost::{get_cost_data, CostData};
 
+pub(crate) fn codex_session_ids(home: &std::path::Path, prefix: &str) -> Vec<String> {
+    codex_archive::load_default_snapshots(home)
+        .into_iter()
+        .filter(|snapshot| snapshot.thread_id.starts_with(prefix))
+        .map(|snapshot| snapshot.thread_id)
+        .collect()
+}
+
 pub mod memory;
 pub use memory::{get_memory_files, MemoryFile, ProjectMemory};
 


### PR DESCRIPTION
## Summary

- Preserve Codex project paths and modified timestamps in CLI search results.
- Make `search --project` retain matching Codex sessions.
- Resolve unique Codex session ID prefixes for `view` and other lightweight CLI lookups.
- Report ambiguity consistently across Claude Code and Codex sessions.

## Root cause

PR #112 added Codex search results, but CLI enrichment still looked up project metadata only under `~/.claude/projects`. Codex hits therefore received null project metadata and were removed whenever `--project` was used. The lightweight session-prefix resolver had the same Claude-only assumption.

## Validation

- `cargo test --no-default-features --features cli --lib` — 283 passed, 1 ignored
- `cargo test --no-default-features --features cli cli::session_formatter_tests --no-fail-fast` — 7 passed
- `git diff --check`
- Live `search "OPEN DASHBOARD" --project c9watch` returned Codex results with project path and modified timestamp
- Live `view 019f58e8 --last 1` resolved the Codex prefix to its full session ID

## Follow-up

This fixes issues found during the post-merge review of #112.
