### PR TITLE
docs: record merged memory optimization status

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Enable the dashboard UI by setting `PM_ORCHESTRATION_ENABLED = true` in
     `src/lib/feature-flags.ts`.
 
+### Improved
+- **Lower memory usage for Codex session monitoring.** Incremental rollout
+  parsing and bounded monitor representations reduce peak RSS by 65.8% on a
+  controlled workload while preserving full conversation and tool details.
+  ([#116](https://github.com/minchenlee/c9watch/pull/116))
+- Added a dry-run-by-default utility for cleaning stale Cargo targets from
+  other registered worktrees.
+
 ### Added
 - PM-orchestration `bg` backend: spawn workers via `claude --bg` instead of
   `claude --print`. Workers stay on Pro/Max subscription quota after


### PR DESCRIPTION
## Summary

- Record the merged PR #116 memory improvement in the `[Unreleased]` changelog.
- Document the 65.8% controlled-workload RSS reduction.
- Record the new safe worktree cleanup utility as an engineering improvement.

## Scope

Documentation only. No product code, release version, or runtime behavior changes.

## Validation

- `git diff --check` passed.
- The referenced implementation PR #116 was already squash-merged with CI passing.