### PR TITLE
feat: add macOS session status widget

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,8 @@ node_modules
 vite.config.js.timestamp-*
 vite.config.ts.timestamp-*
 Icon Exports/
+macos-widget/build/
+macos-widget/C9WatchWidgets.xcodeproj/
 .worktrees/
 
 # Local development notes (not tracked)

--- a/macos-widget/Host/Host.entitlements
+++ b/macos-widget/Host/Host.entitlements
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>com.apple.security.application-groups</key>
+	<array>
+		<string>group.com.minchenlee.c9watch</string>
+	</array>
+</dict>
+</plist>

--- a/macos-widget/Host/Host.swift
+++ b/macos-widget/Host/Host.swift
@@ -1,0 +1,11 @@
+import SwiftUI
+
+@main
+struct C9WatchWidgetHost: App {
+    var body: some Scene {
+        WindowGroup {
+            Text("c9watch widgets are available from Edit Widgets")
+                .padding(24)
+        }
+    }
+}

--- a/macos-widget/Widget/C9WatchWidget.swift
+++ b/macos-widget/Widget/C9WatchWidget.swift
@@ -1,0 +1,415 @@
+import SwiftUI
+import WidgetKit
+import OSLog
+
+private let appGroup = "group.com.minchenlee.c9watch"
+private let snapshotFile = "widget.json"
+private let localSnapshotDirectory = "c9watch"
+private let widgetLogger = Logger(subsystem: "com.minchenlee.c9watch.widget", category: "snapshot")
+
+struct C9WatchSnapshot: Codable {
+    let hasSession: Bool
+    let provider: String
+    let title: String
+    let status: String
+    let project: String
+    let latestMessage: String
+    let workingCount: Int
+    let approvalCount: Int
+    let waitingCount: Int
+
+    init(
+        hasSession: Bool,
+        provider: String,
+        title: String,
+        status: String,
+        project: String,
+        latestMessage: String,
+        workingCount: Int = 0,
+        approvalCount: Int = 0,
+        waitingCount: Int = 0
+    ) {
+        self.hasSession = hasSession
+        self.provider = provider
+        self.title = title
+        self.status = status
+        self.project = project
+        self.latestMessage = latestMessage
+        self.workingCount = workingCount
+        self.approvalCount = approvalCount
+        self.waitingCount = waitingCount
+    }
+
+    enum CodingKeys: String, CodingKey {
+        case hasSession, provider, title, status, project, latestMessage
+        case workingCount, approvalCount, waitingCount
+    }
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        hasSession = try container.decode(Bool.self, forKey: .hasSession)
+        provider = try container.decode(String.self, forKey: .provider)
+        title = try container.decode(String.self, forKey: .title)
+        status = try container.decode(String.self, forKey: .status)
+        project = try container.decode(String.self, forKey: .project)
+        latestMessage = try container.decode(String.self, forKey: .latestMessage)
+        workingCount = try container.decodeIfPresent(Int.self, forKey: .workingCount) ?? 0
+        approvalCount = try container.decodeIfPresent(Int.self, forKey: .approvalCount) ?? 0
+        waitingCount = try container.decodeIfPresent(Int.self, forKey: .waitingCount) ?? 0
+    }
+}
+
+struct C9WatchEntry: TimelineEntry {
+    let date: Date
+    let snapshot: C9WatchSnapshot
+}
+
+struct C9WatchProvider: TimelineProvider {
+    private let placeholderSnapshot = C9WatchSnapshot(
+        hasSession: true,
+        provider: "CHATGPT / CODEX",
+        title: "Building something useful",
+        status: "Working now",
+        project: "c9watch",
+        latestMessage: "The active AI session will appear here.",
+        workingCount: 1,
+        approvalCount: 0,
+        waitingCount: 0
+    )
+
+    func placeholder(in context: Context) -> C9WatchEntry {
+        C9WatchEntry(date: .now, snapshot: placeholderSnapshot)
+    }
+
+    func getSnapshot(in context: Context, completion: @escaping (C9WatchEntry) -> Void) {
+        completion(C9WatchEntry(date: .now, snapshot: readSnapshot()))
+    }
+
+    func getTimeline(in context: Context, completion: @escaping (Timeline<C9WatchEntry>) -> Void) {
+        let entry = C9WatchEntry(date: .now, snapshot: readSnapshot())
+        // Keep the dashboard responsive while the app is watching sessions.
+        // WidgetKit may still apply its own refresh budget, but this prevents
+        // an old zero-count timeline from living for a full minute.
+        completion(Timeline(entries: [entry], policy: .after(.now.addingTimeInterval(15))))
+    }
+
+    private func readSnapshot() -> C9WatchSnapshot {
+        for url in snapshotURLs() {
+            guard let data = try? Data(contentsOf: url) else { continue }
+            guard let snapshot = try? JSONDecoder().decode(C9WatchSnapshot.self, from: data) else {
+                widgetLogger.error("Unable to decode snapshot file: \(url.path, privacy: .public)")
+                continue
+            }
+
+            widgetLogger.info(
+                "Loaded snapshot from \(url.path, privacy: .public): hasSession=\(snapshot.hasSession, privacy: .public), working=\(snapshot.workingCount, privacy: .public), approval=\(snapshot.approvalCount, privacy: .public), waiting=\(snapshot.waitingCount, privacy: .public)"
+            )
+            return snapshot
+        }
+
+        widgetLogger.error("Unable to read snapshot from App Group or local widget container")
+        return fallbackSnapshot()
+    }
+
+    private func snapshotURLs() -> [URL] {
+        var urls: [URL] = []
+        if let container = FileManager.default.containerURL(
+            forSecurityApplicationGroupIdentifier: appGroup
+        ) {
+            urls.append(container.appendingPathComponent(snapshotFile))
+        } else {
+            widgetLogger.error("Unable to resolve app-group container: \(appGroup, privacy: .public)")
+        }
+
+        if let applicationSupport = FileManager.default.urls(
+            for: .applicationSupportDirectory,
+            in: .userDomainMask
+        ).first {
+            urls.append(
+                applicationSupport
+                    .appendingPathComponent(localSnapshotDirectory, isDirectory: true)
+                    .appendingPathComponent(snapshotFile)
+            )
+        }
+        return urls
+    }
+
+    private func fallbackSnapshot() -> C9WatchSnapshot {
+        C9WatchSnapshot(
+            hasSession: false,
+            provider: "c9watch",
+            title: "No active session",
+            status: "Waiting",
+            project: "",
+            latestMessage: "Start a Codex or Claude Code session.",
+            workingCount: 0,
+            approvalCount: 0,
+            waitingCount: 0
+        )
+    }
+}
+
+struct C9WatchWidgetView: View {
+    let entry: C9WatchEntry
+    @Environment(\.widgetFamily) private var family
+
+    private var snapshot: C9WatchSnapshot { entry.snapshot }
+    private var accent: Color {
+        snapshot.hasSession
+            ? Color(red: 0.44, green: 0.76, blue: 1.0)
+            : Color.white.opacity(0.45)
+    }
+
+    var body: some View {
+        Group {
+            switch family {
+            case .systemSmall:
+                smallLayout
+            case .systemLarge:
+                largeLayout
+            default:
+                mediumLayout
+            }
+        }
+        .containerBackground(for: .widget) {
+            ZStack {
+                LinearGradient(
+                    colors: [
+                        Color(red: 0.07, green: 0.10, blue: 0.18),
+                        Color(red: 0.12, green: 0.08, blue: 0.24)
+                    ],
+                    startPoint: .topLeading,
+                    endPoint: .bottomTrailing
+                )
+
+                Circle()
+                    .fill(accent.opacity(0.20))
+                    .frame(width: 180, height: 180)
+                    .blur(radius: 34)
+                    .offset(x: 92, y: -92)
+            }
+        }
+    }
+
+    private var smallLayout: some View {
+        VStack(alignment: .leading, spacing: 12) {
+            header
+
+            Spacer(minLength: 0)
+
+            Text(snapshot.title)
+                .font(.title3.weight(.semibold))
+                .foregroundStyle(.white)
+                .lineLimit(3)
+
+            statusBadge
+
+            if !snapshot.project.isEmpty {
+                projectLabel
+            }
+        }
+        .padding(16)
+    }
+
+    private var mediumLayout: some View {
+        VStack(alignment: .leading, spacing: 14) {
+            header
+
+            Text(snapshot.title)
+                .font(.title2.weight(.semibold))
+                .foregroundStyle(.white)
+                .lineLimit(2)
+
+            Text(snapshot.latestMessage)
+                .font(.subheadline)
+                .foregroundStyle(.white.opacity(0.72))
+                .lineLimit(2)
+
+            Spacer(minLength: 0)
+
+            HStack {
+                statusBadge
+                Spacer()
+                projectLabel
+            }
+        }
+        .padding(18)
+    }
+
+    private var largeLayout: some View {
+        VStack(alignment: .leading, spacing: 10) {
+            header
+
+            HStack(alignment: .firstTextBaseline, spacing: 10) {
+                Text(snapshot.title)
+                    .font(.title2.weight(.bold))
+                    .foregroundStyle(.white)
+                    .lineLimit(2)
+
+                Spacer(minLength: 0)
+
+                statusBadge
+            }
+
+            Text(snapshot.latestMessage)
+                .font(.caption)
+                .foregroundStyle(.white.opacity(0.78))
+                .lineLimit(2)
+                .frame(maxWidth: .infinity, alignment: .leading)
+                .padding(10)
+                .background(.white.opacity(0.08), in: RoundedRectangle(cornerRadius: 14))
+
+            statusOverview
+
+            Spacer(minLength: 0)
+
+            HStack {
+                projectLabel
+                Spacer()
+                Text("Live session overview")
+                    .font(.caption2.weight(.medium))
+                    .foregroundStyle(.white.opacity(0.42))
+            }
+        }
+        .padding(14)
+    }
+
+    private var header: some View {
+        HStack(alignment: .center, spacing: 11) {
+            Image(nsImage: NSImage(named: NSImage.applicationIconName) ?? NSImage())
+                .resizable()
+                .scaledToFill()
+                .frame(width: 42, height: 42)
+                .clipShape(RoundedRectangle(cornerRadius: 12))
+                .overlay {
+                    RoundedRectangle(cornerRadius: 12)
+                        .stroke(.white.opacity(0.18), lineWidth: 1)
+                }
+
+            VStack(alignment: .leading, spacing: 3) {
+                Text(snapshot.provider)
+                    .font(.caption.weight(.bold))
+                    .tracking(0.5)
+                    .foregroundStyle(.white.opacity(0.68))
+                    .lineLimit(1)
+
+                Text("c9watch")
+                    .font(.subheadline.weight(.semibold))
+                    .foregroundStyle(.white)
+            }
+
+            Spacer(minLength: 0)
+
+            Image(systemName: snapshot.hasSession ? "waveform" : "moon.zzz.fill")
+                .font(.title3.weight(.semibold))
+                .foregroundStyle(accent)
+        }
+    }
+
+    private var statusBadge: some View {
+        HStack(spacing: 6) {
+            Circle()
+                .fill(accent)
+                .frame(width: 7, height: 7)
+                .shadow(color: accent, radius: snapshot.hasSession ? 5 : 0)
+
+            Text(snapshot.status)
+                .font(.caption.weight(.semibold))
+                .foregroundStyle(.white.opacity(0.84))
+                .lineLimit(1)
+        }
+        .padding(.horizontal, 9)
+        .padding(.vertical, 6)
+        .background(.white.opacity(0.10), in: Capsule())
+    }
+
+    private var statusOverview: some View {
+        VStack(alignment: .leading, spacing: 7) {
+            HStack {
+                Text("SESSION STATUS")
+                    .font(.caption2.weight(.bold))
+                    .tracking(1.0)
+                    .foregroundStyle(.white.opacity(0.5))
+
+                Spacer()
+
+                Text("\(snapshot.workingCount + snapshot.approvalCount + snapshot.waitingCount) total")
+                    .font(.caption2.weight(.medium))
+                    .foregroundStyle(.white.opacity(0.45))
+            }
+
+            statusRow(
+                label: "WORKING",
+                count: snapshot.workingCount,
+                icon: "bolt.fill",
+                color: Color(red: 0.34, green: 0.82, blue: 0.72)
+            )
+            statusRow(
+                label: "APPROVAL",
+                count: snapshot.approvalCount,
+                icon: "hand.raised.fill",
+                color: Color(red: 1.0, green: 0.65, blue: 0.30)
+            )
+            statusRow(
+                label: "WAITING",
+                count: snapshot.waitingCount,
+                icon: "clock.fill",
+                color: Color(red: 0.60, green: 0.68, blue: 1.0)
+            )
+        }
+        .padding(10)
+        .background(.black.opacity(0.16), in: RoundedRectangle(cornerRadius: 16))
+        .overlay {
+            RoundedRectangle(cornerRadius: 16)
+                .stroke(.white.opacity(0.08), lineWidth: 1)
+        }
+    }
+
+    private func statusRow(label: String, count: Int, icon: String, color: Color) -> some View {
+        HStack(spacing: 9) {
+            Image(systemName: icon)
+                .font(.caption2.weight(.bold))
+                .foregroundStyle(color)
+                .frame(width: 17)
+
+            Text(label)
+                .font(.caption2.weight(.bold))
+                .tracking(0.8)
+                .foregroundStyle(.white.opacity(0.78))
+
+            Spacer()
+
+            Text("\(count)")
+                .font(.headline.weight(.bold).monospacedDigit())
+                .foregroundStyle(.white)
+        }
+    }
+
+    private var projectLabel: some View {
+        Label(snapshot.project.isEmpty ? "No project" : snapshot.project, systemImage: "folder.fill")
+            .font(.caption2.weight(.medium))
+            .foregroundStyle(.white.opacity(0.58))
+            .lineLimit(1)
+    }
+}
+
+struct C9WatchWidget: Widget {
+    let kind = "C9WatchWidget"
+
+    var body: some WidgetConfiguration {
+        StaticConfiguration(kind: kind, provider: C9WatchProvider()) { entry in
+            C9WatchWidgetView(entry: entry)
+        }
+        .configurationDisplayName("c9watch session")
+        .description("See the active Codex or Claude Code session at a glance.")
+        .supportedFamilies([.systemSmall, .systemMedium, .systemLarge])
+        .contentMarginsDisabled()
+    }
+}
+
+@main
+struct C9WatchWidgetBundle: WidgetBundle {
+    var body: some Widget {
+        C9WatchWidget()
+    }
+}

--- a/macos-widget/Widget/Info.plist
+++ b/macos-widget/Widget/Info.plist
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDisplayName</key>
+	<string>c9watch</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>$(PRODUCT_NAME)</string>
+	<key>CFBundleIdentifier</key>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+	<key>CFBundleExecutable</key>
+	<string>$(EXECUTABLE_NAME)</string>
+	<key>CFBundleShortVersionString</key>
+	<string>$(MARKETING_VERSION)</string>
+	<key>CFBundleVersion</key>
+	<string>$(CURRENT_PROJECT_VERSION)</string>
+	<key>CFBundlePackageType</key>
+	<string>XPC!</string>
+	<key>NSExtension</key>
+	<dict>
+		<key>NSExtensionPointIdentifier</key>
+		<string>com.apple.widgetkit-extension</string>
+	</dict>
+</dict>
+</plist>

--- a/macos-widget/Widget/Widget.entitlements
+++ b/macos-widget/Widget/Widget.entitlements
@@ -2,15 +2,11 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+    <key>com.apple.security.app-sandbox</key>
+    <true/>
     <key>com.apple.security.application-groups</key>
     <array>
         <string>group.com.minchenlee.c9watch</string>
-    </array>
-    <key>com.apple.security.cs.allow-jit</key>
-    <true/>
-    <key>com.apple.security.cs.allow-unsigned-executable-memory</key>
-    <true/>
-    <key>com.apple.security.cs.allow-dyld-environment-variables</key>
-    <true/>
+	</array>
 </dict>
 </plist>

--- a/macos-widget/project.yml
+++ b/macos-widget/project.yml
@@ -1,0 +1,38 @@
+name: C9WatchWidgets
+options:
+  deploymentTarget:
+    macOS: "14.0"
+  createIntermediateGroups: true
+settings:
+  base:
+    SWIFT_VERSION: "6.0"
+    MARKETING_VERSION: "0.8.1"
+    CURRENT_PROJECT_VERSION: "1"
+    DEVELOPMENT_TEAM: ""
+    CODE_SIGNING_ALLOWED: NO
+targets:
+  C9WatchWidgetHost:
+    type: application
+    platform: macOS
+    sources:
+      - path: Host
+    settings:
+      PRODUCT_BUNDLE_IDENTIFIER: com.minchenlee.c9watch.widgethost
+      INFOPLIST_KEY_CFBundleDisplayName: c9watch
+      INFOPLIST_KEY_LSUIElement: YES
+      CODE_SIGN_ENTITLEMENTS: Host/Host.entitlements
+  C9WatchWidget:
+    type: app-extension
+    platform: macOS
+    sources:
+      - path: Widget
+    settings:
+      PRODUCT_BUNDLE_IDENTIFIER: com.minchenlee.c9watch.widget
+      INFOPLIST_FILE: Widget/Info.plist
+      CODE_SIGN_ENTITLEMENTS: Widget/Widget.entitlements
+      APPLICATION_EXTENSION_API_ONLY: YES
+schemes:
+  C9WatchWidgets:
+    build:
+      targets:
+        C9WatchWidget: all

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
   "scripts": {
     "dev": "vite dev",
     "build": "vite build",
+    "build:widget": "sh scripts/build-macos-widget.sh",
     "preview": "vite preview",
     "check": "svelte-kit sync && svelte-check --tsconfig ./tsconfig.json",
     "check:watch": "svelte-kit sync && svelte-check --tsconfig ./tsconfig.json --watch",

--- a/scripts/build-macos-widget.sh
+++ b/scripts/build-macos-widget.sh
@@ -1,0 +1,39 @@
+#!/bin/sh
+set -eu
+
+if [ "$(uname -s)" != "Darwin" ]; then
+  exit 0
+fi
+
+widget_root="$(cd "$(dirname "$0")/../macos-widget" && pwd)"
+developer_dir="${DEVELOPER_DIR:-/Applications/Xcode.app/Contents/Developer}"
+
+if [ ! -x "$developer_dir/usr/bin/xcodebuild" ]; then
+  echo "Xcode is required to build the c9watch desktop widget." >&2
+  exit 1
+fi
+
+cd "$widget_root"
+xcodegen generate --spec project.yml
+DEVELOPER_DIR="$developer_dir" xcodebuild \
+  -project C9WatchWidgets.xcodeproj \
+  -scheme C9WatchWidgets \
+  -configuration Release \
+  -derivedDataPath build/DerivedData \
+  CODE_SIGNING_ALLOWED=NO \
+  build >/dev/null
+
+rm -rf build/c9watch-widget.appex
+mkdir -p build
+ditto \
+  build/DerivedData/Build/Products/Release/C9WatchWidget.appex \
+  build/c9watch-widget.appex
+
+# Tauri signs the containing application later. Sign the extension here so the
+# nested WidgetKit bundle is valid when it is copied into Contents/PlugIns.
+codesign --force --sign - \
+  --entitlements Widget/Widget.entitlements \
+  build/c9watch-widget.appex/Contents/MacOS/C9WatchWidget >/dev/null
+codesign --force --sign - \
+  --entitlements Widget/Widget.entitlements \
+  build/c9watch-widget.appex >/dev/null

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -443,6 +443,7 @@ dependencies = [
  "anyhow",
  "axum",
  "base64 0.22.1",
+ "cc",
  "chrono",
  "clap",
  "dirs 5.0.1",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -41,6 +41,7 @@ pm-orchestration = ["cli"]
 
 [build-dependencies]
 tauri-build = { version = "2", features = [], optional = true }
+cc = "1"
 
 [dependencies]
 # ── Core (always included) ───────────────────────────────────────────

--- a/src-tauri/build.rs
+++ b/src-tauri/build.rs
@@ -6,6 +6,16 @@ fn main() {
         std::fs::create_dir_all(build_dir).ok();
     }
 
+    #[cfg(target_os = "macos")]
+    {
+        cc::Build::new()
+            .file("src/macos_now_playing.m")
+            .flag("-fobjc-arc")
+            .compile("c9watch_now_playing");
+        println!("cargo:rustc-link-lib=framework=AppKit");
+        println!("cargo:rustc-link-lib=framework=MediaPlayer");
+    }
+
     // Only run tauri_build when the gui feature is enabled.
     // CLI-only builds don't need Tauri's code generation.
     #[cfg(feature = "gui")]

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -7,6 +7,9 @@ pub mod session;
 pub mod debug_log;
 pub mod actions;
 
+#[cfg(all(target_os = "macos", feature = "gui"))]
+mod macos_now_playing;
+
 // ── GUI-only modules ────────────────────────────────────────────────
 #[cfg(all(not(mobile), feature = "gui"))]
 pub mod auth;

--- a/src-tauri/src/macos_now_playing.m
+++ b/src-tauri/src/macos_now_playing.m
@@ -1,0 +1,103 @@
+#import <AppKit/AppKit.h>
+#import <MediaPlayer/MediaPlayer.h>
+#import <dispatch/dispatch.h>
+
+static NSString *C9String(const char *value) {
+    if (value == NULL) {
+        return @"";
+    }
+    return [NSString stringWithUTF8String:value] ?: @"";
+}
+
+static void C9InstallRemoteCommands(void) {
+    static dispatch_once_t onceToken;
+    dispatch_once(&onceToken, ^{
+        MPRemoteCommandCenter *commands = [MPRemoteCommandCenter sharedCommandCenter];
+        commands.playCommand.enabled = YES;
+        commands.pauseCommand.enabled = YES;
+        commands.togglePlayPauseCommand.enabled = YES;
+
+        [commands.playCommand addTargetWithHandler:^MPRemoteCommandHandlerStatus(
+            MPRemoteCommandEvent *_event
+        ) {
+            return MPRemoteCommandHandlerStatusSuccess;
+        }];
+        [commands.pauseCommand addTargetWithHandler:^MPRemoteCommandHandlerStatus(
+            MPRemoteCommandEvent *_event
+        ) {
+            return MPRemoteCommandHandlerStatusSuccess;
+        }];
+        [commands.togglePlayPauseCommand addTargetWithHandler:^MPRemoteCommandHandlerStatus(
+            MPRemoteCommandEvent *_event
+        ) {
+            return MPRemoteCommandHandlerStatusSuccess;
+        }];
+    });
+}
+
+void c9watch_update_now_playing(
+    const char *title,
+    const char *status,
+    const char *project,
+    const char *latest_message,
+    bool is_playing
+) {
+    @autoreleasepool {
+        NSString *titleString = [C9String(title) copy];
+        NSString *statusString = [C9String(status) copy];
+        NSString *projectString = [C9String(project) copy];
+        NSString *latestMessageString = [C9String(latest_message) copy];
+        BOOL playing = is_playing;
+
+        // The polling loop runs on a worker thread. AppKit/MediaPlayer state
+        // is published on the main queue so macOS can observe it reliably.
+        dispatch_async(dispatch_get_main_queue(), ^{
+            C9InstallRemoteCommands();
+            NSMutableDictionary *info = [NSMutableDictionary dictionary];
+            info[MPMediaItemPropertyTitle] = titleString;
+            info[MPMediaItemPropertyArtist] = statusString;
+            info[MPMediaItemPropertyAlbumTitle] = projectString;
+            info[MPMediaItemPropertyGenre] = @"AI assistant";
+            info[MPMediaItemPropertyMediaType] = @(MPMediaTypeMusic);
+            info[MPMediaItemPropertyPersistentID] = @(1);
+            info[MPMediaItemPropertyPlaybackDuration] = @(1.0);
+            info[MPNowPlayingInfoPropertyElapsedPlaybackTime] = @(0.0);
+            info[MPNowPlayingInfoPropertyPlaybackRate] = @(playing ? 1.0 : 0.0);
+
+            // This field is not guaranteed to be rendered by macOS, but gives
+            // system clients an additional lyric-like line when supported.
+            if (latestMessageString.length > 0) {
+                info[MPMediaItemPropertyComposer] = latestMessageString;
+            }
+
+            NSImage *artworkImage = [NSImage imageNamed:NSImageNameApplicationIcon];
+            if (artworkImage != nil) {
+                CGSize size = artworkImage.size;
+                if (size.width <= 0 || size.height <= 0) {
+                    size = CGSizeMake(512, 512);
+                }
+                MPMediaItemArtwork *artwork = [[MPMediaItemArtwork alloc]
+                    initWithBoundsSize:size
+                    requestHandler:^NSImage *(CGSize _requestedSize) {
+                        (void)_requestedSize;
+                        return artworkImage;
+                    }];
+                info[MPMediaItemPropertyArtwork] = artwork;
+            }
+
+            MPNowPlayingInfoCenter *center = [MPNowPlayingInfoCenter defaultCenter];
+            center.nowPlayingInfo = info;
+            center.playbackState = playing
+                ? MPNowPlayingPlaybackStatePlaying
+                : MPNowPlayingPlaybackStatePaused;
+        });
+    }
+}
+
+void c9watch_clear_now_playing(void) {
+    dispatch_async(dispatch_get_main_queue(), ^{
+        MPNowPlayingInfoCenter *center = [MPNowPlayingInfoCenter defaultCenter];
+        center.nowPlayingInfo = nil;
+        center.playbackState = MPNowPlayingPlaybackStateStopped;
+    });
+}

--- a/src-tauri/src/macos_now_playing.rs
+++ b/src-tauri/src/macos_now_playing.rs
@@ -1,0 +1,184 @@
+//! macOS Now Playing metadata bridge.
+//!
+//! The system owns the final UI. c9watch supplies the selected AI session as
+//! title/status/project metadata and uses the app icon as square artwork.
+
+use crate::polling::Session;
+use crate::session::SessionStatus;
+use serde::Serialize;
+use std::ffi::CString;
+
+const WIDGET_GROUP: &str = "group.com.minchenlee.c9watch";
+const WIDGET_BUNDLE_ID: &str = "com.minchenlee.c9watch.widget";
+
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase")]
+struct WidgetSnapshot<'a> {
+    has_session: bool,
+    provider: &'a str,
+    title: &'a str,
+    status: &'a str,
+    project: &'a str,
+    latest_message: &'a str,
+    working_count: usize,
+    approval_count: usize,
+    waiting_count: usize,
+}
+
+fn write_widget_snapshot(snapshot: &WidgetSnapshot<'_>) {
+    let Some(home) = dirs::home_dir() else { return };
+    let Ok(data) = serde_json::to_vec(snapshot) else { return };
+
+    let destinations = [
+        home.join("Library/Group Containers")
+            .join(WIDGET_GROUP)
+            .join("widget.json"),
+        home.join("Library/Containers")
+            .join(WIDGET_BUNDLE_ID)
+            .join("Data/Library/Application Support/c9watch/widget.json"),
+    ];
+    for path in destinations {
+        let Some(directory) = path.parent() else { continue };
+        if let Err(error) = std::fs::create_dir_all(directory)
+            .and_then(|()| std::fs::write(&path, &data))
+        {
+            crate::debug_log::log_warn(&format!(
+                "Failed to update desktop widget data at {}: {error}",
+                path.display()
+            ));
+        }
+    }
+}
+
+unsafe extern "C" {
+    fn c9watch_update_now_playing(
+        title: *const std::ffi::c_char,
+        status: *const std::ffi::c_char,
+        project: *const std::ffi::c_char,
+        latest_message: *const std::ffi::c_char,
+        is_playing: bool,
+    );
+    fn c9watch_clear_now_playing();
+}
+
+fn c_string(value: &str) -> CString {
+    CString::new(value.replace('\0', " ")).unwrap_or_default()
+}
+
+fn status_priority(status: &SessionStatus) -> u8 {
+    match status {
+        SessionStatus::NeedsAttention => 0,
+        SessionStatus::Working => 1,
+        SessionStatus::Connecting => 2,
+        SessionStatus::WaitingForInput => 3,
+    }
+}
+
+fn selected_session<'a>(sessions: &'a [Session]) -> Option<&'a Session> {
+    let codex = sessions
+        .iter()
+        .filter(|session| session.provider == crate::session::SessionProvider::Codex)
+        .collect::<Vec<_>>();
+    let candidates = if codex.is_empty() {
+        sessions.iter().collect::<Vec<_>>()
+    } else {
+        codex
+    };
+
+    candidates.into_iter().min_by(|a, b| {
+        status_priority(&a.status)
+            .cmp(&status_priority(&b.status))
+            .then_with(|| b.modified.cmp(&a.modified))
+    })
+}
+
+fn status_counts(sessions: &[Session]) -> (usize, usize, usize) {
+    sessions.iter().fold((0, 0, 0), |mut counts, session| {
+        match &session.status {
+            SessionStatus::Working | SessionStatus::Connecting => counts.0 += 1,
+            SessionStatus::NeedsAttention => counts.1 += 1,
+            SessionStatus::WaitingForInput => counts.2 += 1,
+        }
+        counts
+    })
+}
+
+pub fn publish(sessions: &[Session]) {
+    let (working_count, approval_count, waiting_count) = status_counts(sessions);
+
+    let Some(session) = selected_session(sessions) else {
+        write_widget_snapshot(&WidgetSnapshot {
+            has_session: false,
+            provider: "c9watch",
+            title: "No active session",
+            status: "Waiting",
+            project: "",
+            latest_message: "Start a Codex or Claude Code session.",
+            working_count,
+            approval_count,
+            waiting_count,
+        });
+        crate::debug_log::log_info("Now Playing cleared: no active AI sessions");
+        // SAFETY: The bridge is compiled and linked only on macOS.
+        unsafe { c9watch_clear_now_playing() };
+        return;
+    };
+
+    let title = session
+        .custom_title
+        .as_deref()
+        .or(session.summary.as_deref())
+        .filter(|value| !value.trim().is_empty())
+        .unwrap_or(&session.session_name);
+    let status = match &session.status {
+        SessionStatus::NeedsAttention => session
+            .pending_tool_name
+            .as_deref()
+            .map(|tool| format!("Needs your input · {tool}"))
+            .unwrap_or_else(|| "Needs your input".to_string()),
+        SessionStatus::Working => "Working".to_string(),
+        SessionStatus::Connecting => "Connecting".to_string(),
+        SessionStatus::WaitingForInput => "Waiting for input".to_string(),
+    };
+    let project = std::path::Path::new(&session.project_path)
+        .file_name()
+        .and_then(|name| name.to_str())
+        .unwrap_or("AI session");
+    let provider = if session.provider == crate::session::SessionProvider::Codex {
+        "CHATGPT / CODEX"
+    } else {
+        "CLAUDE CODE"
+    };
+    write_widget_snapshot(&WidgetSnapshot {
+        has_session: true,
+        provider,
+        title,
+        status: &status,
+        project,
+        latest_message: &session.latest_message,
+        working_count,
+        approval_count,
+        waiting_count,
+    });
+    let title = c_string(title);
+    let status = c_string(&status);
+    let project = c_string(project);
+    let latest_message = c_string(&session.latest_message);
+    let is_playing = session.status == SessionStatus::Working;
+    crate::debug_log::log_info(&format!(
+        "Now Playing published: provider={:?}, status={:?}",
+        session.provider, session.status
+    ));
+
+    // SAFETY: All pointers remain valid for the duration of the synchronous
+    // Objective-C call and the bridge copies the strings into Foundation objects.
+    unsafe {
+        c9watch_update_now_playing(
+            title.as_ptr(),
+            status.as_ptr(),
+            project.as_ptr(),
+            latest_message.as_ptr(),
+            is_playing,
+        );
+    }
+}

--- a/src-tauri/src/polling.rs
+++ b/src-tauri/src/polling.rs
@@ -257,6 +257,9 @@ pub fn start_polling(
                     });
                     let changed = current_hash != prev_sessions_hash;
                     if changed {
+                        #[cfg(target_os = "macos")]
+                        crate::macos_now_playing::publish(&sessions);
+
                         if let Err(e) = app_handle.emit("sessions-updated", &sessions) {
                             crate::debug_log::log_error(&format!(
                                 "Failed to emit sessions-updated: {}",

--- a/src-tauri/tauri.macos.conf.json
+++ b/src-tauri/tauri.macos.conf.json
@@ -1,0 +1,13 @@
+{
+  "build": {
+    "beforeBuildCommand": "npm run build && npm run build:widget"
+  },
+  "bundle": {
+    "macOS": {
+      "minimumSystemVersion": "14.0",
+      "files": {
+        "PlugIns/c9watch-widget.appex": "../macos-widget/build/c9watch-widget.appex"
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Summary
<img width="716" height="355" alt="image" src="https://github.com/user-attachments/assets/bb456072-f046-4704-b17c-7fa384a5eda7" />

- add small, medium, and large macOS desktop widgets for c9watch
- show working, approval, and waiting session counts
- publish live session snapshots and support local ad-hoc widget builds
- register the WidgetKit extension in the packaged app

## Verification
- npm run check
- cargo check --manifest-path src-tauri/Cargo.toml
- npm run build:widget
- npm run tauri build -- --bundles app --config {"bundle":{"createUpdaterArtifacts":false}}