### PR TITLE
feat: add Cursor Agent support and provider-scoped session routing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,7 +9,43 @@ permissions:
   contents: write
 
 jobs:
+  source-gates:
+    runs-on: macos-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+
+      - name: Install frontend dependencies
+        run: npm ci
+
+      - name: Diff hygiene
+        run: git diff --check "${GITHUB_SHA}^" "$GITHUB_SHA"
+
+      - name: Rust format
+        run: cargo fmt --all --manifest-path src-tauri/Cargo.toml -- --check
+
+      - name: Rust library tests
+        run: cargo test --locked --manifest-path src-tauri/Cargo.toml --lib
+
+      - name: Rust integration tests
+        run: cargo test --locked --manifest-path src-tauri/Cargo.toml --tests
+
+      - name: Frontend type and static checks
+        run: npm run check
+
+      - name: Frontend production build
+        run: npm run build
+
   build-macos:
+    needs: source-gates
     runs-on: macos-latest
     strategy:
       matrix:
@@ -43,19 +79,44 @@ jobs:
           TAURI_SIGNING_PRIVATE_KEY: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY }}
         run: test -n "$TAURI_SIGNING_PRIVATE_KEY"
 
+      - name: Verify Apple signing and notarization credentials
+        env:
+          APPLE_CERTIFICATE: ${{ secrets.APPLE_CERTIFICATE }}
+          APPLE_CERTIFICATE_PASSWORD: ${{ secrets.APPLE_CERTIFICATE_PASSWORD }}
+          APPLE_SIGNING_IDENTITY: ${{ secrets.APPLE_SIGNING_IDENTITY }}
+          APPLE_ID: ${{ secrets.APPLE_ID }}
+          APPLE_PASSWORD: ${{ secrets.APPLE_PASSWORD }}
+          APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
+        run: |
+          test -n "$APPLE_CERTIFICATE"
+          test -n "$APPLE_CERTIFICATE_PASSWORD"
+          test -n "$APPLE_SIGNING_IDENTITY"
+          test -n "$APPLE_ID"
+          test -n "$APPLE_PASSWORD"
+          test -n "$APPLE_TEAM_ID"
+
       - name: Build Tauri app
         env:
           TAURI_SIGNING_PRIVATE_KEY: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY }}
           TAURI_SIGNING_PRIVATE_KEY_PASSWORD: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY_PASSWORD }}
-          # Apple code signing (optional — set these secrets to enable)
+          # Apple code signing
           APPLE_CERTIFICATE: ${{ secrets.APPLE_CERTIFICATE }}
           APPLE_CERTIFICATE_PASSWORD: ${{ secrets.APPLE_CERTIFICATE_PASSWORD }}
           APPLE_SIGNING_IDENTITY: ${{ secrets.APPLE_SIGNING_IDENTITY }}
-          # Apple notarization (optional — set these secrets to enable)
+          # Apple notarization
           APPLE_ID: ${{ secrets.APPLE_ID }}
           APPLE_PASSWORD: ${{ secrets.APPLE_PASSWORD }}
           APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
         run: npx tauri build --target ${{ matrix.target }}
+
+      - name: Validate signed and notarized native bundle
+        run: |
+          BUNDLE="src-tauri/target/${{ matrix.target }}/release/bundle"
+          APP=$(find "$BUNDLE/macos" -maxdepth 1 -type d -name '*.app' -print -quit)
+          test -n "$APP"
+          codesign --verify --deep --strict --verbose=2 "$APP"
+          xcrun stapler validate "$APP"
+          spctl --assess --type execute --verbose=4 "$APP"
 
       - name: Rename artifacts for clarity
         run: |
@@ -81,6 +142,14 @@ jobs:
             fi
           done
 
+          archive="macos/c9watch_${{ github.ref_name }}_${{ matrix.arch }}.app.tar.gz"
+          test -s "$archive"
+          test -s "${archive}.sig"
+
+          dmg=$(find dmg -maxdepth 1 -type f -name '*.dmg' -print -quit)
+          test -n "$dmg"
+          hdiutil imageinfo "$dmg" >/dev/null
+
       - name: Upload DMG
         uses: actions/upload-artifact@v4
         with:
@@ -103,6 +172,7 @@ jobs:
           if-no-files-found: error
 
   build-cli:
+    needs: source-gates
     strategy:
       matrix:
         include:
@@ -135,6 +205,17 @@ jobs:
             --no-default-features --features cli \
             --target ${{ matrix.target }}
 
+      - name: Verify Apple signing credentials
+        if: runner.os == 'macOS'
+        env:
+          APPLE_CERTIFICATE: ${{ secrets.APPLE_CERTIFICATE }}
+          APPLE_CERTIFICATE_PASSWORD: ${{ secrets.APPLE_CERTIFICATE_PASSWORD }}
+          APPLE_SIGNING_IDENTITY: ${{ secrets.APPLE_SIGNING_IDENTITY }}
+        run: |
+          test -n "$APPLE_CERTIFICATE"
+          test -n "$APPLE_CERTIFICATE_PASSWORD"
+          test -n "$APPLE_SIGNING_IDENTITY"
+
       - name: Sign CLI binary (macOS)
         if: runner.os == 'macOS'
         env:
@@ -158,9 +239,8 @@ jobs:
             # Clean up sensitive files
             rm -f "$RUNNER_TEMP/certificate.p12"
             security delete-keychain "$KEYCHAIN_PATH" 2>/dev/null || true
-          else
-            codesign --force --options runtime --sign - "$BINARY"
           fi
+          codesign --verify --strict --verbose=2 "$BINARY"
 
       - name: Package CLI binary
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,6 +13,8 @@ jobs:
     runs-on: macos-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 2
 
       - name: Install Rust
         uses: dtolnay/rust-toolchain@stable
@@ -117,6 +119,34 @@ jobs:
           codesign --verify --deep --strict --verbose=2 "$APP"
           xcrun stapler validate "$APP"
           spctl --assess --type execute --verbose=4 "$APP"
+
+      - name: Native launch and server health smoke
+        env:
+          HOME: ${{ runner.temp }}/c9watch-native-home
+        run: |
+          BUNDLE="src-tauri/target/${{ matrix.target }}/release/bundle"
+          APP=$(find "$BUNDLE/macos" -maxdepth 1 -type d -name '*.app' -print -quit)
+          BINARY="$APP/Contents/MacOS/c9watch"
+          test -x "$BINARY"
+          mkdir -p "$HOME"
+          "$BINARY" --version
+          "$BINARY" > "$RUNNER_TEMP/c9watch-native.log" 2>&1 &
+          PID=$!
+          cleanup() { kill "$PID" 2>/dev/null || true; }
+          trap cleanup EXIT
+          for _ in $(seq 1 30); do
+            if curl --fail --silent http://127.0.0.1:9210/health >/dev/null; then
+              curl --fail --silent http://127.0.0.1:9210/info | grep -q '"version":"0.10.0"'
+              exit 0
+            fi
+            if ! kill -0 "$PID" 2>/dev/null; then
+              cat "$RUNNER_TEMP/c9watch-native.log"
+              exit 1
+            fi
+            sleep 1
+          done
+          cat "$RUNNER_TEMP/c9watch-native.log"
+          exit 1
 
       - name: Rename artifacts for clarity
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -38,6 +38,11 @@ jobs:
       - name: Install Tauri CLI
         run: npm install -g @tauri-apps/cli@2
 
+      - name: Verify updater signing key
+        env:
+          TAURI_SIGNING_PRIVATE_KEY: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY }}
+        run: test -n "$TAURI_SIGNING_PRIVATE_KEY"
+
       - name: Build Tauri app
         env:
           TAURI_SIGNING_PRIVATE_KEY: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY }}
@@ -54,32 +59,48 @@ jobs:
 
       - name: Rename artifacts for clarity
         run: |
-          cd src-tauri/target/${{ matrix.target }}/release/bundle
+          BUNDLE="src-tauri/target/${{ matrix.target }}/release/bundle"
+          cd "$BUNDLE"
           if [ -d dmg ]; then
             for f in dmg/*.dmg; do
+              [ -f "$f" ] || continue
               mv "$f" "dmg/c9watch_${{ github.ref_name }}_${{ matrix.arch }}.dmg"
             done
           fi
+
+          # Keep the exact archive that Tauri signed. Re-tarring the .app in
+          # create-release would produce different bytes from the signed file.
+          for archive in macos/*.app.tar.gz; do
+            [ -f "$archive" ] || continue
+            final="macos/c9watch_${{ github.ref_name }}_${{ matrix.arch }}.app.tar.gz"
+            if [ "$archive" != "$final" ]; then
+              mv "$archive" "$final"
+              if [ -f "${archive}.sig" ]; then
+                mv "${archive}.sig" "${final}.sig"
+              fi
+            fi
+          done
 
       - name: Upload DMG
         uses: actions/upload-artifact@v4
         with:
           name: macos-dmg-${{ matrix.arch }}
           path: src-tauri/target/${{ matrix.target }}/release/bundle/dmg/*.dmg
+          if-no-files-found: error
 
       - name: Upload app bundle
         uses: actions/upload-artifact@v4
         with:
           name: macos-app-${{ matrix.arch }}
           path: src-tauri/target/${{ matrix.target }}/release/bundle/macos/*.app
+          if-no-files-found: error
 
-      - name: Upload updater signature (if exists)
+      - name: Upload signed updater artifact
         uses: actions/upload-artifact@v4
-        if: always()
         with:
-          name: updater-sig-${{ matrix.arch }}
-          path: src-tauri/target/${{ matrix.target }}/release/bundle/macos/*.app.tar.gz*
-          if-no-files-found: ignore
+          name: updater-${{ matrix.arch }}
+          path: src-tauri/target/${{ matrix.target }}/release/bundle/macos/c9watch_${{ github.ref_name }}_${{ matrix.arch }}.app.tar.gz*
+          if-no-files-found: error
 
   build-cli:
     strategy:
@@ -164,15 +185,14 @@ jobs:
         with:
           path: artifacts
 
-      - name: Create .tar.gz from .app bundles (for Homebrew)
+      - name: Collect signed updater artifacts
         run: |
-          cd artifacts
           for arch in aarch64 x86_64; do
-            if [ -d "macos-app-${arch}" ]; then
-              cd "macos-app-${arch}"
-              tar -czf "../c9watch_${{ github.ref_name }}_${arch}.app.tar.gz" *.app
-              cd ..
-            fi
+            archive="artifacts/updater-${arch}/c9watch_${{ github.ref_name }}_${arch}.app.tar.gz"
+            test -f "$archive"
+            test -f "${archive}.sig"
+            cp "$archive" "artifacts/c9watch_${{ github.ref_name }}_${arch}.app.tar.gz"
+            cp "${archive}.sig" "artifacts/c9watch_${{ github.ref_name }}_${arch}.app.tar.gz.sig"
           done
 
       - name: Generate updater JSON manifest
@@ -182,15 +202,8 @@ jobs:
           VERSION_NO_V="${VERSION#v}"
           DATE=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
 
-          # Read signatures if they exist
-          AARCH64_SIG=""
-          X86_64_SIG=""
-          if [ -f "artifacts/updater-sig-aarch64/"*.sig ]; then
-            AARCH64_SIG=$(cat artifacts/updater-sig-aarch64/*.sig 2>/dev/null || echo "")
-          fi
-          if [ -f "artifacts/updater-sig-x86_64/"*.sig ]; then
-            X86_64_SIG=$(cat artifacts/updater-sig-x86_64/*.sig 2>/dev/null || echo "")
-          fi
+          AARCH64_SIG=$(cat "artifacts/c9watch_${VERSION}_aarch64.app.tar.gz.sig")
+          X86_64_SIG=$(cat "artifacts/c9watch_${VERSION}_x86_64.app.tar.gz.sig")
 
           cat > artifacts/latest.json << MANIFEST
           {

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,36 +7,54 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.9.0] - 2026-08-16
+
+### Added
+- **Codex App and CLI monitoring.** c9watch now detects both Codex surfaces,
+  displays provider-aware `CODEX` badges, and groups Codex subagents under
+  their parent sessions.
+- **Shared provider filtering.** The `All | Claude Code | Codex` filter now
+  applies to Monitor, History, Cost, and Memory, including provider-specific
+  memory files and Codex model cost estimates.
+- **Claude agent metadata backend.** Use `claude agents --json` when
+  available, with a legacy fallback for older Claude Code installations.
+- **User-controlled updates.** The new SETTINGS tab and update banner let
+  users decide when an available app update is installed.
+- **TODO side panel.** Conversation previews can show the session's TODO list
+  without leaving the preview overlay.
+- **PM `bg` backend.** PM workers can use `claude --bg` instead of
+  `claude --print`, with automatic detection for newer Claude Code versions
+  and `C9WATCH_WORKER_BACKEND=bg|print|auto` override support.
+- `c9watch spawn --prompt <text>` is available when the `bg` backend is active.
+- Added `EventStatus::Awaiting` and `InboxEvent::awaiting()` for workers that
+  are waiting for user input.
+
 ### Changed
-- **PM orchestration is now disabled by default.** Claude Code and Codex
-  provide native agent spawning, so c9watch's own PM/worker orchestration is
-  opt-in. Normal builds omit the PM CLI subcommands (`spawn`, `send`,
-  `workers`, `inbox`, `adopt`, `daemon`) and hide the dashboard's
-  HUMANS/WORKERS toggle, WORKER/PM badges, worker title prefix, and Workers
-  panel. All sessions still show normally — records with legacy `workerOf`
-  metadata render as ordinary sessions — and the native Subagents panel is
-  unchanged. The implementation is preserved, not removed:
-  - Enable the CLI with the `pm-orchestration` Cargo feature:
-    `cargo build --no-default-features --features cli,pm-orchestration`.
-  - Enable the dashboard UI by setting `PM_ORCHESTRATION_ENABLED = true` in
-    `src/lib/feature-flags.ts`.
+- **PM orchestration is now disabled by default.** Normal builds omit the PM
+  CLI subcommands and hide the HUMANS/WORKERS toggle, worker badges, worker
+  title prefix, and Workers panel. The implementation remains opt-in through
+  the `pm-orchestration` Cargo feature and `PM_ORCHESTRATION_ENABLED` UI flag.
+- **History search now defaults to phrase matching** and exposes
+  case-sensitive and whole-word toggles.
+- **The MEMORY tab uses an accordion layout** with improved reading size and
+  animation.
+- Added `Cmd+1` through `Cmd+4` shortcuts for tab navigation.
+
+### Fixed
+- Preserved Codex CLI search metadata and prefixes across search results.
+- Dropped history entries whose JSONL files were cleared instead of showing
+  unviewable stale cards.
 
 ### Improved
 - **Lower memory usage for Codex session monitoring.** Incremental rollout
   parsing and bounded monitor representations reduce peak RSS by 65.8% on a
   controlled workload while preserving full conversation and tool details.
   ([#116](https://github.com/minchenlee/c9watch/pull/116))
+- Opening a session now focuses the matching macOS Terminal/iTerm2 target by
+  tty, and can focus the exact Supacode tab and surface when its coordinates
+  are available.
 - Added a dry-run-by-default utility for cleaning stale Cargo targets from
   other registered worktrees.
-
-### Added
-- PM-orchestration `bg` backend: spawn workers via `claude --bg` instead of
-  `claude --print`. Workers stay on Pro/Max subscription quota after
-  Anthropic's 2026-06-15 Agent SDK billing split. Auto-detected when CC
-  >= 2.1.150. Override with `C9WATCH_WORKER_BACKEND=bg|print|auto`.
-- `c9watch spawn --prompt <text>` flag (required when bg backend is active).
-- `EventStatus::Awaiting` + `InboxEvent::awaiting()` for bg workers entering
-  `state:blocked` (turn ended waiting on user input — distinct from done/crashed).
 
 ## [0.8.1] - 2026-04-20
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,34 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.10.0] - 2026-08-24
+
+### Added
+- **Cursor Agent monitoring.** Detect Cursor Agent root and subagent sessions,
+  expose Cursor lifecycle and provider metadata, and include Cursor sessions in
+  Monitor, History, conversation search, and provider filtering.
+- **Provider-scoped session identity.** Claude Code, Codex, and Cursor session
+  IDs are isolated across detection, enrichment, CLI output, notifications, and
+  frontend selection state.
+- **Cursor transcript resilience coverage.** Synthetic tests cover lifecycle
+  transitions, deleted and renamed transcripts, large transcripts, and reads
+  concurrent with an incomplete write.
+
+### Fixed
+- **Cursor incremental transcript cache correctness.** Appends now verify the
+  cached prefix before reusing the prior summary, so truncate-and-rewrite and
+  prefix-mismatch changes fall back to a full parse. Incomplete final JSONL
+  records remain pending until a complete line is available.
+- **Provider collision safety for rename requests.** Explicit Codex/Cursor
+  rename targets are rejected, and providerless legacy requests are rejected
+  before writing when the raw ID is also detected under another provider.
+- **Codex archive cache correctness.** Persistent archive snapshots now reject
+  weak/coarse file metadata, detect same-length and middle rewrites, and retry
+  when a rollout changes while it is being read.
+- **Shared provider source lifetime.** GUI polling and CLI/Web enrichment reuse
+  the same Codex and Cursor incremental sources instead of silently reparsing
+  from a cold cache on every request.
+
 ## [0.9.0] - 2026-08-16
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -4,9 +4,9 @@
 
 <h1 align="center">c9watch</h1>
 
-<p align="center">Monitor and control all your Claude Code sessions — built for both humans and agents.</p>
+<p align="center">Monitor and control Claude Code sessions, with Codex and Cursor Agent visibility — built for both humans and agents.</p>
 
-**c9watch** (short for **c**laude cod**e** watch, like k8s for Kubernetes) gives you a real-time view of every Claude Code session running on your machine. A **desktop dashboard** for you, and a **JSON CLI** for your agents — both watching the same sessions at the same time.
+**c9watch** (short for **c**laude cod**e** watch, like k8s for Kubernetes) gives you a real-time view of every Claude Code, Codex, and Cursor Agent session running on your machine. A **desktop dashboard** for you, and a **JSON CLI** for your agents — both watching the same sessions at the same time.
 
 You see which agent needs permission, which one is working, and which one is idle. Your agents can do the same — querying session status, searching past work, and coordinating with each other — all through the same tool.
 
@@ -123,6 +123,8 @@ c9watch status
 
 # View a conversation (prefix matching works)
 c9watch view abc123 --last 5 --pretty
+# Use the provider-scoped key from `c9watch list` when IDs collide
+c9watch view codex:<session-id> --last 5
 
 # Browse and search history
 c9watch history -n 20
@@ -143,6 +145,7 @@ c9watch tasks abc123
 # Cost breakdown, including per-session lookup
 c9watch cost --daily
 c9watch cost --session abc12345 --pretty
+c9watch cost --session codex:<session-id> --pretty
 c9watch cost --session-prefix abc
 
 # PM orchestration (opt-in — see note below): spawn and manage child workers

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -85,6 +85,7 @@ Null/empty optional fields are omitted to save tokens.
 c9watch view <session-id>               # Full conversation
 c9watch view <session-id> --last 5      # Last 5 messages
 c9watch view 46fe --last 3 --pretty     # UUID prefix works
+c9watch view codex:<session-id>         # Provider-scoped key disambiguates IDs
 ```
 
 Each message includes:
@@ -119,7 +120,7 @@ c9watch search "refactor parser" --project c9watch
 }
 ```
 
-Search covers Claude Code and Codex history. Each hit includes `provider`, `surface`, and `agentKind` so consumers can distinguish the source and session type.
+Search covers Claude Code, Codex, and Cursor history. Each hit includes `provider`, `surface`, and `agentKind` so consumers can distinguish the source and session type.
 
 ### `history` — Past Sessions
 
@@ -165,6 +166,7 @@ Read tasks from `~/.claude/tasks/<session-id>/`.
 
 ```bash
 c9watch tasks <session-id>
+c9watch tasks cursor:<session-id>       # Provider-scoped key
 ```
 
 ```json
@@ -250,6 +252,11 @@ All commands that accept a session ID support UUID prefix matching:
 c9watch view 46fe          # Matches 46fe2af3-fd8e-43e3-bd6d-6c7800722cbf
 c9watch tasks 5c54          # Matches 5c5426de-08b0-484a-b1ae-1df59ac84a39
 ```
+
+`view`, `tasks`, and `cost --session` also accept the provider-scoped keys
+emitted by `list` and `watch`: `claudeCode:<id>`, `codex:<id>`, or
+`cursor:<id>`. This is the explicit form to use when the same raw ID exists
+under more than one provider.
 
 If the prefix is ambiguous (matches multiple sessions), an error is returned. Prefix resolution scans JSONL filenames directly — no process detection needed.
 

--- a/docs/codex-monitoring-manual-test.md
+++ b/docs/codex-monitoring-manual-test.md
@@ -24,7 +24,7 @@ open src-tauri/target/debug/bundle/macos
 
 The current debug app has these properties:
 
-- Version: `c9watch 0.8.1`
+- Version: `c9watch 0.9.0`
 - Architecture: macOS arm64
 - Signing: local ad-hoc signature
 - Not notarized and not intended for release distribution

--- a/docs/notes/cursor-agent-cache-review-2026-08-23.md
+++ b/docs/notes/cursor-agent-cache-review-2026-08-23.md
@@ -1,16 +1,16 @@
 # Cursor Agent Incremental Cache Review
 
-Date: 2026-08-23  
-Branch: `feature/cursor-agent-detection`  
-Scope: `src-tauri/src/session/cursor.rs`  
-Source commits: `c26dff6`, `bd263eb`  
-Review note: untracked; not committed.
+Date: 2026-08-23
+Branch: `feature/cursor-agent-detection`
+Scope: `src-tauri/src/session/cursor.rs`
+Source commits: `c26dff6`, `bd263eb`
+Review note: preserved and committed with the v0.10.0 candidate.
 
 ## Outcome
 
 **Initial verdict: Approve with follow-up.**
 
-The implementation fixes the targeted truncate-and-grow transcript rewrite bug. The independent review found no P0, P1, or P2 correctness issue. The two executable follow-ups, P3-1 and P3-3, were subsequently completed. P3-2 and the large-transcript benchmark remain explicitly deferred.
+The implementation fixes the targeted truncate-and-grow transcript rewrite bug. The independent review found no P0, P1, or P2 correctness issue. The two executable follow-ups, P3-1 and P3-3, were subsequently completed. Same-length rewrites on filesystems with unchanged metadata remain an explicit platform limitation.
 
 ## Root cause
 
@@ -32,6 +32,13 @@ The change is confined to `src-tauri/src/session/cursor.rs` and does not alter f
 Commit `bd263eb` refactors the append path to reuse the verified prefix hasher. The implementation now separates prefix feeding, prefix verification, and suffix feeding so a genuine append hashes only the newly appended bytes after the cached prefix has been verified.
 
 The same follow-up adds `partial_line_is_ignored_until_fully_written`, covering a torn JSONL write: an unterminated line does not advance the offset, and the completed line is later emitted exactly once.
+
+The review-fix pass adds a bounded validation policy for large transcripts. Files up to
+4 MiB use exact prefix verification on every append. Larger files validate fixed-size
+head/tail guards between full-prefix checkpoints, and schedule those checkpoints after
+geometric growth. This bounds normal append validation I/O and keeps cumulative full
+revalidation linear in transcript growth; an arbitrary rewrite in the unguarded middle
+of a large file is detected at the next full checkpoint.
 
 ## Regression evidence reported by Pi
 
@@ -91,7 +98,8 @@ Before the follow-up commits, the Codex-side read-only inspection observed:
  M src-tauri/src/session/cursor.rs
 ```
 
-`git diff --check` produced no output at inspection time. No real `~/.cursor` transcript was used.
+No real `~/.cursor` transcript was used. The current review-fix commit also runs the
+range form of `git diff --check` as a release source gate.
 
 ## Independent review findings
 
@@ -121,7 +129,9 @@ The source implementation and the executable review follow-ups are now committed
 
 - [x] Avoid double prefix hashing on append (`bd263eb`).
 - [x] Add a partial-line incremental parsing regression test (`bd263eb`).
+- [x] Add bounded large-transcript prefix validation and a synthetic byte-budget regression.
 - [ ] Decide whether same-length rewrite detection needs a platform-specific solution.
-- [ ] Benchmark synthetic large transcripts if prefix-hash cost becomes user-visible.
 
-Current working tree status: source changes are committed at `bd263eb`; this review note is the only untracked file. Full workspace build, Tauri integration/e2e tests, real high-frequency writes, and large real-user transcripts remain outside this review's verification scope.
+The note is committed with the candidate. Full workspace build, Tauri integration/e2e
+tests, and large real-user transcripts remain outside this synthetic-fixture review's
+verification scope.

--- a/docs/notes/cursor-agent-cache-review-2026-08-23.md
+++ b/docs/notes/cursor-agent-cache-review-2026-08-23.md
@@ -1,0 +1,127 @@
+# Cursor Agent Incremental Cache Review
+
+Date: 2026-08-23  
+Branch: `feature/cursor-agent-detection`  
+Scope: `src-tauri/src/session/cursor.rs`  
+Source commits: `c26dff6`, `bd263eb`  
+Review note: untracked; not committed.
+
+## Outcome
+
+**Initial verdict: Approve with follow-up.**
+
+The implementation fixes the targeted truncate-and-grow transcript rewrite bug. The independent review found no P0, P1, or P2 correctness issue. The two executable follow-ups, P3-1 and P3-3, were subsequently completed. P3-2 and the large-transcript benchmark remain explicitly deferred.
+
+## Root cause
+
+`summary_for` previously used `stamp.len > cached.offset` as the append test. If a Cursor transcript was truncated and rewritten with a total length greater than the old cached offset, the detector could resume parsing from an invalid byte position while reusing the old summary. This could retain stale messages and lifecycle state or skip new content.
+
+## Implemented change
+
+`CacheEntry` now stores a `prefix_hash` for the parsed byte range `[0, offset)`. Incremental parsing is allowed only when all of the following hold:
+
+1. The file is longer than the cached parsed offset.
+2. The current file prefix hash matches the cached prefix hash.
+
+If the prefix does not match, the detector falls back to a full parse. Hash-read failures also take the safe full-parse path.
+
+The change is confined to `src-tauri/src/session/cursor.rs` and does not alter frontend behavior, provider detection semantics, freshness rules, or the vscdb overlay.
+
+### Follow-up completion
+
+Commit `bd263eb` refactors the append path to reuse the verified prefix hasher. The implementation now separates prefix feeding, prefix verification, and suffix feeding so a genuine append hashes only the newly appended bytes after the cached prefix has been verified.
+
+The same follow-up adds `partial_line_is_ignored_until_fully_written`, covering a torn JSONL write: an unterminated line does not advance the offset, and the completed line is later emitted exactly once.
+
+## Regression evidence reported by Pi
+
+The new test is:
+
+`session::cursor::tests::truncated_then_rewritten_longer_matches_full_parse`
+
+It performs the following sequence:
+
+1. Write an initial JSONL transcript and call `detect()` to establish the cache.
+2. Truncate and rewrite the same path with different content whose length is greater than the cached offset.
+3. Call `detect()` again.
+4. Compare the result with a fresh `CursorSessionSource` doing a full parse.
+
+The reviewer also reported running the new test against the baseline implementation and reproducing the stale-message failure before applying the fix.
+
+## Test and verification evidence
+
+The following results were reported by the implementation/review Pi agents and were not independently rerun in this Codex turn:
+
+```text
+cargo test --lib session::cursor::tests::truncated_then_rewritten_longer_matches_full_parse
+  baseline: FAILED as expected; stale messages remained
+
+cargo test --lib session::cursor
+  18 passed, 0 failed
+
+cargo test --lib
+  322 passed, 0 failed
+
+cargo fmt --check
+  OK
+
+cargo clippy --lib
+  2 existing warnings in cursor.rs; no warning reported as introduced by this change
+```
+
+After the follow-up commits, the reported verification was:
+
+```text
+cargo test --lib session::cursor
+  19 passed, 0 failed
+
+cargo test --lib
+  323 passed, 0 failed
+
+cargo fmt --check
+  OK
+
+cargo clippy --lib
+  2 existing warnings; no new warnings reported
+```
+
+Before the follow-up commits, the Codex-side read-only inspection observed:
+
+```text
+ M src-tauri/src/session/cursor.rs
+```
+
+`git diff --check` produced no output at inspection time. No real `~/.cursor` transcript was used.
+
+## Independent review findings
+
+### P3-1 — Changed files hash the prefix twice — resolved
+
+On a genuine append, the implementation hashes the cached prefix to validate the append and then hashes the new prefix again when storing the updated cache entry. This makes the I/O cost proportional to the total transcript size, with overlapping reads, even though JSON parsing remains incremental.
+
+Resolved by `bd263eb`: the verified prefix hasher is reused and only the appended suffix is fed into the resulting hash state. The unchanged-file fast path remains intact.
+
+### P3-2 — Same-length rewrite and coarse mtime
+
+If a rewrite preserves the exact file length and the filesystem metadata stamp also remains unchanged, the existing fast path could still return stale data. This is considered low risk on the current macOS/APFS target and is not introduced by the prefix-hash change.
+
+Suggested follow-up: consider a platform-appropriate file identity or stronger change signal if support for coarse-mtime filesystems becomes important. An inode alone would not cover every in-place rewrite case.
+
+### P3-3 — Missing partial-line regression test — resolved
+
+Resolved by `bd263eb` with `partial_line_is_ignored_until_fully_written`. The test verifies that an unterminated line does not advance the offset and that the completed message appears exactly once.
+
+### Observation — Concurrent write tear
+
+There is a small time-of-check/time-of-use window between metadata capture and parsing. A concurrent truncate-and-rewrite could produce a mixed summary until a later poll repairs it. The reviewer treated this as an existing, self-healing edge case rather than a blocker.
+
+## Decision and follow-ups
+
+The source implementation and the executable review follow-ups are now committed and suitable for manual review. Keep the following remaining items as separate follow-up work:
+
+- [x] Avoid double prefix hashing on append (`bd263eb`).
+- [x] Add a partial-line incremental parsing regression test (`bd263eb`).
+- [ ] Decide whether same-length rewrite detection needs a platform-specific solution.
+- [ ] Benchmark synthetic large transcripts if prefix-hash cost becomes user-visible.
+
+Current working tree status: source changes are committed at `bd263eb`; this review note is the only untracked file. Full workspace build, Tauri integration/e2e tests, real high-frequency writes, and large real-user transcripts remain outside this review's verification scope.

--- a/docs/notes/cursor-agent-cache-review-2026-08-23.md
+++ b/docs/notes/cursor-agent-cache-review-2026-08-23.md
@@ -38,7 +38,9 @@ The review-fix pass adds a bounded validation policy for large transcripts. File
 head/tail guards between full-prefix checkpoints, and schedule those checkpoints after
 geometric growth. This bounds normal append validation I/O and keeps cumulative full
 revalidation linear in transcript growth; an arbitrary rewrite in the unguarded middle
-of a large file is detected at the next full checkpoint.
+of a large file is detected at the next full checkpoint. Guard-only appends preserve
+the checkpoint anchored to the last full verification; the checkpoint is advanced only
+after a full verification or a full parse.
 
 ## Regression evidence reported by Pi
 
@@ -130,6 +132,7 @@ The source implementation and the executable review follow-ups are now committed
 - [x] Avoid double prefix hashing on append (`bd263eb`).
 - [x] Add a partial-line incremental parsing regression test (`bd263eb`).
 - [x] Add bounded large-transcript prefix validation and a synthetic byte-budget regression.
+- [x] Keep full-prefix checkpoint scheduling anchored across guard-only appends and test middle-rewrite detection at the checkpoint.
 - [ ] Decide whether same-length rewrite detection needs a platform-specific solution.
 
 The note is committed with the candidate. Full workspace build, Tauri integration/e2e

--- a/docs/notes/cursor-agent-v0.10.0-readiness-2026-08-24.md
+++ b/docs/notes/cursor-agent-v0.10.0-readiness-2026-08-24.md
@@ -6,11 +6,12 @@ push, tag, publish, or GitHub release was performed.
 ## Baseline
 
 - Branch: `feature/cursor-agent-detection`
-- HEAD: `bd263eb` (`refactor: reuse verified prefix hasher on cursor transcript append`)
+- Original review baseline: `242f987` (`feat: prepare v0.10.0 Cursor Agent support`)
+- Review-fix candidate: the current HEAD, verified live with `git status` and `git log`
 - v0.9.0 tag: `08b860d`; `origin/release/v0.9.0` points to the same commit.
 - `origin/main`: `223b61c`.
 - Known Cursor commits are present in HEAD: `13b9805`, `c26dff6`, `bd263eb`.
-- The pre-existing untracked note `docs/notes/cursor-agent-cache-review-2026-08-23.md` was preserved.
+- The pre-existing note `docs/notes/cursor-agent-cache-review-2026-08-23.md` was preserved and committed.
 
 ## v0.10.0 scope
 
@@ -41,7 +42,7 @@ push, tag, publish, or GitHub release was performed.
 
 | Gate | Result | Evidence / boundary |
 | --- | --- | --- |
-| Focused Cursor tests | PASS | 25 passed, 0 failed; synthetic fixtures cover append reuse, prefix/truncate-rewrite fallback, partial lines, lifecycle, delete/rename, same-length rewrite with preserved mtime, large transcripts, torn concurrent writes, and suffix-hash read failure |
+| Focused Cursor tests | PASS | 26 passed, 0 failed; synthetic fixtures cover append reuse, bounded large-append validation, prefix/truncate-rewrite fallback, partial lines, lifecycle, delete/rename, same-length rewrite with preserved mtime, large transcripts, torn concurrent writes, and suffix-hash read failure |
 | Focused Codex source tests | PASS | 39 passed, 0 failed; includes incremental hits, partial/truncation, same-length and middle rewrites, lifecycle, hierarchy, and conversation behavior |
 | Focused Codex archive tests | PASS | 12 passed, 0 failed; synthetic fixtures cover partial lines, append/truncation, preserved-mtime same-length rewrite, anchor-external middle rewrite, merge/search, and token accounting |
 | Provider-scoped CLI references | PASS | `cli::` focused suite: 50 passed, 0 failed; `view`, `tasks`, and `cost --session` accept `claudeCode:<id>`, `codex:<id>`, and `cursor:<id>` and disambiguate colliding raw IDs |
@@ -62,7 +63,7 @@ push, tag, publish, or GitHub release was performed.
 | DMG bundle | PENDING GHA evidence | Local generated `bundle_dmg.sh` previously failed; repository release path uses GHA `tauri build` |
 | Apple notarization | PENDING GHA evidence | Workflow accepts Apple credentials; no local notarization was run |
 | x86_64 CI/native E2E | PENDING | Workflow matrix contains x86_64; no completed GHA/native behavior evidence in this checkout |
-| Diff whitespace | PASS | `git diff --check` |
+| Diff whitespace | PASS | Review-fix commit range checked with `git diff --check HEAD^ HEAD` |
 
 The provider-owner synthetic suite also passes 6/6: global and cloned Codex/Cursor owners
 share their mutable source and their second detection reuses the same parsed
@@ -108,18 +109,22 @@ re-review** and did not run tests or builds. Findings and current status:
 - P2 non-atomic filesystem snapshots: remains an explicit limitation. Reads
   use metadata/read/retry boundaries, but no reader promises an atomic snapshot
   during every concurrent writer race.
-- P2 cumulative prefix I/O: remains a performance follow-up. Verified-prefix
-  append checks are correct, but repeated small appends to a large transcript
-  can accumulate O(N^2) work; no benchmark is claimed.
+- P2 cumulative prefix I/O: fixed in the review-fix candidate. Transcripts up to
+  4 MiB use exact prefix verification on every append. Larger transcripts use
+  fixed-size head/tail guards between geometrically scheduled full-prefix
+  checkpoints, so normal append validation has a bounded read budget and the
+  cumulative full-revalidation work is linear in transcript growth. A synthetic
+  byte-budget regression covers the high-frequency large-file path.
 - P3 Cursor suffix-hash errors being swallowed: fixed. Hash/read failure now
   returns a parse error instead of persisting an incomplete hash, with a
   synthetic regression test.
 - P3 frontend raw subagent key: fixed. `ExpandedCardOverlay` now keys and
   compares subagents with provider-qualified keys.
-- Missing behavior-level frontend/native E2E, mutation/retry-exhaustion
-  integration coverage, and large-append performance benchmarking remain
-  open. Frontend behavior/native E2E is intentionally deferred to the user;
-  `npm run check` and `npm run build` validate types/compilation only.
+- Missing behavior-level frontend/native E2E and mutation/retry-exhaustion
+  integration coverage remain open. Frontend behavior/native E2E is intentionally
+  deferred to the user; `npm run check` and `npm run build` validate
+  types/compilation only. The large-append validation budget is now covered by a
+  synthetic regression rather than an unbounded benchmark claim.
 
 The delta reviewer did not perform a final full re-review after the
 collision-aware compatibility fix. A resumed independent reviewer then
@@ -159,25 +164,25 @@ trusting a stale serialized key.
 ## Release workflow review
 
 `.github/workflows/release.yml` triggers on `v*` tags and builds macOS
-`aarch64` and `x86_64`. It now fails closed when
-`TAURI_SIGNING_PRIVATE_KEY` is absent or a signed updater archive/signature is
-not produced. The workflow preserves the exact Tauri-generated
-`.app.tar.gz` bytes that were signed, renames those artifacts (without
-re-tarring the `.app`), renames DMGs to `c9watch_<tag>_<arch>.dmg`, and
-generates `latest.json` URLs matching the published archive names. DMG, app,
-and updater artifact uploads now fail when their expected files are absent.
-Optional Apple signing/notarization secrets remain GHA inputs. The updater
-endpoint and public key remain configured in `src-tauri/tauri.conf.json`;
-`createUpdaterArtifacts` is still `v1Compatible`. This workflow logic has not
-yet been exercised by a GitHub Actions run in this checkout.
+`aarch64` and `x86_64`. A serial `source-gates` job now blocks both release
+build matrices until diff hygiene, Rust format/tests, and frontend check/build
+pass. The macOS job fails closed when updater signing or Apple signing and
+notarization credentials are absent, then verifies the built app with
+`codesign`, `stapler`, and `spctl`, validates the DMG with `hdiutil`, and checks
+that the signed updater archive and signature exist. The workflow preserves the
+exact Tauri-generated `.app.tar.gz` bytes that were signed, renames those
+artifacts (without re-tarring the `.app`), renames DMGs to
+`c9watch_<tag>_<arch>.dmg`, and generates `latest.json` URLs matching the
+published archive names. The updater endpoint and public key remain configured
+in `src-tauri/tauri.conf.json`; `createUpdaterArtifacts` is still `v1Compatible`.
+The workflow changes have not yet been exercised by a GitHub Actions run in this
+checkout.
 
 ## Decision
 
-- Ready for PR: **yes, conditionally** — the candidate is reviewable with
-  green focused/full Rust and frontend compile gates; the known P2 rename
-  issue is fixed and locally verified, and the final bounded independent
-  collision/owner review returned PASS with no P0-P3 findings. Deferred native
-  E2E and uncommitted changes must remain visible.
+- Ready for PR: **pending final re-review** — the two P2 findings and two P3
+  findings from the full independent review have been addressed in the
+  review-fix candidate, but the same reviewer must confirm the fixes.
 - Ready for release: **no** — local DMG packaging, updater signing,
   notarization, cross-architecture GHA evidence, and native app E2E are not
   all green; no release authorization was given.

--- a/docs/notes/cursor-agent-v0.10.0-readiness-2026-08-24.md
+++ b/docs/notes/cursor-agent-v0.10.0-readiness-2026-08-24.md
@@ -1,0 +1,186 @@
+# c9watch v0.10.0 release readiness
+
+As of 2026-08-24, this is a release-preparation candidate only. No merge,
+push, tag, publish, or GitHub release was performed.
+
+## Baseline
+
+- Branch: `feature/cursor-agent-detection`
+- HEAD: `bd263eb` (`refactor: reuse verified prefix hasher on cursor transcript append`)
+- v0.9.0 tag: `08b860d`; `origin/release/v0.9.0` points to the same commit.
+- `origin/main`: `223b61c`.
+- Known Cursor commits are present in HEAD: `13b9805`, `c26dff6`, `bd263eb`.
+- The pre-existing untracked note `docs/notes/cursor-agent-cache-review-2026-08-23.md` was preserved.
+
+## v0.10.0 scope
+
+- Cursor Agent root and subagent discovery under the Cursor projects fixture
+  layout, with optional read-only Composer metadata overlay.
+- JSONL parsing for user/assistant/tool records, incomplete final lines, and
+  `turn_ended` lifecycle state.
+- Working/idle/connecting/waiting enrichment, parent-child hierarchy, history,
+  conversation lookup, deep search, and provider-aware frontend filtering.
+- Incremental cache append reuse with verified prefix hashing, full-parse
+  fallback for truncation/prefix mismatch, strong Unix metadata stamps, weak
+  metadata fallback, stale-entry eviction, and read-change retries.
+- Cursor provider semantics in cost visualization and an explicit read-only
+  history overlay.
+- Provider-scoped session identity (`provider:sessionId`) across backend
+  deduplication, conversation dispatch, CLI watch/cost resolution, frontend
+  selection/maps, notifications, tasks, and provider hierarchy.
+- Persistent Codex/Cursor source owners for CLI/web polling, plus a reverse
+  JSONL tail reader that expands beyond a fixed byte window for large records.
+- Persistent Codex archive cache correctness: strong ctime/identity stamps,
+  cache-version invalidation, full logical-prefix hashing beyond the cheap
+  anchor, and bounded retries when a rollout changes during a read.
+- A shared `FileVersion`/cache-consistency primitive for file length, change
+  time, and identity; append/reset/retry and provider parser/lifecycle rules
+  remain provider-specific.
+
+## Acceptance evidence
+
+| Gate | Result | Evidence / boundary |
+| --- | --- | --- |
+| Focused Cursor tests | PASS | 25 passed, 0 failed; synthetic fixtures cover append reuse, prefix/truncate-rewrite fallback, partial lines, lifecycle, delete/rename, same-length rewrite with preserved mtime, large transcripts, torn concurrent writes, and suffix-hash read failure |
+| Focused Codex source tests | PASS | 39 passed, 0 failed; includes incremental hits, partial/truncation, same-length and middle rewrites, lifecycle, hierarchy, and conversation behavior |
+| Focused Codex archive tests | PASS | 12 passed, 0 failed; synthetic fixtures cover partial lines, append/truncation, preserved-mtime same-length rewrite, anchor-external middle rewrite, merge/search, and token accounting |
+| Provider-scoped CLI references | PASS | `cli::` focused suite: 50 passed, 0 failed; `view`, `tasks`, and `cost --session` accept `claudeCode:<id>`, `codex:<id>`, and `cursor:<id>` and disambiguate colliding raw IDs |
+| Provider owner sharing tests | PASS | 6 passed, 0 failed; global and cloned owners share source state, second synthetic detection does not increment parse count, and test owners do not initialize production roots |
+| Shared cache-stamp contract | PASS | 3 passed, 0 failed; shared `FileVersion` reads length/change-time/identity, weak metadata rejects unchanged fast path, and strong identity/subsecond stamp is accepted |
+| Provider-aware rename protocol | PASS | 7 passed, 0 failed; explicit Codex/Cursor rename is rejected, providerless legacy requests retain their v0.9 shape, and a shared-owner collision guard rejects cross-provider IDs before any write |
+| Synthetic Tauri/WebSocket collision regression | PASS | 3 passed, 0 failed; synthetic Cursor and Codex owners reject providerless rename before the Tauri writer callback or WebSocket title-write dispatch |
+| Full Rust library tests | PASS | 359 passed, 1 ignored, 0 failed |
+| Rust integration tests | PASS | library 359 passed/1 ignored; main 0; background test 1 ignored; parser integration 3 passed |
+| Rust format | PASS | `cargo fmt --all --manifest-path src-tauri/Cargo.toml -- --check` |
+| Frontend type/check | PASS | `npm run check`: 0 errors, 0 warnings |
+| Frontend production build | PASS | `npm run build` completed with SvelteKit/Vite output |
+| Version metadata sync | PASS | `package.json`, `src-tauri/Cargo.toml`, and `src-tauri/tauri.conf.json` all report `0.10.0` |
+| Rust release compile | PASS | `cargo build --release --manifest-path src-tauri/Cargo.toml` |
+| Release workflow YAML parse | PASS | Ruby YAML parser loaded `.github/workflows/release.yml` successfully |
+| Tauri app bundle | UNVERIFIED in this final pass | Rust release compile passed; no new native bundle run was performed |
+| Tauri updater artifact | PENDING GHA evidence | Local signing requires `TAURI_SIGNING_PRIVATE_KEY`; workflow now fails closed when the secret/signature artifact is missing |
+| DMG bundle | PENDING GHA evidence | Local generated `bundle_dmg.sh` previously failed; repository release path uses GHA `tauri build` |
+| Apple notarization | PENDING GHA evidence | Workflow accepts Apple credentials; no local notarization was run |
+| x86_64 CI/native E2E | PENDING | Workflow matrix contains x86_64; no completed GHA/native behavior evidence in this checkout |
+| Diff whitespace | PASS | `git diff --check` |
+
+The provider-owner synthetic suite also passes 6/6: global and cloned Codex/Cursor owners
+share their mutable source and their second detection reuses the same parsed
+source, independent test owners remain isolated, and both Codex and Cursor
+owners detect a temporary fixture without touching a real transcript root.
+
+The shared cache-consistency contract passes 3/3 tests: `FileVersion` exposes
+the same length/change-time/identity shape to provider caches, missing,
+seconds-only, or missing-identity metadata is rejected for the unchanged fast
+path, while a subsecond change time with file identity is accepted. The Codex
+archive cache uses the same primitive and adds a persisted FNV prefix hash so a
+middle rewrite outside its 256-byte anchor is detected before append reuse.
+
+The initial pre-correction test run is not used as privacy evidence: an
+existing polling smoke test called production discovery and could inspect the
+real Cursor home. It was replaced with a tempfile-backed fixture before the
+final gates above. Final Cursor fixtures use explicit temporary roots. Test
+`ProviderSourceOwners` instances disable lazy production-root initialization,
+and a regression test covers that boundary, so state/owner tests do not call
+`CursorSessionSource::new()` or read real `~/.cursor` transcripts. The
+enrichment fixture may still load optional Claude custom-name/title settings;
+it does not read Cursor transcripts.
+
+## Independent review
+
+Sol's architect review is architecture input, not independent-review
+evidence. Its final choice was staged extraction: share file-version,
+append/reset/retry, complete-line cursor, prefix-hash/checkpoint invariants,
+and test matrices, while keeping discovery, lifecycle, parser, and history
+provider-specific. Its P1 findings (Codex CLI/Web source lifetime and Claude
+large-record reverse-tail reading) were implemented before this review.
+
+A separate bounded read-only reviewer completed an initial post-fix delta with
+verdict `REQUEST CHANGES`; it explicitly marked that pass as **not a full
+re-review** and did not run tests or builds. Findings and current status:
+
+- P2 provider-unqualified rename: fixed locally after the delta review.
+  Explicit non-Claude providers are rejected; providerless legacy requests
+  retain the v0.9 protocol shape but consult the shared Codex/Cursor owners'
+  metadata/path indexes and are rejected before writing when the raw ID
+  collides across providers. The TypeScript API remains backward-compatible
+  with an optional provider.
+- P2 non-atomic filesystem snapshots: remains an explicit limitation. Reads
+  use metadata/read/retry boundaries, but no reader promises an atomic snapshot
+  during every concurrent writer race.
+- P2 cumulative prefix I/O: remains a performance follow-up. Verified-prefix
+  append checks are correct, but repeated small appends to a large transcript
+  can accumulate O(N^2) work; no benchmark is claimed.
+- P3 Cursor suffix-hash errors being swallowed: fixed. Hash/read failure now
+  returns a parse error instead of persisting an incomplete hash, with a
+  synthetic regression test.
+- P3 frontend raw subagent key: fixed. `ExpandedCardOverlay` now keys and
+  compares subagents with provider-qualified keys.
+- Missing behavior-level frontend/native E2E, mutation/retry-exhaustion
+  integration coverage, and large-append performance benchmarking remain
+  open. Frontend behavior/native E2E is intentionally deferred to the user;
+  `npm run check` and `npm run build` validate types/compilation only.
+
+The delta reviewer did not perform a final full re-review after the
+collision-aware compatibility fix. A resumed independent reviewer then
+completed a full current-delta review of the collision/owner scope with
+verdict **PASS**: no confirmed P0/P1/P2/P3 findings. It verified that
+providerless rename is rejected before the Claude custom-title write and that
+the shared owners plus Codex/Cursor path checks are coherent. Two other
+bounded contexts were stopped after they did not return a verdict; they are
+not counted as review evidence.
+
+The independent reviewer identified a missing regression: synthetic
+Tauri/WebSocket end-to-end tests for both Codex and Cursor collisions that
+assert no title/custom-title write occurs. That regression is now covered by
+three tests: two Tauri rename-writer preflight tests (Cursor and Codex) and one
+synthetic WebSocket dispatch test covering both providers. The tests use
+tempfile-backed owners and never write a real title file. Frontend/native
+behavior E2E remains a separate user-owned gate.
+
+The provider/session ID collision paths are covered by `SessionIdentity`,
+provider-aware conversation dispatch, collision-aware legacy rename validation,
+provider-scoped frontend maps, Claude-only task/subagent lookup, CLI watch/cost
+resolution, provider-scoped cost breakdown filtering, ambiguous legacy
+conversation rejection, and provider-scoped notification keys. The GUI
+`DetectorState`, CLI/Web enrichment, and rename collision guard obtain
+Codex/Cursor sources from the process-wide `ProviderSourceOwners` registry;
+cloned owners share mutable source state and synthetic tests cover that
+lifecycle. Claude remains separate because its discovery/lifecycle contract is
+different.
+
+The unchanged fast path requires file identity plus subsecond change time.
+Coarse or weak metadata deliberately falls back to content validation/full
+parsing, retaining correctness at the cost of additional I/O. The popover now
+uses provider-scoped keys for hierarchy filtering and keyed rendering, and
+frontend `sessionKeyOf` derives `provider:id` from canonical fields rather than
+trusting a stale serialized key.
+
+## Release workflow review
+
+`.github/workflows/release.yml` triggers on `v*` tags and builds macOS
+`aarch64` and `x86_64`. It now fails closed when
+`TAURI_SIGNING_PRIVATE_KEY` is absent or a signed updater archive/signature is
+not produced. The workflow preserves the exact Tauri-generated
+`.app.tar.gz` bytes that were signed, renames those artifacts (without
+re-tarring the `.app`), renames DMGs to `c9watch_<tag>_<arch>.dmg`, and
+generates `latest.json` URLs matching the published archive names. DMG, app,
+and updater artifact uploads now fail when their expected files are absent.
+Optional Apple signing/notarization secrets remain GHA inputs. The updater
+endpoint and public key remain configured in `src-tauri/tauri.conf.json`;
+`createUpdaterArtifacts` is still `v1Compatible`. This workflow logic has not
+yet been exercised by a GitHub Actions run in this checkout.
+
+## Decision
+
+- Ready for PR: **yes, conditionally** — the candidate is reviewable with
+  green focused/full Rust and frontend compile gates; the known P2 rename
+  issue is fixed and locally verified, and the final bounded independent
+  collision/owner review returned PASS with no P0-P3 findings. Deferred native
+  E2E and uncommitted changes must remain visible.
+- Ready for release: **no** — local DMG packaging, updater signing,
+  notarization, cross-architecture GHA evidence, and native app E2E are not
+  all green; no release authorization was given.
+- Smallest next action: hand the frontend/native E2E gate to the user, then
+  rely on the repository GHA workflow for DMG, signing, notarization, and
+  architecture evidence.

--- a/docs/notes/cursor-agent-v0.10.0-readiness-2026-08-24.md
+++ b/docs/notes/cursor-agent-v0.10.0-readiness-2026-08-24.md
@@ -7,7 +7,7 @@ push, tag, publish, or GitHub release was performed.
 
 - Branch: `feature/cursor-agent-detection`
 - Original review baseline: `242f987` (`feat: prepare v0.10.0 Cursor Agent support`)
-- Review-fix candidate: the current HEAD, verified live with `git status` and `git log`
+- Final review candidate: `504c0e5`, verified live with `git status` and `git log`
 - v0.9.0 tag: `08b860d`; `origin/release/v0.9.0` points to the same commit.
 - `origin/main`: `223b61c`.
 - Known Cursor commits are present in HEAD: `13b9805`, `c26dff6`, `bd263eb`.
@@ -145,6 +145,13 @@ synthetic WebSocket dispatch test covering both providers. The tests use
 tempfile-backed owners and never write a real title file. Frontend/native
 behavior E2E remains a separate user-owned gate.
 
+A final independent review of `81e086a..504c0e5` then completed with
+`FINAL INDEPENDENT REVIEW: yes` and `VERDICT: PASS`. The reviewer independently
+checked the checkpoint invariants, release workflow parent checkout, readiness
+counts, provider/owner collision paths, and synthetic Tauri/WebSocket tests;
+no confirmed P0, P1, P2, or P3 findings remained. This does not convert the
+separate native/package/E2E or release-service gates into local acceptance.
+
 The provider/session ID collision paths are covered by `SessionIdentity`,
 provider-aware conversation dispatch, collision-aware legacy rename validation,
 provider-scoped frontend maps, Claude-only task/subagent lookup, CLI watch/cost
@@ -183,9 +190,9 @@ checkout.
 
 ## Decision
 
-- Ready for PR: **pending final re-review** — the two P2 findings and two P3
-  findings from the full independent review have been addressed in the
-  review-fix candidate, but the same reviewer must confirm the fixes.
+- Ready for PR: **yes, with the deferred E2E boundary recorded** — the final
+  independent reviewer returned `PASS` with no confirmed P0/P1/P2/P3 findings.
+  Full frontend/native behavior E2E remains a separate user-owned gate.
 - Ready for release: **no** — local DMG packaging, updater signing,
   notarization, cross-architecture GHA evidence, and native app E2E are not
   all green; no release authorization was given.

--- a/docs/notes/cursor-agent-v0.10.0-readiness-2026-08-24.md
+++ b/docs/notes/cursor-agent-v0.10.0-readiness-2026-08-24.md
@@ -42,7 +42,7 @@ push, tag, publish, or GitHub release was performed.
 
 | Gate | Result | Evidence / boundary |
 | --- | --- | --- |
-| Focused Cursor tests | PASS | 26 passed, 0 failed; synthetic fixtures cover append reuse, bounded large-append validation, prefix/truncate-rewrite fallback, partial lines, lifecycle, delete/rename, same-length rewrite with preserved mtime, large transcripts, torn concurrent writes, and suffix-hash read failure |
+| Focused Cursor tests | PASS | 27 passed, 0 failed; synthetic fixtures cover append reuse, bounded large-append validation, checkpoint scheduling and middle-rewrite detection, prefix/truncate-rewrite fallback, partial lines, lifecycle, delete/rename, same-length rewrite with preserved mtime, large transcripts, torn concurrent writes, and suffix-hash read failure |
 | Focused Codex source tests | PASS | 39 passed, 0 failed; includes incremental hits, partial/truncation, same-length and middle rewrites, lifecycle, hierarchy, and conversation behavior |
 | Focused Codex archive tests | PASS | 12 passed, 0 failed; synthetic fixtures cover partial lines, append/truncation, preserved-mtime same-length rewrite, anchor-external middle rewrite, merge/search, and token accounting |
 | Provider-scoped CLI references | PASS | `cli::` focused suite: 50 passed, 0 failed; `view`, `tasks`, and `cost --session` accept `claudeCode:<id>`, `codex:<id>`, and `cursor:<id>` and disambiguate colliding raw IDs |
@@ -50,19 +50,19 @@ push, tag, publish, or GitHub release was performed.
 | Shared cache-stamp contract | PASS | 3 passed, 0 failed; shared `FileVersion` reads length/change-time/identity, weak metadata rejects unchanged fast path, and strong identity/subsecond stamp is accepted |
 | Provider-aware rename protocol | PASS | 7 passed, 0 failed; explicit Codex/Cursor rename is rejected, providerless legacy requests retain their v0.9 shape, and a shared-owner collision guard rejects cross-provider IDs before any write |
 | Synthetic Tauri/WebSocket collision regression | PASS | 3 passed, 0 failed; synthetic Cursor and Codex owners reject providerless rename before the Tauri writer callback or WebSocket title-write dispatch |
-| Full Rust library tests | PASS | 359 passed, 1 ignored, 0 failed |
-| Rust integration tests | PASS | library 359 passed/1 ignored; main 0; background test 1 ignored; parser integration 3 passed |
+| Full Rust library tests | PASS | 361 passed, 1 ignored, 0 failed |
+| Rust integration tests | PASS | library 361 passed/1 ignored; main 0; background test 1 ignored; parser integration 3 passed |
 | Rust format | PASS | `cargo fmt --all --manifest-path src-tauri/Cargo.toml -- --check` |
 | Frontend type/check | PASS | `npm run check`: 0 errors, 0 warnings |
 | Frontend production build | PASS | `npm run build` completed with SvelteKit/Vite output |
 | Version metadata sync | PASS | `package.json`, `src-tauri/Cargo.toml`, and `src-tauri/tauri.conf.json` all report `0.10.0` |
 | Rust release compile | PASS | `cargo build --release --manifest-path src-tauri/Cargo.toml` |
 | Release workflow YAML parse | PASS | Ruby YAML parser loaded `.github/workflows/release.yml` successfully |
-| Tauri app bundle | UNVERIFIED in this final pass | Rust release compile passed; no new native bundle run was performed |
+| Tauri app bundle | PENDING GHA evidence | Workflow now includes signed/notarized bundle validation and a native launch/server-health smoke; no GHA run was completed in this checkout |
 | Tauri updater artifact | PENDING GHA evidence | Local signing requires `TAURI_SIGNING_PRIVATE_KEY`; workflow now fails closed when the secret/signature artifact is missing |
 | DMG bundle | PENDING GHA evidence | Local generated `bundle_dmg.sh` previously failed; repository release path uses GHA `tauri build` |
 | Apple notarization | PENDING GHA evidence | Workflow accepts Apple credentials; no local notarization was run |
-| x86_64 CI/native E2E | PENDING | Workflow matrix contains x86_64; no completed GHA/native behavior evidence in this checkout |
+| x86_64 CI/native E2E | PENDING | Workflow matrix contains x86_64 and native launch smoke; no completed GHA/native behavior E2E evidence in this checkout |
 | Diff whitespace | PASS | Review-fix commit range checked with `git diff --check HEAD^ HEAD` |
 
 The provider-owner synthetic suite also passes 6/6: global and cloned Codex/Cursor owners
@@ -113,8 +113,10 @@ re-review** and did not run tests or builds. Findings and current status:
   4 MiB use exact prefix verification on every append. Larger transcripts use
   fixed-size head/tail guards between geometrically scheduled full-prefix
   checkpoints, so normal append validation has a bounded read budget and the
-  cumulative full-revalidation work is linear in transcript growth. A synthetic
-  byte-budget regression covers the high-frequency large-file path.
+  cumulative full-revalidation work is linear in transcript growth. The next
+  checkpoint is anchored to the last full verification and is not moved by
+  guard-only appends. Synthetic regressions cover the high-frequency large-file
+  path and middle-rewrite detection at a checkpoint.
 - P3 Cursor suffix-hash errors being swallowed: fixed. Hash/read failure now
   returns a parse error instead of persisting an incomplete hash, with a
   synthetic regression test.
@@ -168,8 +170,9 @@ trusting a stale serialized key.
 build matrices until diff hygiene, Rust format/tests, and frontend check/build
 pass. The macOS job fails closed when updater signing or Apple signing and
 notarization credentials are absent, then verifies the built app with
-`codesign`, `stapler`, and `spctl`, validates the DMG with `hdiutil`, and checks
-that the signed updater archive and signature exist. The workflow preserves the
+`codesign`, `stapler`, and `spctl`, launches the native binary and checks its
+local server health/version endpoint, validates the DMG with `hdiutil`, and
+checks that the signed updater archive and signature exist. The workflow preserves the
 exact Tauri-generated `.app.tar.gz` bytes that were signed, renames those
 artifacts (without re-tarring the `.app`), renames DMGs to
 `c9watch_<tag>_<arch>.dmg`, and generates `latest.json` URLs matching the

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "c9watch",
-  "version": "0.7.0",
+  "version": "0.9.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "c9watch",
-      "version": "0.7.0",
+      "version": "0.9.0",
       "license": "MIT",
       "dependencies": {
         "@choochmeque/tauri-plugin-sharekit-api": "^0.3.1",
@@ -16,7 +16,6 @@
         "@tauri-apps/plugin-process": "^2.3.1",
         "@tauri-apps/plugin-updater": "^2.10.0",
         "dompurify": "^3.3.1",
-        "geist": "^1.7.0",
         "marked": "^17.0.1",
         "qrcode": "^1.5.4"
       },
@@ -40,17 +39,6 @@
       "integrity": "sha512-Cdd1wPW9Arang3sapz1LXDdklY06wnaf+zqsT+iS1c64cyozjhKYwAzLdirJY0HtlPlaZ7G5PsCfqgLoXkpqlg==",
       "dependencies": {
         "@tauri-apps/api": "^2.6.0"
-      }
-    },
-    "node_modules/@emnapi/runtime": {
-      "version": "1.8.1",
-      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.8.1.tgz",
-      "integrity": "sha512-mehfKSMWjjNol8659Z8KxEMrdSJDDot5SXMq00dM8BN4o+CLNXQ0xH2V7EchNHV4RmbZLmmPdEaXZc5H2FXmDg==",
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "tslib": "^2.4.0"
       }
     },
     "node_modules/@esbuild/aix-ppc64": {
@@ -495,497 +483,6 @@
         "node": ">=18"
       }
     },
-    "node_modules/@img/colour": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@img/colour/-/colour-1.0.0.tgz",
-      "integrity": "sha512-A5P/LfWGFSl6nsckYtjw9da+19jB8hkJ6ACTGcDfEJ0aE+l2n2El7dsVM7UVHZQ9s2lmYMWlrS21YLy2IR1LUw==",
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@img/sharp-darwin-arm64": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-darwin-arm64/-/sharp-darwin-arm64-0.34.5.tgz",
-      "integrity": "sha512-imtQ3WMJXbMY4fxb/Ndp6HBTNVtWCUI0WdobyheGf5+ad6xX8VIDO8u2xE4qc/fr08CKG/7dDseFtn6M6g/r3w==",
-      "cpu": [
-        "arm64"
-      ],
-      "license": "Apache-2.0",
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "peer": true,
-      "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/libvips"
-      },
-      "optionalDependencies": {
-        "@img/sharp-libvips-darwin-arm64": "1.2.4"
-      }
-    },
-    "node_modules/@img/sharp-darwin-x64": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-darwin-x64/-/sharp-darwin-x64-0.34.5.tgz",
-      "integrity": "sha512-YNEFAF/4KQ/PeW0N+r+aVVsoIY0/qxxikF2SWdp+NRkmMB7y9LBZAVqQ4yhGCm/H3H270OSykqmQMKLBhBJDEw==",
-      "cpu": [
-        "x64"
-      ],
-      "license": "Apache-2.0",
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "peer": true,
-      "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/libvips"
-      },
-      "optionalDependencies": {
-        "@img/sharp-libvips-darwin-x64": "1.2.4"
-      }
-    },
-    "node_modules/@img/sharp-libvips-darwin-arm64": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-arm64/-/sharp-libvips-darwin-arm64-1.2.4.tgz",
-      "integrity": "sha512-zqjjo7RatFfFoP0MkQ51jfuFZBnVE2pRiaydKJ1G/rHZvnsrHAOcQALIi9sA5co5xenQdTugCvtb1cuf78Vf4g==",
-      "cpu": [
-        "arm64"
-      ],
-      "license": "LGPL-3.0-or-later",
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "peer": true,
-      "funding": {
-        "url": "https://opencollective.com/libvips"
-      }
-    },
-    "node_modules/@img/sharp-libvips-darwin-x64": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-x64/-/sharp-libvips-darwin-x64-1.2.4.tgz",
-      "integrity": "sha512-1IOd5xfVhlGwX+zXv2N93k0yMONvUlANylbJw1eTah8K/Jtpi15KC+WSiaX/nBmbm2HxRM1gZ0nSdjSsrZbGKg==",
-      "cpu": [
-        "x64"
-      ],
-      "license": "LGPL-3.0-or-later",
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "peer": true,
-      "funding": {
-        "url": "https://opencollective.com/libvips"
-      }
-    },
-    "node_modules/@img/sharp-libvips-linux-arm": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm/-/sharp-libvips-linux-arm-1.2.4.tgz",
-      "integrity": "sha512-bFI7xcKFELdiNCVov8e44Ia4u2byA+l3XtsAj+Q8tfCwO6BQ8iDojYdvoPMqsKDkuoOo+X6HZA0s0q11ANMQ8A==",
-      "cpu": [
-        "arm"
-      ],
-      "license": "LGPL-3.0-or-later",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "peer": true,
-      "funding": {
-        "url": "https://opencollective.com/libvips"
-      }
-    },
-    "node_modules/@img/sharp-libvips-linux-arm64": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm64/-/sharp-libvips-linux-arm64-1.2.4.tgz",
-      "integrity": "sha512-excjX8DfsIcJ10x1Kzr4RcWe1edC9PquDRRPx3YVCvQv+U5p7Yin2s32ftzikXojb1PIFc/9Mt28/y+iRklkrw==",
-      "cpu": [
-        "arm64"
-      ],
-      "license": "LGPL-3.0-or-later",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "peer": true,
-      "funding": {
-        "url": "https://opencollective.com/libvips"
-      }
-    },
-    "node_modules/@img/sharp-libvips-linux-ppc64": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-ppc64/-/sharp-libvips-linux-ppc64-1.2.4.tgz",
-      "integrity": "sha512-FMuvGijLDYG6lW+b/UvyilUWu5Ayu+3r2d1S8notiGCIyYU/76eig1UfMmkZ7vwgOrzKzlQbFSuQfgm7GYUPpA==",
-      "cpu": [
-        "ppc64"
-      ],
-      "license": "LGPL-3.0-or-later",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "peer": true,
-      "funding": {
-        "url": "https://opencollective.com/libvips"
-      }
-    },
-    "node_modules/@img/sharp-libvips-linux-riscv64": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-riscv64/-/sharp-libvips-linux-riscv64-1.2.4.tgz",
-      "integrity": "sha512-oVDbcR4zUC0ce82teubSm+x6ETixtKZBh/qbREIOcI3cULzDyb18Sr/Wcyx7NRQeQzOiHTNbZFF1UwPS2scyGA==",
-      "cpu": [
-        "riscv64"
-      ],
-      "license": "LGPL-3.0-or-later",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "peer": true,
-      "funding": {
-        "url": "https://opencollective.com/libvips"
-      }
-    },
-    "node_modules/@img/sharp-libvips-linux-s390x": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-s390x/-/sharp-libvips-linux-s390x-1.2.4.tgz",
-      "integrity": "sha512-qmp9VrzgPgMoGZyPvrQHqk02uyjA0/QrTO26Tqk6l4ZV0MPWIW6LTkqOIov+J1yEu7MbFQaDpwdwJKhbJvuRxQ==",
-      "cpu": [
-        "s390x"
-      ],
-      "license": "LGPL-3.0-or-later",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "peer": true,
-      "funding": {
-        "url": "https://opencollective.com/libvips"
-      }
-    },
-    "node_modules/@img/sharp-libvips-linux-x64": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-x64/-/sharp-libvips-linux-x64-1.2.4.tgz",
-      "integrity": "sha512-tJxiiLsmHc9Ax1bz3oaOYBURTXGIRDODBqhveVHonrHJ9/+k89qbLl0bcJns+e4t4rvaNBxaEZsFtSfAdquPrw==",
-      "cpu": [
-        "x64"
-      ],
-      "license": "LGPL-3.0-or-later",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "peer": true,
-      "funding": {
-        "url": "https://opencollective.com/libvips"
-      }
-    },
-    "node_modules/@img/sharp-libvips-linuxmusl-arm64": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-arm64/-/sharp-libvips-linuxmusl-arm64-1.2.4.tgz",
-      "integrity": "sha512-FVQHuwx1IIuNow9QAbYUzJ+En8KcVm9Lk5+uGUQJHaZmMECZmOlix9HnH7n1TRkXMS0pGxIJokIVB9SuqZGGXw==",
-      "cpu": [
-        "arm64"
-      ],
-      "license": "LGPL-3.0-or-later",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "peer": true,
-      "funding": {
-        "url": "https://opencollective.com/libvips"
-      }
-    },
-    "node_modules/@img/sharp-libvips-linuxmusl-x64": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-x64/-/sharp-libvips-linuxmusl-x64-1.2.4.tgz",
-      "integrity": "sha512-+LpyBk7L44ZIXwz/VYfglaX/okxezESc6UxDSoyo2Ks6Jxc4Y7sGjpgU9s4PMgqgjj1gZCylTieNamqA1MF7Dg==",
-      "cpu": [
-        "x64"
-      ],
-      "license": "LGPL-3.0-or-later",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "peer": true,
-      "funding": {
-        "url": "https://opencollective.com/libvips"
-      }
-    },
-    "node_modules/@img/sharp-linux-arm": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm/-/sharp-linux-arm-0.34.5.tgz",
-      "integrity": "sha512-9dLqsvwtg1uuXBGZKsxem9595+ujv0sJ6Vi8wcTANSFpwV/GONat5eCkzQo/1O6zRIkh0m/8+5BjrRr7jDUSZw==",
-      "cpu": [
-        "arm"
-      ],
-      "license": "Apache-2.0",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "peer": true,
-      "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/libvips"
-      },
-      "optionalDependencies": {
-        "@img/sharp-libvips-linux-arm": "1.2.4"
-      }
-    },
-    "node_modules/@img/sharp-linux-arm64": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm64/-/sharp-linux-arm64-0.34.5.tgz",
-      "integrity": "sha512-bKQzaJRY/bkPOXyKx5EVup7qkaojECG6NLYswgktOZjaXecSAeCWiZwwiFf3/Y+O1HrauiE3FVsGxFg8c24rZg==",
-      "cpu": [
-        "arm64"
-      ],
-      "license": "Apache-2.0",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "peer": true,
-      "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/libvips"
-      },
-      "optionalDependencies": {
-        "@img/sharp-libvips-linux-arm64": "1.2.4"
-      }
-    },
-    "node_modules/@img/sharp-linux-ppc64": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-linux-ppc64/-/sharp-linux-ppc64-0.34.5.tgz",
-      "integrity": "sha512-7zznwNaqW6YtsfrGGDA6BRkISKAAE1Jo0QdpNYXNMHu2+0dTrPflTLNkpc8l7MUP5M16ZJcUvysVWWrMefZquA==",
-      "cpu": [
-        "ppc64"
-      ],
-      "license": "Apache-2.0",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "peer": true,
-      "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/libvips"
-      },
-      "optionalDependencies": {
-        "@img/sharp-libvips-linux-ppc64": "1.2.4"
-      }
-    },
-    "node_modules/@img/sharp-linux-riscv64": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-linux-riscv64/-/sharp-linux-riscv64-0.34.5.tgz",
-      "integrity": "sha512-51gJuLPTKa7piYPaVs8GmByo7/U7/7TZOq+cnXJIHZKavIRHAP77e3N2HEl3dgiqdD/w0yUfiJnII77PuDDFdw==",
-      "cpu": [
-        "riscv64"
-      ],
-      "license": "Apache-2.0",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "peer": true,
-      "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/libvips"
-      },
-      "optionalDependencies": {
-        "@img/sharp-libvips-linux-riscv64": "1.2.4"
-      }
-    },
-    "node_modules/@img/sharp-linux-s390x": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-linux-s390x/-/sharp-linux-s390x-0.34.5.tgz",
-      "integrity": "sha512-nQtCk0PdKfho3eC5MrbQoigJ2gd1CgddUMkabUj+rBevs8tZ2cULOx46E7oyX+04WGfABgIwmMC0VqieTiR4jg==",
-      "cpu": [
-        "s390x"
-      ],
-      "license": "Apache-2.0",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "peer": true,
-      "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/libvips"
-      },
-      "optionalDependencies": {
-        "@img/sharp-libvips-linux-s390x": "1.2.4"
-      }
-    },
-    "node_modules/@img/sharp-linux-x64": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-linux-x64/-/sharp-linux-x64-0.34.5.tgz",
-      "integrity": "sha512-MEzd8HPKxVxVenwAa+JRPwEC7QFjoPWuS5NZnBt6B3pu7EG2Ge0id1oLHZpPJdn3OQK+BQDiw9zStiHBTJQQQQ==",
-      "cpu": [
-        "x64"
-      ],
-      "license": "Apache-2.0",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "peer": true,
-      "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/libvips"
-      },
-      "optionalDependencies": {
-        "@img/sharp-libvips-linux-x64": "1.2.4"
-      }
-    },
-    "node_modules/@img/sharp-linuxmusl-arm64": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-arm64/-/sharp-linuxmusl-arm64-0.34.5.tgz",
-      "integrity": "sha512-fprJR6GtRsMt6Kyfq44IsChVZeGN97gTD331weR1ex1c1rypDEABN6Tm2xa1wE6lYb5DdEnk03NZPqA7Id21yg==",
-      "cpu": [
-        "arm64"
-      ],
-      "license": "Apache-2.0",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "peer": true,
-      "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/libvips"
-      },
-      "optionalDependencies": {
-        "@img/sharp-libvips-linuxmusl-arm64": "1.2.4"
-      }
-    },
-    "node_modules/@img/sharp-linuxmusl-x64": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-x64/-/sharp-linuxmusl-x64-0.34.5.tgz",
-      "integrity": "sha512-Jg8wNT1MUzIvhBFxViqrEhWDGzqymo3sV7z7ZsaWbZNDLXRJZoRGrjulp60YYtV4wfY8VIKcWidjojlLcWrd8Q==",
-      "cpu": [
-        "x64"
-      ],
-      "license": "Apache-2.0",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "peer": true,
-      "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/libvips"
-      },
-      "optionalDependencies": {
-        "@img/sharp-libvips-linuxmusl-x64": "1.2.4"
-      }
-    },
-    "node_modules/@img/sharp-wasm32": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-wasm32/-/sharp-wasm32-0.34.5.tgz",
-      "integrity": "sha512-OdWTEiVkY2PHwqkbBI8frFxQQFekHaSSkUIJkwzclWZe64O1X4UlUjqqqLaPbUpMOQk6FBu/HtlGXNblIs0huw==",
-      "cpu": [
-        "wasm32"
-      ],
-      "license": "Apache-2.0 AND LGPL-3.0-or-later AND MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "@emnapi/runtime": "^1.7.0"
-      },
-      "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/libvips"
-      }
-    },
-    "node_modules/@img/sharp-win32-arm64": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-win32-arm64/-/sharp-win32-arm64-0.34.5.tgz",
-      "integrity": "sha512-WQ3AgWCWYSb2yt+IG8mnC6Jdk9Whs7O0gxphblsLvdhSpSTtmu69ZG1Gkb6NuvxsNACwiPV6cNSZNzt0KPsw7g==",
-      "cpu": [
-        "arm64"
-      ],
-      "license": "Apache-2.0 AND LGPL-3.0-or-later",
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "peer": true,
-      "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/libvips"
-      }
-    },
-    "node_modules/@img/sharp-win32-ia32": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-win32-ia32/-/sharp-win32-ia32-0.34.5.tgz",
-      "integrity": "sha512-FV9m/7NmeCmSHDD5j4+4pNI8Cp3aW+JvLoXcTUo0IqyjSfAZJ8dIUmijx1qaJsIiU+Hosw6xM5KijAWRJCSgNg==",
-      "cpu": [
-        "ia32"
-      ],
-      "license": "Apache-2.0 AND LGPL-3.0-or-later",
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "peer": true,
-      "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/libvips"
-      }
-    },
-    "node_modules/@img/sharp-win32-x64": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-win32-x64/-/sharp-win32-x64-0.34.5.tgz",
-      "integrity": "sha512-+29YMsqY2/9eFEiW93eqWnuLcWcufowXewwSNIT6UwZdUUCrM3oFjMWH/Z6/TMmb4hlFenmfAVbpWeup2jryCw==",
-      "cpu": [
-        "x64"
-      ],
-      "license": "Apache-2.0 AND LGPL-3.0-or-later",
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "peer": true,
-      "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/libvips"
-      }
-    },
     "node_modules/@jridgewell/gen-mapping": {
       "version": "0.3.13",
       "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz",
@@ -1036,147 +533,20 @@
         "@jridgewell/sourcemap-codec": "^1.4.14"
       }
     },
-    "node_modules/@next/env": {
-      "version": "16.1.6",
-      "resolved": "https://registry.npmjs.org/@next/env/-/env-16.1.6.tgz",
-      "integrity": "sha512-N1ySLuZjnAtN3kFnwhAwPvZah8RJxKasD7x1f8shFqhncnWZn4JMfg37diLNuoHsLAlrDfM3g4mawVdtAG8XLQ==",
-      "license": "MIT",
-      "peer": true
-    },
-    "node_modules/@next/swc-darwin-arm64": {
-      "version": "16.1.6",
-      "resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-16.1.6.tgz",
-      "integrity": "sha512-wTzYulosJr/6nFnqGW7FrG3jfUUlEf8UjGA0/pyypJl42ExdVgC6xJgcXQ+V8QFn6niSG2Pb8+MIG1mZr2vczw==",
-      "cpu": [
-        "arm64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "peer": true,
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "node_modules/@next/swc-darwin-x64": {
-      "version": "16.1.6",
-      "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-16.1.6.tgz",
-      "integrity": "sha512-BLFPYPDO+MNJsiDWbeVzqvYd4NyuRrEYVB5k2N3JfWncuHAy2IVwMAOlVQDFjj+krkWzhY2apvmekMkfQR0CUQ==",
+    "node_modules/@napi-rs/lzma-linux-x64-gnu": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/@napi-rs/lzma-linux-x64-gnu/-/lzma-linux-x64-gnu-1.5.1.tgz",
+      "integrity": "sha512-oTXEIha4SsuXdTA4Iyskj0kpdx2yVXdhd75c2v3xGrHFfVMsbhTPZU/nMPL4sWKo4pBHm3aucLaqGlF696dTyQ==",
       "cpu": [
         "x64"
       ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "peer": true,
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "node_modules/@next/swc-linux-arm64-gnu": {
-      "version": "16.1.6",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-16.1.6.tgz",
-      "integrity": "sha512-OJYkCd5pj/QloBvoEcJ2XiMnlJkRv9idWA/j0ugSuA34gMT6f5b7vOiCQHVRpvStoZUknhl6/UxOXL4OwtdaBw==",
-      "cpu": [
-        "arm64"
-      ],
-      "license": "MIT",
+      "dev": true,
       "optional": true,
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
-        "node": ">= 10"
-      }
-    },
-    "node_modules/@next/swc-linux-arm64-musl": {
-      "version": "16.1.6",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-16.1.6.tgz",
-      "integrity": "sha512-S4J2v+8tT3NIO9u2q+S0G5KdvNDjXfAv06OhfOzNDaBn5rw84DGXWndOEB7d5/x852A20sW1M56vhC/tRVbccQ==",
-      "cpu": [
-        "arm64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "peer": true,
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "node_modules/@next/swc-linux-x64-gnu": {
-      "version": "16.1.6",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-16.1.6.tgz",
-      "integrity": "sha512-2eEBDkFlMMNQnkTyPBhQOAyn2qMxyG2eE7GPH2WIDGEpEILcBPI/jdSv4t6xupSP+ot/jkfrCShLAa7+ZUPcJQ==",
-      "cpu": [
-        "x64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "peer": true,
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "node_modules/@next/swc-linux-x64-musl": {
-      "version": "16.1.6",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-16.1.6.tgz",
-      "integrity": "sha512-oicJwRlyOoZXVlxmIMaTq7f8pN9QNbdes0q2FXfRsPhfCi8n8JmOZJm5oo1pwDaFbnnD421rVU409M3evFbIqg==",
-      "cpu": [
-        "x64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "peer": true,
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "node_modules/@next/swc-win32-arm64-msvc": {
-      "version": "16.1.6",
-      "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-16.1.6.tgz",
-      "integrity": "sha512-gQmm8izDTPgs+DCWH22kcDmuUp7NyiJgEl18bcr8irXA5N2m2O+JQIr6f3ct42GOs9c0h8QF3L5SzIxcYAAXXw==",
-      "cpu": [
-        "arm64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "peer": true,
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "node_modules/@next/swc-win32-x64-msvc": {
-      "version": "16.1.6",
-      "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-16.1.6.tgz",
-      "integrity": "sha512-NRfO39AIrzBnixKbjuo2YiYhB6o9d8v/ymU9m/Xk8cyVk+k7XylniXkHwjs4s70wedVffc6bQNbufk5v0xEm0A==",
-      "cpu": [
-        "x64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "peer": true,
-      "engines": {
-        "node": ">= 10"
+        "node": "^22.20 || ^24.12 || >=25"
       }
     },
     "node_modules/@polka/url": {
@@ -1187,350 +557,325 @@
       "license": "MIT"
     },
     "node_modules/@rollup/rollup-android-arm-eabi": {
-      "version": "4.57.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.57.1.tgz",
-      "integrity": "sha512-A6ehUVSiSaaliTxai040ZpZ2zTevHYbvu/lDoeAteHI8QnaosIzm4qwtezfRg1jOYaUmnzLX1AOD6Z+UJjtifg==",
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.62.4.tgz",
+      "integrity": "sha512-RrPokAb7dmbxFoeO3TloqHyOjgye8RkBhSqmp4aJMIex4c9r46ZstPnleDQOq1t46VOVjwIuwNogIqbodV1Vvg==",
       "cpu": [
         "arm"
       ],
       "dev": true,
-      "license": "MIT",
       "optional": true,
       "os": [
         "android"
       ]
     },
     "node_modules/@rollup/rollup-android-arm64": {
-      "version": "4.57.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.57.1.tgz",
-      "integrity": "sha512-dQaAddCY9YgkFHZcFNS/606Exo8vcLHwArFZ7vxXq4rigo2bb494/xKMMwRRQW6ug7Js6yXmBZhSBRuBvCCQ3w==",
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.62.4.tgz",
+      "integrity": "sha512-JKuJc+pnpks2pjy7L/N3v/cAkZxYlnmuZoD840ldbMI5KDbC4iO9NKwPKYdjYFCMAIIlBzYSFHxIJVYzRo2/8A==",
       "cpu": [
         "arm64"
       ],
       "dev": true,
-      "license": "MIT",
       "optional": true,
       "os": [
         "android"
       ]
     },
     "node_modules/@rollup/rollup-darwin-arm64": {
-      "version": "4.57.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.57.1.tgz",
-      "integrity": "sha512-crNPrwJOrRxagUYeMn/DZwqN88SDmwaJ8Cvi/TN1HnWBU7GwknckyosC2gd0IqYRsHDEnXf328o9/HC6OkPgOg==",
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.62.4.tgz",
+      "integrity": "sha512-krw5uS2STmvJ02x0uTXHbqQNuz+9eZ1iw+qXk9dmW2gvV4jV7O2hEoOnuhFrpOPiel1mBFtqbxYZZtC46hXLOw==",
       "cpu": [
         "arm64"
       ],
       "dev": true,
-      "license": "MIT",
       "optional": true,
       "os": [
         "darwin"
       ]
     },
     "node_modules/@rollup/rollup-darwin-x64": {
-      "version": "4.57.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.57.1.tgz",
-      "integrity": "sha512-Ji8g8ChVbKrhFtig5QBV7iMaJrGtpHelkB3lsaKzadFBe58gmjfGXAOfI5FV0lYMH8wiqsxKQ1C9B0YTRXVy4w==",
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.62.4.tgz",
+      "integrity": "sha512-wsTxtgApb4PrOsNJIm0FZ1h3WvCC+k9uxLJ4ad75hgoS4NiRes2SoJFlDAyMwiUY8IssDqGcHbXuN0sx1tfF1A==",
       "cpu": [
         "x64"
       ],
       "dev": true,
-      "license": "MIT",
       "optional": true,
       "os": [
         "darwin"
       ]
     },
     "node_modules/@rollup/rollup-freebsd-arm64": {
-      "version": "4.57.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.57.1.tgz",
-      "integrity": "sha512-R+/WwhsjmwodAcz65guCGFRkMb4gKWTcIeLy60JJQbXrJ97BOXHxnkPFrP+YwFlaS0m+uWJTstrUA9o+UchFug==",
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.62.4.tgz",
+      "integrity": "sha512-GUOnQlyZe3yAXhWOtOMsn5Qkrv5E5mZXa0thbARWi5Ei2szlVXJFQhddZ4HbAzh8q92w5twp+CQvs/eFanz9YQ==",
       "cpu": [
         "arm64"
       ],
       "dev": true,
-      "license": "MIT",
       "optional": true,
       "os": [
         "freebsd"
       ]
     },
     "node_modules/@rollup/rollup-freebsd-x64": {
-      "version": "4.57.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.57.1.tgz",
-      "integrity": "sha512-IEQTCHeiTOnAUC3IDQdzRAGj3jOAYNr9kBguI7MQAAZK3caezRrg0GxAb6Hchg4lxdZEI5Oq3iov/w/hnFWY9Q==",
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.62.4.tgz",
+      "integrity": "sha512-/Y7f3QuxjzPKsjA/rfEDa3+0vXqyjmJ50Ln8dPpCmWkKTrUoWHG1cWhTqaAMLob2m2nESWuC7yGrREz019Ztqg==",
       "cpu": [
         "x64"
       ],
       "dev": true,
-      "license": "MIT",
       "optional": true,
       "os": [
         "freebsd"
       ]
     },
     "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
-      "version": "4.57.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.57.1.tgz",
-      "integrity": "sha512-F8sWbhZ7tyuEfsmOxwc2giKDQzN3+kuBLPwwZGyVkLlKGdV1nvnNwYD0fKQ8+XS6hp9nY7B+ZeK01EBUE7aHaw==",
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.62.4.tgz",
+      "integrity": "sha512-81wiiX3v7aqy+T+bT61TJ78yJjRquqFFTTbAPt08imfQQzkPIW8t6aJbkTagtCCrXMNc9D66+geqlK7ydLPNqA==",
       "cpu": [
         "arm"
       ],
       "dev": true,
-      "license": "MIT",
       "optional": true,
       "os": [
         "linux"
       ]
     },
     "node_modules/@rollup/rollup-linux-arm-musleabihf": {
-      "version": "4.57.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.57.1.tgz",
-      "integrity": "sha512-rGfNUfn0GIeXtBP1wL5MnzSj98+PZe/AXaGBCRmT0ts80lU5CATYGxXukeTX39XBKsxzFpEeK+Mrp9faXOlmrw==",
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.62.4.tgz",
+      "integrity": "sha512-9kmDIvNZqdoHOBZgNtpTBeLWYO/LVipM3H/j62P8848/l/VPEQL6N3uxU9pvP1oZAsXyC2MEnFP3ovRjo7WYNQ==",
       "cpu": [
         "arm"
       ],
       "dev": true,
-      "license": "MIT",
       "optional": true,
       "os": [
         "linux"
       ]
     },
     "node_modules/@rollup/rollup-linux-arm64-gnu": {
-      "version": "4.57.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.57.1.tgz",
-      "integrity": "sha512-MMtej3YHWeg/0klK2Qodf3yrNzz6CGjo2UntLvk2RSPlhzgLvYEB3frRvbEF2wRKh1Z2fDIg9KRPe1fawv7C+g==",
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.62.4.tgz",
+      "integrity": "sha512-CcnXHWnXg69g+DX5VWL3FHts3qMRN2uVEHX+BZvGLdd07/gXkn3ePjYtO1LDJvxkGKVHMclKBRa1QUTH+6toYQ==",
       "cpu": [
         "arm64"
       ],
       "dev": true,
-      "license": "MIT",
       "optional": true,
       "os": [
         "linux"
       ]
     },
     "node_modules/@rollup/rollup-linux-arm64-musl": {
-      "version": "4.57.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.57.1.tgz",
-      "integrity": "sha512-1a/qhaaOXhqXGpMFMET9VqwZakkljWHLmZOX48R0I/YLbhdxr1m4gtG1Hq7++VhVUmf+L3sTAf9op4JlhQ5u1Q==",
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.62.4.tgz",
+      "integrity": "sha512-iFOibiHnTRuhrWLlRsOQFdZJJIa7S8OwkneJr4ocALP16u5yk6lWLINFwhHaEqBFMsKDUZofLkGos7+CPzGB3g==",
       "cpu": [
         "arm64"
       ],
       "dev": true,
-      "license": "MIT",
       "optional": true,
       "os": [
         "linux"
       ]
     },
     "node_modules/@rollup/rollup-linux-loong64-gnu": {
-      "version": "4.57.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.57.1.tgz",
-      "integrity": "sha512-QWO6RQTZ/cqYtJMtxhkRkidoNGXc7ERPbZN7dVW5SdURuLeVU7lwKMpo18XdcmpWYd0qsP1bwKPf7DNSUinhvA==",
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.62.4.tgz",
+      "integrity": "sha512-XnWYMI7euHlb5a871xPja+Gm7DRCFU+FGRrtS2sMq9N8FvqtpagUy6gD4YOemC5MRk9xbh8+jYMEJbigFQwsgA==",
       "cpu": [
         "loong64"
       ],
       "dev": true,
-      "license": "MIT",
       "optional": true,
       "os": [
         "linux"
       ]
     },
     "node_modules/@rollup/rollup-linux-loong64-musl": {
-      "version": "4.57.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.57.1.tgz",
-      "integrity": "sha512-xpObYIf+8gprgWaPP32xiN5RVTi/s5FCR+XMXSKmhfoJjrpRAjCuuqQXyxUa/eJTdAE6eJ+KDKaoEqjZQxh3Gw==",
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.62.4.tgz",
+      "integrity": "sha512-qGDAlO0U8xedCcsdRm9oaoQY8DAx/QT7uIxJWhCdx0ceIWX783UC9QSYkdpzAe29wNiVfp24+bZdQmn49o45SQ==",
       "cpu": [
         "loong64"
       ],
       "dev": true,
-      "license": "MIT",
       "optional": true,
       "os": [
         "linux"
       ]
     },
     "node_modules/@rollup/rollup-linux-ppc64-gnu": {
-      "version": "4.57.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.57.1.tgz",
-      "integrity": "sha512-4BrCgrpZo4hvzMDKRqEaW1zeecScDCR+2nZ86ATLhAoJ5FQ+lbHVD3ttKe74/c7tNT9c6F2viwB3ufwp01Oh2w==",
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.62.4.tgz",
+      "integrity": "sha512-ru4H6ezD7ysA5EiEK6qkkaEb4modH8CTej6kUy/gQi20u3kB3G7Zn8snXXkeJSCOFKG/rbPPtM/+9Wgas1961w==",
       "cpu": [
         "ppc64"
       ],
       "dev": true,
-      "license": "MIT",
       "optional": true,
       "os": [
         "linux"
       ]
     },
     "node_modules/@rollup/rollup-linux-ppc64-musl": {
-      "version": "4.57.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.57.1.tgz",
-      "integrity": "sha512-NOlUuzesGauESAyEYFSe3QTUguL+lvrN1HtwEEsU2rOwdUDeTMJdO5dUYl/2hKf9jWydJrO9OL/XSSf65R5+Xw==",
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.62.4.tgz",
+      "integrity": "sha512-2W4MO5WQVJnbJaZdvDb9rhBDuFU1nKIepPFpJUBsTh2k1YY2g+ODViaWuyOAjQ5cOP7NvrvLzt3wvHOoiAvc7w==",
       "cpu": [
         "ppc64"
       ],
       "dev": true,
-      "license": "MIT",
       "optional": true,
       "os": [
         "linux"
       ]
     },
     "node_modules/@rollup/rollup-linux-riscv64-gnu": {
-      "version": "4.57.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.57.1.tgz",
-      "integrity": "sha512-ptA88htVp0AwUUqhVghwDIKlvJMD/fmL/wrQj99PRHFRAG6Z5nbWoWG4o81Nt9FT+IuqUQi+L31ZKAFeJ5Is+A==",
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.62.4.tgz",
+      "integrity": "sha512-+fxjfuoAmVMCYV5QyjoIpu0cp5DOiOTeqYFk1AVaxGr+/ravWLX89XfQmptsoWcaVy/TGf2hexzbUOrCQIL1CQ==",
       "cpu": [
         "riscv64"
       ],
       "dev": true,
-      "license": "MIT",
       "optional": true,
       "os": [
         "linux"
       ]
     },
     "node_modules/@rollup/rollup-linux-riscv64-musl": {
-      "version": "4.57.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.57.1.tgz",
-      "integrity": "sha512-S51t7aMMTNdmAMPpBg7OOsTdn4tySRQvklmL3RpDRyknk87+Sp3xaumlatU+ppQ+5raY7sSTcC2beGgvhENfuw==",
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.62.4.tgz",
+      "integrity": "sha512-jTn8JfHGL4djjFxPuM06LmNUJDsst2jeVlsd9OmIH6zc5sC9K6rIuO4YajXatLUpBmBKl6b35ro1QZocLi+tcA==",
       "cpu": [
         "riscv64"
       ],
       "dev": true,
-      "license": "MIT",
       "optional": true,
       "os": [
         "linux"
       ]
     },
     "node_modules/@rollup/rollup-linux-s390x-gnu": {
-      "version": "4.57.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.57.1.tgz",
-      "integrity": "sha512-Bl00OFnVFkL82FHbEqy3k5CUCKH6OEJL54KCyx2oqsmZnFTR8IoNqBF+mjQVcRCT5sB6yOvK8A37LNm/kPJiZg==",
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.62.4.tgz",
+      "integrity": "sha512-oCJCJL4pXsoDcP2QZ+JVlPTIRc6266zsIaeJJsWImmF7HO0W8nb6HuSgZlMWxJwaPf8ehbSw8yo0EUw925hKsA==",
       "cpu": [
         "s390x"
       ],
       "dev": true,
-      "license": "MIT",
       "optional": true,
       "os": [
         "linux"
       ]
     },
     "node_modules/@rollup/rollup-linux-x64-gnu": {
-      "version": "4.57.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.57.1.tgz",
-      "integrity": "sha512-ABca4ceT4N+Tv/GtotnWAeXZUZuM/9AQyCyKYyKnpk4yoA7QIAuBt6Hkgpw8kActYlew2mvckXkvx0FfoInnLg==",
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.62.4.tgz",
+      "integrity": "sha512-W69hukhZ3KKNRCaMIEzKvcFye42hh0FE1+YoYaf5+Ikacuftoco6yO/xouz0hc5d5W/s3yBro5jRiuEE/Q5vUw==",
       "cpu": [
         "x64"
       ],
       "dev": true,
-      "license": "MIT",
       "optional": true,
       "os": [
         "linux"
       ]
     },
     "node_modules/@rollup/rollup-linux-x64-musl": {
-      "version": "4.57.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.57.1.tgz",
-      "integrity": "sha512-HFps0JeGtuOR2convgRRkHCekD7j+gdAuXM+/i6kGzQtFhlCtQkpwtNzkNj6QhCDp7DRJ7+qC/1Vg2jt5iSOFw==",
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.62.4.tgz",
+      "integrity": "sha512-qiXbGG2jkjXhzXpsFZSR2Xpb8DN/UaxYsbb/STbuR/6fpaDgRmmaq1B/LmtF2wQFOFOSsK2jdE0RZ3a0zHn4QA==",
       "cpu": [
         "x64"
       ],
       "dev": true,
-      "license": "MIT",
       "optional": true,
       "os": [
         "linux"
       ]
     },
     "node_modules/@rollup/rollup-openbsd-x64": {
-      "version": "4.57.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.57.1.tgz",
-      "integrity": "sha512-H+hXEv9gdVQuDTgnqD+SQffoWoc0Of59AStSzTEj/feWTBAnSfSD3+Dql1ZruJQxmykT/JVY0dE8Ka7z0DH1hw==",
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.62.4.tgz",
+      "integrity": "sha512-nWeM//hxv8mIo6jD7Hu4o48DVmV9pbV6gsKaWU+4NFyqHoPKwrkRiZGLKUhOBk8qNmDmpwFtPKg80Bo/Tn4xiQ==",
       "cpu": [
         "x64"
       ],
       "dev": true,
-      "license": "MIT",
       "optional": true,
       "os": [
         "openbsd"
       ]
     },
     "node_modules/@rollup/rollup-openharmony-arm64": {
-      "version": "4.57.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.57.1.tgz",
-      "integrity": "sha512-4wYoDpNg6o/oPximyc/NG+mYUejZrCU2q+2w6YZqrAs2UcNUChIZXjtafAiiZSUc7On8v5NyNj34Kzj/Ltk6dQ==",
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.62.4.tgz",
+      "integrity": "sha512-s62SQ/vgsRSvMwDkOEfTqfgASF0f26ZNaQuTA6Aok5lrikf89yI2W0gFHvZb2Jpgc6N8JnOKZgCK2iciO3CsxQ==",
       "cpu": [
         "arm64"
       ],
       "dev": true,
-      "license": "MIT",
       "optional": true,
       "os": [
         "openharmony"
       ]
     },
     "node_modules/@rollup/rollup-win32-arm64-msvc": {
-      "version": "4.57.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.57.1.tgz",
-      "integrity": "sha512-O54mtsV/6LW3P8qdTcamQmuC990HDfR71lo44oZMZlXU4tzLrbvTii87Ni9opq60ds0YzuAlEr/GNwuNluZyMQ==",
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.62.4.tgz",
+      "integrity": "sha512-J6wGf8TVGbXJq+HH+ttTvrcfNKPbuZecV6KT1B8I18BC5IURUh5kl4Yl5OEP5eFIUoI5BWxCsyYMhFsDx8kekw==",
       "cpu": [
         "arm64"
       ],
       "dev": true,
-      "license": "MIT",
       "optional": true,
       "os": [
         "win32"
       ]
     },
     "node_modules/@rollup/rollup-win32-ia32-msvc": {
-      "version": "4.57.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.57.1.tgz",
-      "integrity": "sha512-P3dLS+IerxCT/7D2q2FYcRdWRl22dNbrbBEtxdWhXrfIMPP9lQhb5h4Du04mdl5Woq05jVCDPCMF7Ub0NAjIew==",
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.62.4.tgz",
+      "integrity": "sha512-zmfrQd/0wu6oJs8Vq8KwY/YtsKSsLtKe/HwAP4Wqy8LhWjeT55fHRAkOhYQ12wI3ayS4Tt12d5CDRD7N96SAYQ==",
       "cpu": [
         "ia32"
       ],
       "dev": true,
-      "license": "MIT",
       "optional": true,
       "os": [
         "win32"
       ]
     },
     "node_modules/@rollup/rollup-win32-x64-gnu": {
-      "version": "4.57.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.57.1.tgz",
-      "integrity": "sha512-VMBH2eOOaKGtIJYleXsi2B8CPVADrh+TyNxJ4mWPnKfLB/DBUmzW+5m1xUrcwWoMfSLagIRpjUFeW5CO5hyciQ==",
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.62.4.tgz",
+      "integrity": "sha512-qPzHqdj9rfUD+w79dtE07zi/kFwKyCJqplp5K5ygeLTp7jLpAoc16OAH39HSmRC9UpozaecsleI8uAdEj6v2yw==",
       "cpu": [
         "x64"
       ],
       "dev": true,
-      "license": "MIT",
       "optional": true,
       "os": [
         "win32"
       ]
     },
     "node_modules/@rollup/rollup-win32-x64-msvc": {
-      "version": "4.57.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.57.1.tgz",
-      "integrity": "sha512-mxRFDdHIWRxg3UfIIAwCm6NzvxG0jDX/wBN6KsQFTvKFqqg9vTrWUE68qEjHt19A5wwx5X5aUi2zuZT7YR0jrA==",
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.62.4.tgz",
+      "integrity": "sha512-zD6NdeWEByGE9QF9vCrlJ5YQB4oq9q91kPZS37Jwj5hOkvR1lTBSpsKhKDw4IJtbQ35LsTS1HD9DZYGKIshU1Q==",
       "cpu": [
         "x64"
       ],
       "dev": true,
-      "license": "MIT",
       "optional": true,
       "os": [
         "win32"
@@ -1544,11 +889,10 @@
       "license": "MIT"
     },
     "node_modules/@sveltejs/acorn-typescript": {
-      "version": "1.0.8",
-      "resolved": "https://registry.npmjs.org/@sveltejs/acorn-typescript/-/acorn-typescript-1.0.8.tgz",
-      "integrity": "sha512-esgN+54+q0NjB0Y/4BomT9samII7jGwNy/2a3wNZbT2A2RpmXsXwUt24LvLhx6jUq2gVk4cWEvcRO6MFQbOfNA==",
+      "version": "1.0.13",
+      "resolved": "https://registry.npmjs.org/@sveltejs/acorn-typescript/-/acorn-typescript-1.0.13.tgz",
+      "integrity": "sha512-wgKggnhZVL9Bfx1OaKKTrYY9BFRk6C8UAkQNUcIv1+llzYrIqy+RZm5HPKzn0NpEBvTVhTqB4kQyllZywsRBRQ==",
       "dev": true,
-      "license": "MIT",
       "peerDependencies": {
         "acorn": "^8.9.0"
       }
@@ -1564,23 +908,21 @@
       }
     },
     "node_modules/@sveltejs/kit": {
-      "version": "2.50.2",
-      "resolved": "https://registry.npmjs.org/@sveltejs/kit/-/kit-2.50.2.tgz",
-      "integrity": "sha512-875hTUkEbz+MyJIxWbQjfMaekqdmEKUUfR7JyKcpfMRZqcGyrO9Gd+iS1D/Dx8LpE5FEtutWGOtlAh4ReSAiOA==",
+      "version": "2.70.2",
+      "resolved": "https://registry.npmjs.org/@sveltejs/kit/-/kit-2.70.2.tgz",
+      "integrity": "sha512-RzRoRpuR2KXqc5yMO0akQHDZeT4AslOlznGITURsqHaVbtyYP4Wn3eE3gxj9JcDyNYO0crkxhdwFHc+2vkVm6w==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "@standard-schema/spec": "^1.0.0",
-        "@sveltejs/acorn-typescript": "^1.0.5",
+        "@sveltejs/acorn-typescript": "^1.0.9",
         "@types/cookie": "^0.6.0",
-        "acorn": "^8.14.1",
+        "acorn": "^8.16.0",
         "cookie": "^0.6.0",
-        "devalue": "^5.6.2",
+        "devalue": "^5.8.1",
         "esm-env": "^1.2.2",
         "kleur": "^4.1.5",
         "magic-string": "^0.30.5",
         "mrmime": "^2.0.0",
-        "sade": "^1.8.1",
         "set-cookie-parser": "^3.0.0",
         "sirv": "^3.0.0"
       },
@@ -1592,10 +934,10 @@
       },
       "peerDependencies": {
         "@opentelemetry/api": "^1.0.0",
-        "@sveltejs/vite-plugin-svelte": "^3.0.0 || ^4.0.0-next.1 || ^5.0.0 || ^6.0.0-next.0",
+        "@sveltejs/vite-plugin-svelte": "^3.0.0 || ^4.0.0-next.1 || ^5.0.0 || ^6.0.0-next.0 || ^7.0.0",
         "svelte": "^4.0.0 || ^5.0.0-next.0",
-        "typescript": "^5.3.3",
-        "vite": "^5.0.3 || ^6.0.0 || ^7.0.0-beta.0"
+        "typescript": "^5.3.3 || ^6.0.0",
+        "vite": "^5.0.3 || ^6.0.0 || ^7.0.0-beta.0 || ^8.0.0"
       },
       "peerDependenciesMeta": {
         "@opentelemetry/api": {
@@ -1644,16 +986,6 @@
         "@sveltejs/vite-plugin-svelte": "^5.0.0",
         "svelte": "^5.0.0",
         "vite": "^6.0.0"
-      }
-    },
-    "node_modules/@swc/helpers": {
-      "version": "0.5.15",
-      "resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.5.15.tgz",
-      "integrity": "sha512-JQ5TuMi45Owi4/BIMAJBoSQoOJu12oOk/gADqlcUL9JEdHB8vyjUSsxqeNXnmXHjYKMi2WcYtezGEEhqUI/E2g==",
-      "license": "Apache-2.0",
-      "peer": true,
-      "dependencies": {
-        "tslib": "^2.8.0"
       }
     },
     "node_modules/@tauri-apps/api": {
@@ -1936,11 +1268,10 @@
       }
     },
     "node_modules/@types/estree": {
-      "version": "1.0.8",
-      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
-      "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
-      "dev": true,
-      "license": "MIT"
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.9.tgz",
+      "integrity": "sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==",
+      "dev": true
     },
     "node_modules/@types/marked": {
       "version": "5.0.2",
@@ -1977,11 +1308,10 @@
       "license": "MIT"
     },
     "node_modules/acorn": {
-      "version": "8.15.0",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.15.0.tgz",
-      "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
+      "version": "8.18.0",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.18.0.tgz",
+      "integrity": "sha512-lGq+9yr1/GuAWaVYIHRjvvySG5/4VfKIvC8EWxStPdcDh/Ka7FG3twP6v4d5BkravUilhIAsG4Qj83t02LWUPQ==",
       "dev": true,
-      "license": "MIT",
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -2014,11 +1344,10 @@
       }
     },
     "node_modules/aria-query": {
-      "version": "5.3.2",
-      "resolved": "https://registry.npmjs.org/aria-query/-/aria-query-5.3.2.tgz",
-      "integrity": "sha512-COROpnaoap1E2F000S62r6A60uHZnmlvomhfyT2DlTcrY1OrBKn2UhH7qn5wTC9zMvD0AY7csdPSNwKP+7WiQw==",
+      "version": "5.3.1",
+      "resolved": "https://registry.npmjs.org/aria-query/-/aria-query-5.3.1.tgz",
+      "integrity": "sha512-Z/ZeOgVl7bcSYZ/u/rh0fOpvEpq//LZmdbkXyc7syVzjPAhfOa9ebsdTSjEBDU4vs5nC98Kfduj1uFo0qyET3g==",
       "dev": true,
-      "license": "Apache-2.0",
       "engines": {
         "node": ">= 0.4"
       }
@@ -2033,16 +1362,6 @@
         "node": ">= 0.4"
       }
     },
-    "node_modules/baseline-browser-mapping": {
-      "version": "2.9.19",
-      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.9.19.tgz",
-      "integrity": "sha512-ipDqC8FrAl/76p2SSWKSI+H9tFwm7vYqXQrItCuiVPt26Km0jS+NzSsBWAaBusvSbQcfJG+JitdMm+wZAgTYqg==",
-      "license": "Apache-2.0",
-      "peer": true,
-      "bin": {
-        "baseline-browser-mapping": "dist/cli.js"
-      }
-    },
     "node_modules/camelcase": {
       "version": "5.3.1",
       "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
@@ -2051,27 +1370,6 @@
       "engines": {
         "node": ">=6"
       }
-    },
-    "node_modules/caniuse-lite": {
-      "version": "1.0.30001769",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001769.tgz",
-      "integrity": "sha512-BCfFL1sHijQlBGWBMuJyhZUhzo7wer5sVj9hqekB/7xn0Ypy+pER/edCYQm4exbXj4WiySGp40P8UuTh6w1srg==",
-      "funding": [
-        {
-          "type": "opencollective",
-          "url": "https://opencollective.com/browserslist"
-        },
-        {
-          "type": "tidelift",
-          "url": "https://tidelift.com/funding/github/npm/caniuse-lite"
-        },
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/ai"
-        }
-      ],
-      "license": "CC-BY-4.0",
-      "peer": true
     },
     "node_modules/chokidar": {
       "version": "4.0.3",
@@ -2088,13 +1386,6 @@
       "funding": {
         "url": "https://paulmillr.com/funding/"
       }
-    },
-    "node_modules/client-only": {
-      "version": "0.0.1",
-      "resolved": "https://registry.npmjs.org/client-only/-/client-only-0.0.1.tgz",
-      "integrity": "sha512-IV3Ou0jSMzZrd3pZ48nLkT9DA7Ag1pnPzaiQhpW7c3RbcqqzvzzVu+L8gfqMp/8IM2MQtSiqaCxrrcfu8I8rMA==",
-      "license": "MIT",
-      "peer": true
     },
     "node_modules/cliui": {
       "version": "6.0.0",
@@ -2136,11 +1427,10 @@
       "license": "MIT"
     },
     "node_modules/cookie": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.6.0.tgz",
-      "integrity": "sha512-U71cyTamuh1CRNCfpGY6to28lxvNwPG4Guz/EVjgf3Jmzv0vlDp1atT9eS5dDjMYHucpHbWns6Lwf3BKz6svdw==",
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.2.tgz",
+      "integrity": "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==",
       "dev": true,
-      "license": "MIT",
       "engines": {
         "node": ">= 0.6"
       }
@@ -2182,23 +1472,11 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/detect-libc": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
-      "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
-      "license": "Apache-2.0",
-      "optional": true,
-      "peer": true,
-      "engines": {
-        "node": ">=8"
-      }
-    },
     "node_modules/devalue": {
-      "version": "5.6.2",
-      "resolved": "https://registry.npmjs.org/devalue/-/devalue-5.6.2.tgz",
-      "integrity": "sha512-nPRkjWzzDQlsejL1WVifk5rvcFi/y1onBRxjaFMjZeR9mFpqu2gmAZ9xUB9/IEanEP/vBtGeGganC/GO1fmufg==",
-      "dev": true,
-      "license": "MIT"
+      "version": "5.9.0",
+      "resolved": "https://registry.npmjs.org/devalue/-/devalue-5.9.0.tgz",
+      "integrity": "sha512-RWrqdArjvPbsATEhOPUo6Wndc/iWnkWKlhIrdlF3zMMYo/c3CVtoaVAyLtWxz5h8nSlkHzxnzV2uLydPXmtF+A==",
+      "dev": true
     },
     "node_modules/dijkstrajs": {
       "version": "1.0.3",
@@ -2207,10 +1485,9 @@
       "license": "MIT"
     },
     "node_modules/dompurify": {
-      "version": "3.3.1",
-      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.3.1.tgz",
-      "integrity": "sha512-qkdCKzLNtrgPFP1Vo+98FRzJnBRGe4ffyCea9IwHB1fyxPOeNTHpLKYGd4Uk9xvNoH0ZoOjwZxNptyMwqrId1Q==",
-      "license": "(MPL-2.0 OR Apache-2.0)",
+      "version": "3.4.13",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.13.tgz",
+      "integrity": "sha512-2vmYIoqjze2d+kakP8S/nS5shfsl587kzwEjcGlTdiksUVgFHnFCsLYDVj/JNqJVOQZGSYBTmuycv0PodwmnMQ==",
       "optionalDependencies": {
         "@types/trusted-types": "^2.0.7"
       }
@@ -2271,13 +1548,20 @@
       "license": "MIT"
     },
     "node_modules/esrap": {
-      "version": "2.2.2",
-      "resolved": "https://registry.npmjs.org/esrap/-/esrap-2.2.2.tgz",
-      "integrity": "sha512-zA6497ha+qKvoWIK+WM9NAh5ni17sKZKhbS5B3PoYbBvaYHZWoS33zmFybmyqpn07RLUxSmn+RCls2/XF+d0oQ==",
+      "version": "2.3.4",
+      "resolved": "https://registry.npmjs.org/esrap/-/esrap-2.3.4.tgz",
+      "integrity": "sha512-CHnJXZDfBeOAjLIGNy/0BEsmDu5+irHgUXRW9pGptxCbO3uyjJ98crilzFgiBqizW94UodjX3GAPLg/dhEnUfA==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "@jridgewell/sourcemap-codec": "^1.4.15"
+      },
+      "peerDependencies": {
+        "@typescript-eslint/types": "^8.2.0"
+      },
+      "peerDependenciesMeta": {
+        "@typescript-eslint/types": {
+          "optional": true
+        }
       }
     },
     "node_modules/fdir": {
@@ -2324,15 +1608,6 @@
       ],
       "engines": {
         "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
-      }
-    },
-    "node_modules/geist": {
-      "version": "1.7.0",
-      "resolved": "https://registry.npmjs.org/geist/-/geist-1.7.0.tgz",
-      "integrity": "sha512-ZaoiZwkSf0DwwB1ncdLKp+ggAldqxl5L1+SXaNIBGkPAqcu+xjVJLxlf3/S8vLt9UHx1xu5fz3lbzKCj5iOVdQ==",
-      "license": "SIL OPEN FONT LICENSE",
-      "peerDependencies": {
-        "next": ">=13.2.0"
       }
     },
     "node_modules/get-caller-file": {
@@ -2442,104 +1717,21 @@
       "license": "MIT"
     },
     "node_modules/nanoid": {
-      "version": "3.3.11",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
-      "integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
+      "version": "3.3.18",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.18.tgz",
+      "integrity": "sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==",
+      "dev": true,
       "funding": [
         {
           "type": "github",
           "url": "https://github.com/sponsors/ai"
         }
       ],
-      "license": "MIT",
       "bin": {
         "nanoid": "bin/nanoid.cjs"
       },
       "engines": {
         "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
-      }
-    },
-    "node_modules/next": {
-      "version": "16.1.6",
-      "resolved": "https://registry.npmjs.org/next/-/next-16.1.6.tgz",
-      "integrity": "sha512-hkyRkcu5x/41KoqnROkfTm2pZVbKxvbZRuNvKXLRXxs3VfyO0WhY50TQS40EuKO9SW3rBj/sF3WbVwDACeMZyw==",
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "@next/env": "16.1.6",
-        "@swc/helpers": "0.5.15",
-        "baseline-browser-mapping": "^2.8.3",
-        "caniuse-lite": "^1.0.30001579",
-        "postcss": "8.4.31",
-        "styled-jsx": "5.1.6"
-      },
-      "bin": {
-        "next": "dist/bin/next"
-      },
-      "engines": {
-        "node": ">=20.9.0"
-      },
-      "optionalDependencies": {
-        "@next/swc-darwin-arm64": "16.1.6",
-        "@next/swc-darwin-x64": "16.1.6",
-        "@next/swc-linux-arm64-gnu": "16.1.6",
-        "@next/swc-linux-arm64-musl": "16.1.6",
-        "@next/swc-linux-x64-gnu": "16.1.6",
-        "@next/swc-linux-x64-musl": "16.1.6",
-        "@next/swc-win32-arm64-msvc": "16.1.6",
-        "@next/swc-win32-x64-msvc": "16.1.6",
-        "sharp": "^0.34.4"
-      },
-      "peerDependencies": {
-        "@opentelemetry/api": "^1.1.0",
-        "@playwright/test": "^1.51.1",
-        "babel-plugin-react-compiler": "*",
-        "react": "^18.2.0 || 19.0.0-rc-de68d2f4-20241204 || ^19.0.0",
-        "react-dom": "^18.2.0 || 19.0.0-rc-de68d2f4-20241204 || ^19.0.0",
-        "sass": "^1.3.0"
-      },
-      "peerDependenciesMeta": {
-        "@opentelemetry/api": {
-          "optional": true
-        },
-        "@playwright/test": {
-          "optional": true
-        },
-        "babel-plugin-react-compiler": {
-          "optional": true
-        },
-        "sass": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/next/node_modules/postcss": {
-      "version": "8.4.31",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.31.tgz",
-      "integrity": "sha512-PS08Iboia9mts/2ygV3eLpY5ghnUcfLV/EXTOW1E2qYxJKGGBUtNjN76FYHnMs36RmARn41bC0AZmn+rR0OVpQ==",
-      "funding": [
-        {
-          "type": "opencollective",
-          "url": "https://opencollective.com/postcss/"
-        },
-        {
-          "type": "tidelift",
-          "url": "https://tidelift.com/funding/github/npm/postcss"
-        },
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/ai"
-        }
-      ],
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "nanoid": "^3.3.6",
-        "picocolors": "^1.0.0",
-        "source-map-js": "^1.0.2"
-      },
-      "engines": {
-        "node": "^10 || ^12 || >=14"
       }
     },
     "node_modules/p-limit": {
@@ -2591,14 +1783,14 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
       "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+      "dev": true,
       "license": "ISC"
     },
     "node_modules/picomatch": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
-      "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.5.tgz",
+      "integrity": "sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==",
       "dev": true,
-      "license": "MIT",
       "engines": {
         "node": ">=12"
       },
@@ -2616,9 +1808,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.6",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.6.tgz",
-      "integrity": "sha512-3Ybi1tAuwAP9s0r1UQ2J4n5Y0G05bJkpUIO0/bI9MhwmD70S5aTWbXGBwxHrelT+XM1k6dM0pk+SwNkpTRN7Pg==",
+      "version": "8.5.26",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.26.tgz",
+      "integrity": "sha512-u82N74LFzG8ca+dD8puPnplTXoGH4fTPpVGuIbt36G3qvNlkvfD0lEAZSxaly3KX8TS/L1A1gsCEmvKmBcVbkQ==",
       "dev": true,
       "funding": [
         {
@@ -2634,9 +1826,8 @@
           "url": "https://github.com/sponsors/ai"
         }
       ],
-      "license": "MIT",
       "dependencies": {
-        "nanoid": "^3.3.11",
+        "nanoid": "^3.3.17",
         "picocolors": "^1.1.1",
         "source-map-js": "^1.2.1"
       },
@@ -2659,29 +1850,6 @@
       },
       "engines": {
         "node": ">=10.13.0"
-      }
-    },
-    "node_modules/react": {
-      "version": "19.2.4",
-      "resolved": "https://registry.npmjs.org/react/-/react-19.2.4.tgz",
-      "integrity": "sha512-9nfp2hYpCwOjAN+8TZFGhtWEwgvWHXqESH8qT89AT/lWklpLON22Lc8pEtnpsZz7VmawabSU0gCjnj8aC0euHQ==",
-      "license": "MIT",
-      "peer": true,
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/react-dom": {
-      "version": "19.2.4",
-      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.4.tgz",
-      "integrity": "sha512-AXJdLo8kgMbimY95O2aKQqsz2iWi9jMgKJhRBAxECE4IFxfcazB2LmzloIoibJI3C12IlY20+KFaLv+71bUJeQ==",
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "scheduler": "^0.27.0"
-      },
-      "peerDependencies": {
-        "react": "^19.2.4"
       }
     },
     "node_modules/readdirp": {
@@ -2714,13 +1882,12 @@
       "license": "ISC"
     },
     "node_modules/rollup": {
-      "version": "4.57.1",
-      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.57.1.tgz",
-      "integrity": "sha512-oQL6lgK3e2QZeQ7gcgIkS2YZPg5slw37hYufJ3edKlfQSGGm8ICoxswK15ntSzF/a8+h7ekRy7k7oWc3BQ7y8A==",
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.62.4.tgz",
+      "integrity": "sha512-RXOqwaPsBGjMNMa4sQjDjHieHEZDFoj/Rdr46l2MU5DfEs16wHJPC2RPTPHWhNl+M3aI472LLqFkFKut4SblOg==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
-        "@types/estree": "1.0.8"
+        "@types/estree": "1.0.9"
       },
       "bin": {
         "rollup": "dist/bin/rollup"
@@ -2730,31 +1897,32 @@
         "npm": ">=8.0.0"
       },
       "optionalDependencies": {
-        "@rollup/rollup-android-arm-eabi": "4.57.1",
-        "@rollup/rollup-android-arm64": "4.57.1",
-        "@rollup/rollup-darwin-arm64": "4.57.1",
-        "@rollup/rollup-darwin-x64": "4.57.1",
-        "@rollup/rollup-freebsd-arm64": "4.57.1",
-        "@rollup/rollup-freebsd-x64": "4.57.1",
-        "@rollup/rollup-linux-arm-gnueabihf": "4.57.1",
-        "@rollup/rollup-linux-arm-musleabihf": "4.57.1",
-        "@rollup/rollup-linux-arm64-gnu": "4.57.1",
-        "@rollup/rollup-linux-arm64-musl": "4.57.1",
-        "@rollup/rollup-linux-loong64-gnu": "4.57.1",
-        "@rollup/rollup-linux-loong64-musl": "4.57.1",
-        "@rollup/rollup-linux-ppc64-gnu": "4.57.1",
-        "@rollup/rollup-linux-ppc64-musl": "4.57.1",
-        "@rollup/rollup-linux-riscv64-gnu": "4.57.1",
-        "@rollup/rollup-linux-riscv64-musl": "4.57.1",
-        "@rollup/rollup-linux-s390x-gnu": "4.57.1",
-        "@rollup/rollup-linux-x64-gnu": "4.57.1",
-        "@rollup/rollup-linux-x64-musl": "4.57.1",
-        "@rollup/rollup-openbsd-x64": "4.57.1",
-        "@rollup/rollup-openharmony-arm64": "4.57.1",
-        "@rollup/rollup-win32-arm64-msvc": "4.57.1",
-        "@rollup/rollup-win32-ia32-msvc": "4.57.1",
-        "@rollup/rollup-win32-x64-gnu": "4.57.1",
-        "@rollup/rollup-win32-x64-msvc": "4.57.1",
+        "@napi-rs/lzma-linux-x64-gnu": "1.5.1",
+        "@rollup/rollup-android-arm-eabi": "4.62.4",
+        "@rollup/rollup-android-arm64": "4.62.4",
+        "@rollup/rollup-darwin-arm64": "4.62.4",
+        "@rollup/rollup-darwin-x64": "4.62.4",
+        "@rollup/rollup-freebsd-arm64": "4.62.4",
+        "@rollup/rollup-freebsd-x64": "4.62.4",
+        "@rollup/rollup-linux-arm-gnueabihf": "4.62.4",
+        "@rollup/rollup-linux-arm-musleabihf": "4.62.4",
+        "@rollup/rollup-linux-arm64-gnu": "4.62.4",
+        "@rollup/rollup-linux-arm64-musl": "4.62.4",
+        "@rollup/rollup-linux-loong64-gnu": "4.62.4",
+        "@rollup/rollup-linux-loong64-musl": "4.62.4",
+        "@rollup/rollup-linux-ppc64-gnu": "4.62.4",
+        "@rollup/rollup-linux-ppc64-musl": "4.62.4",
+        "@rollup/rollup-linux-riscv64-gnu": "4.62.4",
+        "@rollup/rollup-linux-riscv64-musl": "4.62.4",
+        "@rollup/rollup-linux-s390x-gnu": "4.62.4",
+        "@rollup/rollup-linux-x64-gnu": "4.62.4",
+        "@rollup/rollup-linux-x64-musl": "4.62.4",
+        "@rollup/rollup-openbsd-x64": "4.62.4",
+        "@rollup/rollup-openharmony-arm64": "4.62.4",
+        "@rollup/rollup-win32-arm64-msvc": "4.62.4",
+        "@rollup/rollup-win32-ia32-msvc": "4.62.4",
+        "@rollup/rollup-win32-x64-gnu": "4.62.4",
+        "@rollup/rollup-win32-x64-msvc": "4.62.4",
         "fsevents": "~2.3.2"
       }
     },
@@ -2771,27 +1939,6 @@
         "node": ">=6"
       }
     },
-    "node_modules/scheduler": {
-      "version": "0.27.0",
-      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.27.0.tgz",
-      "integrity": "sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==",
-      "license": "MIT",
-      "peer": true
-    },
-    "node_modules/semver": {
-      "version": "7.7.4",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
-      "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
-      "license": "ISC",
-      "optional": true,
-      "peer": true,
-      "bin": {
-        "semver": "bin/semver.js"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
     "node_modules/set-blocking": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
@@ -2804,52 +1951,6 @@
       "integrity": "sha512-n7Z7dXZhJbwuAHhNzkTti6Aw9QDDjZtm3JTpTGATIdNzdQz5GuFs22w90BcvF4INfnrL5xrX3oGsuqO5Dx3A1Q==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/sharp": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/sharp/-/sharp-0.34.5.tgz",
-      "integrity": "sha512-Ou9I5Ft9WNcCbXrU9cMgPBcCK8LiwLqcbywW3t4oDV37n1pzpuNLsYiAV8eODnjbtQlSDwZ2cUEeQz4E54Hltg==",
-      "hasInstallScript": true,
-      "license": "Apache-2.0",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "@img/colour": "^1.0.0",
-        "detect-libc": "^2.1.2",
-        "semver": "^7.7.3"
-      },
-      "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/libvips"
-      },
-      "optionalDependencies": {
-        "@img/sharp-darwin-arm64": "0.34.5",
-        "@img/sharp-darwin-x64": "0.34.5",
-        "@img/sharp-libvips-darwin-arm64": "1.2.4",
-        "@img/sharp-libvips-darwin-x64": "1.2.4",
-        "@img/sharp-libvips-linux-arm": "1.2.4",
-        "@img/sharp-libvips-linux-arm64": "1.2.4",
-        "@img/sharp-libvips-linux-ppc64": "1.2.4",
-        "@img/sharp-libvips-linux-riscv64": "1.2.4",
-        "@img/sharp-libvips-linux-s390x": "1.2.4",
-        "@img/sharp-libvips-linux-x64": "1.2.4",
-        "@img/sharp-libvips-linuxmusl-arm64": "1.2.4",
-        "@img/sharp-libvips-linuxmusl-x64": "1.2.4",
-        "@img/sharp-linux-arm": "0.34.5",
-        "@img/sharp-linux-arm64": "0.34.5",
-        "@img/sharp-linux-ppc64": "0.34.5",
-        "@img/sharp-linux-riscv64": "0.34.5",
-        "@img/sharp-linux-s390x": "0.34.5",
-        "@img/sharp-linux-x64": "0.34.5",
-        "@img/sharp-linuxmusl-arm64": "0.34.5",
-        "@img/sharp-linuxmusl-x64": "0.34.5",
-        "@img/sharp-wasm32": "0.34.5",
-        "@img/sharp-win32-arm64": "0.34.5",
-        "@img/sharp-win32-ia32": "0.34.5",
-        "@img/sharp-win32-x64": "0.34.5"
-      }
     },
     "node_modules/sirv": {
       "version": "3.0.2",
@@ -2870,6 +1971,7 @@
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
       "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+      "dev": true,
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">=0.10.0"
@@ -2901,48 +2003,24 @@
         "node": ">=8"
       }
     },
-    "node_modules/styled-jsx": {
-      "version": "5.1.6",
-      "resolved": "https://registry.npmjs.org/styled-jsx/-/styled-jsx-5.1.6.tgz",
-      "integrity": "sha512-qSVyDTeMotdvQYoHWLNGwRFJHC+i+ZvdBRYosOFgC+Wg1vx4frN2/RG/NA7SYqqvKNLf39P2LSRA2pu6n0XYZA==",
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "client-only": "0.0.1"
-      },
-      "engines": {
-        "node": ">= 12.0.0"
-      },
-      "peerDependencies": {
-        "react": ">= 16.8.0 || 17.x.x || ^18.0.0-0 || ^19.0.0-0"
-      },
-      "peerDependenciesMeta": {
-        "@babel/core": {
-          "optional": true
-        },
-        "babel-plugin-macros": {
-          "optional": true
-        }
-      }
-    },
     "node_modules/svelte": {
-      "version": "5.49.2",
-      "resolved": "https://registry.npmjs.org/svelte/-/svelte-5.49.2.tgz",
-      "integrity": "sha512-PYLwnngYzyhKzqDlGVlCH4z+NVI8mC0/bTv15vw25CcdOhxENsOHIbQ36oj5DIf3oBazM+STbCAvaskpxtBmWA==",
+      "version": "5.56.9",
+      "resolved": "https://registry.npmjs.org/svelte/-/svelte-5.56.9.tgz",
+      "integrity": "sha512-VT8kSnlEg8069w7AiCcAk3Yf5xvMnrGTagVOmU/OpOLHaHnNqXhWZCH/4EVga/bT/HtWhvE6/fHrXLErx7OnJA==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "@jridgewell/remapping": "^2.3.4",
         "@jridgewell/sourcemap-codec": "^1.5.0",
-        "@sveltejs/acorn-typescript": "^1.0.5",
+        "@sveltejs/acorn-typescript": "^1.0.10",
         "@types/estree": "^1.0.5",
+        "@types/trusted-types": "^2.0.7",
         "acorn": "^8.12.1",
-        "aria-query": "^5.3.1",
+        "aria-query": "5.3.1",
         "axobject-query": "^4.1.0",
         "clsx": "^2.1.1",
-        "devalue": "^5.6.2",
+        "devalue": "^5.8.1",
         "esm-env": "^1.2.1",
-        "esrap": "^2.2.2",
+        "esrap": "^2.2.12",
         "is-reference": "^3.0.3",
         "locate-character": "^3.0.0",
         "magic-string": "^0.30.11",
@@ -3003,13 +2081,6 @@
         "node": ">=6"
       }
     },
-    "node_modules/tslib": {
-      "version": "2.8.1",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
-      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
-      "license": "0BSD",
-      "peer": true
-    },
     "node_modules/typescript": {
       "version": "5.6.3",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.6.3.tgz",
@@ -3032,11 +2103,10 @@
       "license": "MIT"
     },
     "node_modules/vite": {
-      "version": "6.4.1",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-6.4.1.tgz",
-      "integrity": "sha512-+Oxm7q9hDoLMyJOYfUYBuHQo+dkAloi33apOPP56pzj+vsdJDzr+j1NISE5pyaAuKL4A3UD34qd0lx5+kfKp2g==",
+      "version": "6.4.3",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-6.4.3.tgz",
+      "integrity": "sha512-NTKlcQjlAK7MlQoyb6LgaqHc8sso/pVyUJYWMws3jg21uTJw/LddqIFPcPqP6PzpgbIcZyKI85sFE4HBrQDA8A==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "esbuild": "^0.25.0",
         "fdir": "^6.4.4",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "c9watch",
-  "version": "0.9.0",
+  "version": "0.10.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "c9watch",
-      "version": "0.9.0",
+      "version": "0.10.0",
       "license": "MIT",
       "dependencies": {
         "@choochmeque/tauri-plugin-sharekit-api": "^0.3.1",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "c9watch",
-  "version": "0.9.0",
-  "description": "Monitor and control all your Claude Code sessions from one place",
+  "version": "0.10.0",
+  "description": "Monitor and control Claude Code sessions, with Codex and Cursor Agent visibility",
   "type": "module",
   "scripts": {
     "dev": "vite dev",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "c9watch",
-  "version": "0.8.1",
+  "version": "0.9.0",
   "description": "Monitor and control all your Claude Code sessions from one place",
   "type": "module",
   "scripts": {
@@ -20,7 +20,6 @@
     "@tauri-apps/plugin-process": "^2.3.1",
     "@tauri-apps/plugin-updater": "^2.10.0",
     "dompurify": "^3.3.1",
-    "geist": "^1.7.0",
     "marked": "^17.0.1",
     "qrcode": "^1.5.4"
   },
@@ -36,5 +35,8 @@
     "svelte-check": "^4.0.0",
     "typescript": "~5.6.2",
     "vite": "^6.0.3"
+  },
+  "overrides": {
+    "cookie": "^0.7.0"
   }
 }

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -438,7 +438,7 @@ dependencies = [
 
 [[package]]
 name = "c9watch"
-version = "0.8.1"
+version = "0.9.0"
 dependencies = [
  "anyhow",
  "axum",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -450,7 +450,7 @@ dependencies = [
 
 [[package]]
 name = "c9watch"
-version = "0.9.0"
+version = "0.10.0"
 dependencies = [
  "anyhow",
  "axum",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -9,6 +9,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
+name = "ahash"
+version = "0.8.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a15f179cd60c4584b8a8c596927aadc462e27f2ca70c04e0071964a73ba7a75"
+dependencies = [
+ "cfg-if",
+ "once_cell",
+ "version_check",
+ "zerocopy",
+]
+
+[[package]]
 name = "aho-corasick"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -132,9 +144,9 @@ dependencies = [
 
 [[package]]
 name = "async-executor"
-version = "1.13.3"
+version = "1.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "497c00e0fd83a72a79a39fcbd8e3e2f055d6f6c7e025f3b3d91f4f8e76527fb8"
+checksum = "c96bf972d85afc50bf5ab8fe2d54d1586b4e0b46c97c50a0c9e71e2f7bcd812a"
 dependencies = [
  "async-task",
  "concurrent-queue",
@@ -204,9 +216,9 @@ dependencies = [
 
 [[package]]
 name = "async-signal"
-version = "0.2.13"
+version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43c070bbf59cd3570b6b2dd54cd772527c7c3620fce8be898406dd3ed6adc64c"
+checksum = "52b5aaafa020cf5053a01f2a60e8ff5dccf550f0f77ec54a4e47285ac2bab485"
 dependencies = [
  "async-io",
  "async-lock",
@@ -411,9 +423,9 @@ dependencies = [
 
 [[package]]
 name = "bumpalo"
-version = "3.19.1"
+version = "3.20.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5dd9dc738b7a8311c7ade152424974d8115f2cdad61e8dab8dac9f2362298510"
+checksum = "72f5acc6cb2ba439de613abc23857ec3d78374d8ed5ac84e9d11336e87da8649"
 
 [[package]]
 name = "bytemuck"
@@ -451,6 +463,7 @@ dependencies = [
  "qr2term",
  "rand 0.8.5",
  "regex",
+ "rusqlite",
  "rust-embed",
  "serde",
  "serde_json",
@@ -1151,6 +1164,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "fallible-iterator"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2acce4a10f12dc2fb14a218589d4f1f62ef011b2d0cc4b3cb1bba8e94da14649"
+
+[[package]]
+name = "fallible-streaming-iterator"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7360491ce676a36bf9bb3c56c1aa791658183a54d2744120f27285738d90465a"
+
+[[package]]
 name = "fastrand"
 version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1265,15 +1290,15 @@ dependencies = [
 
 [[package]]
 name = "futures-core"
-version = "0.3.31"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "05f29059c0c2090612e8d742178b0580d2dc940c837851ad723096f87af6663e"
+checksum = "7e3450815272ef58cec6d564423f6e755e25379b217b0bc688e295ba24df6b1d"
 
 [[package]]
 name = "futures-executor"
-version = "0.3.31"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e28d1d997f585e54aebc3f97d39e72338912123a67330d723fdbb564d646c9f"
+checksum = "baf29c38818342a3b26b5b923639e7b1f4a61fc5e76102d4b1981c6dc7a7579d"
 dependencies = [
  "futures-core",
  "futures-task",
@@ -1282,9 +1307,9 @@ dependencies = [
 
 [[package]]
 name = "futures-io"
-version = "0.3.31"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e5c1b78ca4aae1ac06c48a526a655760685149f0d465d21f37abfe57ce075c6"
+checksum = "cecba35d7ad927e23624b22ad55235f2239cfa44fd10428eecbeba6d6a717718"
 
 [[package]]
 name = "futures-lite"
@@ -1301,9 +1326,9 @@ dependencies = [
 
 [[package]]
 name = "futures-macro"
-version = "0.3.31"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "162ee34ebcb7c64a8abebc059ce0fee27c2262618d7b60ed8faf72fef13c3650"
+checksum = "e835b70203e41293343137df5c0664546da5745f82ec9b84d40be8336958447b"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1312,21 +1337,21 @@ dependencies = [
 
 [[package]]
 name = "futures-sink"
-version = "0.3.31"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e575fab7d1e0dcb8d0c7bcf9a63ee213816ab51902e6d244a95819acacf1d4f7"
+checksum = "c39754e157331b013978ec91992bde1ac089843443c49cbc7f46150b0fad0893"
 
 [[package]]
 name = "futures-task"
-version = "0.3.31"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f90f7dce0722e95104fcb095585910c0977252f286e354b5e3bd38902cd99988"
+checksum = "037711b3d59c33004d3856fbdc83b99d4ff37a24768fa1be9ce3538a1cde4393"
 
 [[package]]
 name = "futures-util"
-version = "0.3.31"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9fa08315bb612088cc391249efdc3bc77536f16c91f6cf495e6fbe85b20a4a81"
+checksum = "389ca41296e6190b48053de0321d02a77f32f8a5d2461dd38762c0593805c6d6"
 dependencies = [
  "futures-core",
  "futures-io",
@@ -1335,7 +1360,6 @@ dependencies = [
  "futures-task",
  "memchr",
  "pin-project-lite",
- "pin-utils",
  "slab",
 ]
 
@@ -1553,7 +1577,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0bb0228f477c0900c880fd78c8759b95c7636dbd7842707f49e132378aa2acdc"
 dependencies = [
  "heck 0.4.1",
- "proc-macro-crate 2.0.2",
+ "proc-macro-crate 2.0.0",
  "proc-macro-error",
  "proc-macro2",
  "quote",
@@ -1647,9 +1671,27 @@ checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
 
 [[package]]
 name = "hashbrown"
+version = "0.14.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
+dependencies = [
+ "ahash",
+]
+
+[[package]]
+name = "hashbrown"
 version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
+
+[[package]]
+name = "hashlink"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ba4ff7128dee98c7dc9794b6a411377e1404dba1c97deb8d1a55297bd25d8af"
+dependencies = [
+ "hashbrown 0.14.5",
+]
 
 [[package]]
 name = "heck"
@@ -2046,7 +2088,7 @@ dependencies = [
  "cesu8",
  "cfg-if",
  "combine",
- "jni-sys",
+ "jni-sys 0.3.1",
  "log",
  "thiserror 1.0.69",
  "walkdir",
@@ -2055,16 +2097,40 @@ dependencies = [
 
 [[package]]
 name = "jni-sys"
-version = "0.3.0"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8eaf4bc02d17cbdd7ff4c7438cafcdf7fb9a4613313ad11b4f8fefe7d3fa0130"
+checksum = "41a652e1f9b6e0275df1f15b32661cf0d4b78d4d87ddec5e0c3c20f097433258"
+dependencies = [
+ "jni-sys 0.4.1",
+]
+
+[[package]]
+name = "jni-sys"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c6377a88cb3910bee9b0fa88d4f42e1d2da8e79915598f65fb0c7ee14c878af2"
+dependencies = [
+ "jni-sys-macros",
+]
+
+[[package]]
+name = "jni-sys-macros"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38c0b942f458fe50cdac086d2f946512305e5631e720728f2a61aabcd47a6264"
+dependencies = [
+ "quote",
+ "syn 2.0.114",
+]
 
 [[package]]
 name = "js-sys"
-version = "0.3.85"
+version = "0.3.98"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8c942ebf8e95485ca0d52d97da7c5a2c387d0e7f0ba4c35e93bfcaee045955b3"
+checksum = "67df7112613f8bfd9150013a0314e196f4800d3201ae742489d999db2f979f08"
 dependencies = [
+ "cfg-if",
+ "futures-util",
  "once_cell",
  "wasm-bindgen",
 ]
@@ -2162,13 +2228,25 @@ dependencies = [
 
 [[package]]
 name = "libredox"
-version = "0.1.12"
+version = "0.1.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d0b95e02c851351f877147b7deea7b1afb1df71b63aa5f8270716e0c5720616"
+checksum = "e02f3bb43d335493c96bf3fd3a321600bf6bd07ed34bc64118e9293bdffea46c"
 dependencies = [
  "bitflags 2.10.0",
  "libc",
- "redox_syscall 0.7.0",
+ "plain",
+ "redox_syscall 0.7.5",
+]
+
+[[package]]
+name = "libsqlite3-sys"
+version = "0.30.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e99fb7a497b1e3339bc746195567ed8d3e24945ecd636e3619d20b9de9e9149"
+dependencies = [
+ "cc",
+ "pkg-config",
+ "vcpkg",
 ]
 
 [[package]]
@@ -2345,7 +2423,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c3f42e7bbe13d351b6bead8286a43aac9534b82bd3cc43e47037f012ebfd62d4"
 dependencies = [
  "bitflags 2.10.0",
- "jni-sys",
+ "jni-sys 0.3.1",
  "log",
  "ndk-sys",
  "num_enum",
@@ -2365,7 +2443,7 @@ version = "0.6.0+11769913"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ee6cda3051665f1fb8d9e08fc35c96d5a244fb1be711a03b71118828afc9a873"
 dependencies = [
- "jni-sys",
+ "jni-sys 0.3.1",
 ]
 
 [[package]]
@@ -2420,9 +2498,9 @@ dependencies = [
 
 [[package]]
 name = "num_enum"
-version = "0.7.5"
+version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1207a7e20ad57b847bbddc6776b968420d38292bbfe2089accff5e19e82454c"
+checksum = "5d0bca838442ec211fa11de3a8b0e0e8f3a4522575b5c4c06ed722e005036f26"
 dependencies = [
  "num_enum_derive",
  "rustversion",
@@ -2430,11 +2508,11 @@ dependencies = [
 
 [[package]]
 name = "num_enum_derive"
-version = "0.7.5"
+version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ff32365de1b6743cb203b710788263c44a03de03802daf96092f2da4fe6ba4d7"
+checksum = "680998035259dcfcafe653688bf2aa6d3e2dc05e98be6ab46afb089dc84f1df8"
 dependencies = [
- "proc-macro-crate 3.4.0",
+ "proc-macro-crate 3.5.0",
  "proc-macro2",
  "quote",
  "syn 2.0.114",
@@ -2946,9 +3024,9 @@ checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
 name = "piper"
-version = "0.2.4"
+version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "96c8c490f422ef9a4efd2cb5b42b76c8613d7e7dfc1caf667b8a3350a5acc066"
+checksum = "c835479a4443ded371d6c535cbfd8d31ad92c5d23ae9770a61bc155e4992a3c1"
 dependencies = [
  "atomic-waker",
  "fastrand",
@@ -2960,6 +3038,12 @@ name = "pkg-config"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
+
+[[package]]
+name = "plain"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4596b6d070b27117e987119b4dac604f3c58cfb0b191112e24771b2faeac1a6"
 
 [[package]]
 name = "plist"
@@ -3043,21 +3127,20 @@ dependencies = [
 
 [[package]]
 name = "proc-macro-crate"
-version = "2.0.2"
+version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b00f26d3400549137f92511a46ac1cd8ce37cb5598a96d382381458b992a5d24"
+checksum = "7e8366a6159044a37876a2b9817124296703c586a5c92e2c53751fa06d8d43e8"
 dependencies = [
- "toml_datetime 0.6.3",
  "toml_edit 0.20.2",
 ]
 
 [[package]]
 name = "proc-macro-crate"
-version = "3.4.0"
+version = "3.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "219cb19e96be00ab2e37d6e299658a0cfa83e52429179969b0f0121b4ac46983"
+checksum = "e67ba7e9b2b56446f1d419b1d807906278ffa1a658a8a5d8a39dcb1f5a78614f"
 dependencies = [
- "toml_edit 0.23.10+spec-1.0.0",
+ "toml_edit 0.25.11+spec-1.1.0",
 ]
 
 [[package]]
@@ -3295,9 +3378,9 @@ dependencies = [
 
 [[package]]
 name = "redox_syscall"
-version = "0.7.0"
+version = "0.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49f3fe0889e69e2ae9e41f4d6c4c0181701d00e4697b356fb1f74173a5e0ee27"
+checksum = "4666a1a60d8412eab19d94f6d13dcc9cea0a5ef4fdf6a5db306537413c661b1b"
 dependencies = [
  "bitflags 2.10.0",
 ]
@@ -3427,6 +3510,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "rusqlite"
+version = "0.32.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7753b721174eb8ff87a9a0e799e2d7bc3749323e773db92e0984debb00019d6e"
+dependencies = [
+ "bitflags 2.10.0",
+ "fallible-iterator",
+ "fallible-streaming-iterator",
+ "hashlink",
+ "libsqlite3-sys",
+ "smallvec",
+]
+
+[[package]]
 name = "rust-embed"
 version = "8.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3511,9 +3608,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-native-certs"
-version = "0.8.3"
+version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "612460d5f7bea540c490b2b6395d8e34a953e52b491accd6c86c8164c5932a63"
+checksum = "dab5152771c58876a2146916e53e35057e1a4dfa2b9df0f0305b07f611fdea4d"
 dependencies = [
  "openssl-probe",
  "rustls-pki-types",
@@ -3591,9 +3688,9 @@ dependencies = [
 
 [[package]]
 name = "schannel"
-version = "0.1.28"
+version = "0.1.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "891d81b926048e76efe18581bf793546b4c0eaf8448d72be8de2bbee5fd166e1"
+checksum = "91c1b7e4904c873ef0710c1f407dde2e6287de2bebc1bbbf7d430bb7cbffd939"
 dependencies = [
  "windows-sys 0.61.2",
 ]
@@ -4132,7 +4229,7 @@ dependencies = [
  "cfg-expr",
  "heck 0.5.0",
  "pkg-config",
- "toml 0.8.2",
+ "toml 0.8.23",
  "version-compare",
 ]
 
@@ -4734,14 +4831,14 @@ dependencies = [
 
 [[package]]
 name = "toml"
-version = "0.8.2"
+version = "0.8.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "185d8ab0dfbb35cf1399a6344d8484209c088f75f8f68230da55d48d95d43e3d"
+checksum = "dc1beb996b9d83529a9e75c17a1686767d148d70663143c7854d8b4a09ced362"
 dependencies = [
  "serde",
  "serde_spanned 0.6.9",
- "toml_datetime 0.6.3",
- "toml_edit 0.20.2",
+ "toml_datetime 0.6.11",
+ "toml_edit 0.22.27",
 ]
 
 [[package]]
@@ -4761,9 +4858,9 @@ dependencies = [
 
 [[package]]
 name = "toml_datetime"
-version = "0.6.3"
+version = "0.6.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7cda73e2f1397b1262d6dfdcef8aafae14d1de7748d66822d3bfeeb6d03e5e4b"
+checksum = "22cddaf88f4fbc13c51aebbf5f8eceb5c7c5a9da2ac40a13519eb5b0a0e8f11c"
 dependencies = [
  "serde",
 ]
@@ -4778,13 +4875,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "toml_datetime"
+version = "1.1.1+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3165f65f62e28e0115a00b2ebdd37eb6f3b641855f9d636d3cd4103767159ad7"
+dependencies = [
+ "serde_core",
+]
+
+[[package]]
 name = "toml_edit"
 version = "0.19.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1b5bb770da30e5cbfde35a2d7b9b8a2c4b8ef89548a7a6aeab5c9a576e3e7421"
 dependencies = [
  "indexmap 2.13.0",
- "toml_datetime 0.6.3",
+ "toml_datetime 0.6.11",
  "winnow 0.5.40",
 ]
 
@@ -4795,31 +4901,42 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "396e4d48bbb2b7554c944bde63101b5ae446cff6ec4a24227428f15eb72ef338"
 dependencies = [
  "indexmap 2.13.0",
- "serde",
- "serde_spanned 0.6.9",
- "toml_datetime 0.6.3",
+ "toml_datetime 0.6.11",
  "winnow 0.5.40",
 ]
 
 [[package]]
 name = "toml_edit"
-version = "0.23.10+spec-1.0.0"
+version = "0.22.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "84c8b9f757e028cee9fa244aea147aab2a9ec09d5325a9b01e0a49730c2b5269"
+checksum = "41fe8c660ae4257887cf66394862d21dbca4a6ddd26f04a3560410406a2f819a"
 dependencies = [
  "indexmap 2.13.0",
- "toml_datetime 0.7.5+spec-1.1.0",
- "toml_parser",
+ "serde",
+ "serde_spanned 0.6.9",
+ "toml_datetime 0.6.11",
  "winnow 0.7.14",
 ]
 
 [[package]]
-name = "toml_parser"
-version = "1.0.6+spec-1.1.0"
+name = "toml_edit"
+version = "0.25.11+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a3198b4b0a8e11f09dd03e133c0280504d0801269e9afa46362ffde1cbeebf44"
+checksum = "0b59c4d22ed448339746c59b905d24568fcbb3ab65a500494f7b8c3e97739f2b"
 dependencies = [
- "winnow 0.7.14",
+ "indexmap 2.13.0",
+ "toml_datetime 1.1.1+spec-1.1.0",
+ "toml_parser",
+ "winnow 1.0.2",
+]
+
+[[package]]
+name = "toml_parser"
+version = "1.1.2+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2abe9b86193656635d2411dc43050282ca48aa31c2451210f4202550afb7526"
+dependencies = [
+ "winnow 1.0.2",
 ]
 
 [[package]]
@@ -4966,13 +5083,13 @@ checksum = "562d481066bde0658276a35467c4af00bdc6ee726305698a55b86e61d7ad82bb"
 
 [[package]]
 name = "uds_windows"
-version = "1.1.0"
+version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "89daebc3e6fd160ac4aa9fc8b3bf71e1f74fbf92367ae71fb83a037e8bf164b9"
+checksum = "f2f6fb2847f6742cd76af783a2a2c49e9375d0a111c7bef6f71cd9e738c72d6e"
 dependencies = [
  "memoffset",
  "tempfile",
- "winapi",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -5096,6 +5213,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "vcpkg"
+version = "0.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
+
+[[package]]
 name = "version-compare"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5169,18 +5292,18 @@ checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
 
 [[package]]
 name = "wasip2"
-version = "1.0.2+wasi-0.2.9"
+version = "1.0.3+wasi-0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9517f9239f02c069db75e65f174b3da828fe5f5b945c4dd26bd25d89c03ebcf5"
+checksum = "20064672db26d7cdc89c7798c48a0fdfac8213434a1186e5ef29fd560ae223d6"
 dependencies = [
  "wit-bindgen",
 ]
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.108"
+version = "0.2.121"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "64024a30ec1e37399cf85a7ffefebdb72205ca1c972291c51512360d90bd8566"
+checksum = "49ace1d07c165b0864824eee619580c4689389afa9dc9ed3a4c75040d82e6790"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -5191,23 +5314,19 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.58"
+version = "0.4.71"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70a6e77fd0ae8029c9ea0063f87c46fde723e7d887703d74ad2616d792e51e6f"
+checksum = "96492d0d3ffba25305a7dc88720d250b1401d7edca02cc3bcd50633b424673b8"
 dependencies = [
- "cfg-if",
- "futures-util",
  "js-sys",
- "once_cell",
  "wasm-bindgen",
- "web-sys",
 ]
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.108"
+version = "0.2.121"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "008b239d9c740232e71bd39e8ef6429d27097518b6b30bdf9086833bd5b6d608"
+checksum = "8e68e6f4afd367a562002c05637acb8578ff2dea1943df76afb9e83d177c8578"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -5215,9 +5334,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.108"
+version = "0.2.121"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5256bae2d58f54820e6490f9839c49780dff84c65aeab9e772f15d5f0e913a55"
+checksum = "d95a9ec35c64b2a7cb35d3fead40c4238d0940c86d107136999567a4703259f2"
 dependencies = [
  "bumpalo",
  "proc-macro2",
@@ -5228,9 +5347,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.108"
+version = "0.2.121"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f01b580c9ac74c8d8f0c0e4afb04eeef2acf145458e52c03845ee9cd23e3d12"
+checksum = "c4e0100b01e9f0d03189a92b96772a1fb998639d981193d7dbab487302513441"
 dependencies = [
  "unicode-ident",
 ]
@@ -5250,9 +5369,9 @@ dependencies = [
 
 [[package]]
 name = "web-sys"
-version = "0.3.85"
+version = "0.3.98"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "312e32e551d92129218ea9a2452120f4aabc03529ef03e4d0d82fb2780608598"
+checksum = "4b572dff8bcf38bad0fa19729c89bb5748b2b9b1d8be70cf90df697e3a8f32aa"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -5304,9 +5423,9 @@ dependencies = [
 
 [[package]]
 name = "webpki-root-certs"
-version = "1.0.6"
+version = "1.0.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "804f18a4ac2676ffb4e8b5b5fa9ae38af06df08162314f96a68d2a363e21a8ca"
+checksum = "0d46a5a140e6f7afeccd8eae97eff335163939eac8b929834875168b29b3d267"
 dependencies = [
  "rustls-pki-types",
 ]
@@ -5919,6 +6038,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "winnow"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2ee1708bef14716a11bae175f579062d4554d95be2c6829f518df847b7b3fdd0"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "winreg"
 version = "0.55.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5930,9 +6058,9 @@ dependencies = [
 
 [[package]]
 name = "wit-bindgen"
-version = "0.51.0"
+version = "0.57.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7249219f66ced02969388cf2bb044a09756a083d0fab1e566056b04d9fbcaa5"
+checksum = "1ebf944e87a7c253233ad6766e082e3cd714b5d03812acc24c318f549614536e"
 
 [[package]]
 name = "writeable"
@@ -6041,9 +6169,9 @@ dependencies = [
 
 [[package]]
 name = "zbus"
-version = "5.13.2"
+version = "5.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1bfeff997a0aaa3eb20c4652baf788d2dfa6d2839a0ead0b3ff69ce2f9c4bdd1"
+checksum = "c3bcbf15c8708d7fc1be0c993622e0a5cbd5e8b52bfa40afa4c3e0cd8d724ac1"
 dependencies = [
  "async-broadcast",
  "async-executor",
@@ -6068,7 +6196,7 @@ dependencies = [
  "uds_windows",
  "uuid",
  "windows-sys 0.61.2",
- "winnow 0.7.14",
+ "winnow 1.0.2",
  "zbus_macros",
  "zbus_names",
  "zvariant",
@@ -6076,11 +6204,11 @@ dependencies = [
 
 [[package]]
 name = "zbus_macros"
-version = "5.13.2"
+version = "5.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0bbd5a90dbe8feee5b13def448427ae314ccd26a49cac47905cafefb9ff846f1"
+checksum = "51fa5406ad9175a8c825a931f8cf347116b531b3634fcb0b627c290f1f2516ff"
 dependencies = [
- "proc-macro-crate 3.4.0",
+ "proc-macro-crate 3.5.0",
  "proc-macro2",
  "quote",
  "syn 2.0.114",
@@ -6091,12 +6219,12 @@ dependencies = [
 
 [[package]]
 name = "zbus_names"
-version = "4.3.1"
+version = "4.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ffd8af6d5b78619bab301ff3c560a5bd22426150253db278f164d6cf3b72c50f"
+checksum = "7074f3e50b894eac91750142016d30d0a89be8e67dbfd9704fb875825760e52d"
 dependencies = [
  "serde",
- "winnow 0.7.14",
+ "winnow 1.0.2",
  "zvariant",
 ]
 
@@ -6200,25 +6328,25 @@ checksum = "3ff05f8caa9038894637571ae6b9e29466c1f4f829d26c9b28f869a29cbe3445"
 
 [[package]]
 name = "zvariant"
-version = "5.9.2"
+version = "5.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68b64ef4f40c7951337ddc7023dd03528a57a3ce3408ee9da5e948bd29b232c4"
+checksum = "1c1567a6ec68df868cbbfde844cfc6d81649fe5109a62b116b19fabd53e618ee"
 dependencies = [
  "endi",
  "enumflags2",
  "serde",
- "winnow 0.7.14",
+ "winnow 1.0.2",
  "zvariant_derive",
  "zvariant_utils",
 ]
 
 [[package]]
 name = "zvariant_derive"
-version = "5.9.2"
+version = "5.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "484d5d975eb7afb52cc6b929c13d3719a20ad650fea4120e6310de3fc55e415c"
+checksum = "c7d5b780599bbde114e39d9a0799577fad1ced5105d38515745f7b3099d8ceda"
 dependencies = [
- "proc-macro-crate 3.4.0",
+ "proc-macro-crate 3.5.0",
  "proc-macro2",
  "quote",
  "syn 2.0.114",
@@ -6227,13 +6355,13 @@ dependencies = [
 
 [[package]]
 name = "zvariant_utils"
-version = "3.3.0"
+version = "3.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f75c23a64ef8f40f13a6989991e643554d9bef1d682a281160cf0c1bc389c5e9"
+checksum = "6d464f5733ffa07a3164d656f18533caace9d0638596721355d73256a410d691"
 dependencies = [
  "proc-macro2",
  "quote",
  "serde",
  "syn 2.0.114",
- "winnow 0.7.14",
+ "winnow 1.0.2",
 ]

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "c9watch"
-version = "0.8.1"
+version = "0.9.0"
 description = "Monitor and control all your Claude Code sessions from one place"
 authors = ["minchenlee"]
 edition = "2021"

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -53,6 +53,7 @@ dirs = "5.0"
 chrono = "0.4"
 libc = "0.2.180"
 uuid = { version = "1", features = ["v4"] }
+rusqlite = { version = "0.32", features = ["bundled"] }
 
 # ── GUI-only dependencies ────────────────────────────────────────────
 tauri = { version = "2", features = ["tray-icon"], optional = true }

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "c9watch"
-version = "0.9.0"
-description = "Monitor and control all your Claude Code sessions from one place"
+version = "0.10.0"
+description = "Monitor and control Claude Code sessions, with Codex and Cursor Agent visibility"
 authors = ["minchenlee"]
 edition = "2021"
 

--- a/src-tauri/src/actions.rs
+++ b/src-tauri/src/actions.rs
@@ -240,7 +240,10 @@ fn focus_supacode_session(pid: u32) -> Result<(), String> {
 #[cfg(target_os = "macos")]
 fn focus_iterm2_session(pid: u32) -> Result<(), String> {
     let tty = get_session_tty(pid);
-    crate::debug_log::log_info(&format!("[open_session] iTerm2 tty for PID {}: {:?}", pid, tty));
+    crate::debug_log::log_info(&format!(
+        "[open_session] iTerm2 tty for PID {}: {:?}",
+        pid, tty
+    ));
 
     let Some(tty) = tty else {
         // No tty found — just activate iTerm2
@@ -281,7 +284,10 @@ fn focus_iterm2_session(pid: u32) -> Result<(), String> {
         .map_err(|e| format!("Failed to run AppleScript: {}", e))?;
 
     let result = String::from_utf8_lossy(&output.stdout).trim().to_string();
-    crate::debug_log::log_info(&format!("[open_session] iTerm2 tty match result: {}", result));
+    crate::debug_log::log_info(&format!(
+        "[open_session] iTerm2 tty match result: {}",
+        result
+    ));
 
     Ok(())
 }
@@ -369,8 +375,7 @@ fn focus_terminal_session(pid: u32) -> Result<(), String> {
 /// Screen Recording permissions.
 #[cfg(any(target_os = "macos", target_os = "linux"))]
 fn focus_jetbrains_window(app_name: &str, project_path: &str) -> Result<(), String> {
-    let scheme = jetbrains_url_scheme(app_name)
-        .unwrap_or("idea");
+    let scheme = jetbrains_url_scheme(app_name).unwrap_or("idea");
     let root = find_jetbrains_project_root(project_path);
 
     crate::debug_log::log_info(&format!(
@@ -380,7 +385,11 @@ fn focus_jetbrains_window(app_name: &str, project_path: &str) -> Result<(), Stri
 
     let encoded_path = encode_path_for_url(&root);
     let url = format!("{}://open?file={}", scheme, encoded_path);
-    let cmd = if cfg!(target_os = "macos") { "open" } else { "xdg-open" };
+    let cmd = if cfg!(target_os = "macos") {
+        "open"
+    } else {
+        "xdg-open"
+    };
     let output = Command::new(cmd)
         .arg(&url)
         .output()
@@ -872,10 +881,15 @@ fn find_parent_app(pid: u32) -> Result<String, String> {
 
         // Move to parent
         if ppid <= 1 {
-            crate::debug_log::log_info("[open_session] Reached root, checking current comm one more time");
+            crate::debug_log::log_info(
+                "[open_session] Reached root, checking current comm one more time",
+            );
             // Check current process one more time before giving up
             if let Some(app_name) = get_app_name(&comm) {
-                crate::debug_log::log_info(&format!("[open_session] Found app at root: {}", app_name));
+                crate::debug_log::log_info(&format!(
+                    "[open_session] Found app at root: {}",
+                    app_name
+                ));
                 return Ok(app_name.to_string());
             }
             break;
@@ -1137,7 +1151,10 @@ mod tests {
         assert_eq!(get_app_name("wezterm-gui"), Some("WezTerm"));
         assert_eq!(get_app_name("foot"), Some("foot"));
         assert_eq!(get_app_name("gnome-terminal"), Some("GNOME Terminal"));
-        assert_eq!(get_app_name("gnome-terminal-server"), Some("GNOME Terminal"));
+        assert_eq!(
+            get_app_name("gnome-terminal-server"),
+            Some("GNOME Terminal")
+        );
         assert_eq!(get_app_name("konsole"), Some("Konsole"));
         assert_eq!(get_app_name("xfce4-terminal"), Some("Xfce Terminal"));
         assert_eq!(get_app_name("xterm"), Some("xterm"));
@@ -1327,8 +1344,14 @@ mod tests {
 
     #[test]
     fn test_encode_path_for_url() {
-        assert_eq!(encode_path_for_url("/Users/foo/project"), "/Users/foo/project");
-        assert_eq!(encode_path_for_url("/Users/John Smith/My Project"), "/Users/John%20Smith/My%20Project");
+        assert_eq!(
+            encode_path_for_url("/Users/foo/project"),
+            "/Users/foo/project"
+        );
+        assert_eq!(
+            encode_path_for_url("/Users/John Smith/My Project"),
+            "/Users/John%20Smith/My%20Project"
+        );
         assert_eq!(encode_path_for_url("/path/with#hash"), "/path/with%23hash");
         assert_eq!(encode_path_for_url("/path/with&amp"), "/path/with%26amp");
     }
@@ -1336,7 +1359,10 @@ mod tests {
     #[test]
     fn test_find_jetbrains_project_root() {
         // No .idea anywhere — returns original path
-        assert_eq!(find_jetbrains_project_root("/tmp/nonexistent/sub"), "/tmp/nonexistent/sub");
+        assert_eq!(
+            find_jetbrains_project_root("/tmp/nonexistent/sub"),
+            "/tmp/nonexistent/sub"
+        );
 
         // Root path — returns as-is
         assert_eq!(find_jetbrains_project_root("/"), "/");
@@ -1370,9 +1396,6 @@ mod tests {
             get_app_name("/Users/user/Library/Application Support/iTerm2/iTermServer-3.6.6"),
             Some("iTerm")
         );
-        assert_eq!(
-            get_app_name("iTermServer-3.5.0"),
-            Some("iTerm")
-        );
+        assert_eq!(get_app_name("iTermServer-3.5.0"), Some("iTerm"));
     }
 }

--- a/src-tauri/src/cli/bg_protocol.rs
+++ b/src-tauri/src/cli/bg_protocol.rs
@@ -20,7 +20,9 @@ impl Request {
     /// caller appends `\n` before send).
     pub fn to_wire(&self) -> String {
         let mut v = serde_json::to_value(self).expect("Request always serializes");
-        v.as_object_mut().unwrap().insert("proto".to_string(), serde_json::json!(1));
+        v.as_object_mut()
+            .unwrap()
+            .insert("proto".to_string(), serde_json::json!(1));
         serde_json::to_string(&v).expect("Value always serializes")
     }
 }
@@ -66,7 +68,9 @@ mod tests {
 
     #[test]
     fn subscribe_serializes_with_proto() {
-        let req = Request::Subscribe { short: "abc12345".to_string() };
+        let req = Request::Subscribe {
+            short: "abc12345".to_string(),
+        };
         let wire = req.to_wire();
         let v: serde_json::Value = serde_json::from_str(&wire).unwrap();
         assert_eq!(v["proto"], 1);
@@ -91,9 +95,7 @@ mod tests {
 
     #[test]
     fn parse_kill_ok_reply() {
-        let reply: OneShotReply = serde_json::from_str(
-            r#"{"ok":true,"op":"kill"}"#
-        ).unwrap();
+        let reply: OneShotReply = serde_json::from_str(r#"{"ok":true,"op":"kill"}"#).unwrap();
         assert!(reply.ok);
         assert_eq!(reply.op.as_deref(), Some("kill"));
     }
@@ -101,10 +103,14 @@ mod tests {
     #[test]
     fn parse_error_reply() {
         let reply: OneShotReply = serde_json::from_str(
-            r#"{"ok":false,"error":"malformed request: Invalid input","code":"EUNKNOWN"}"#
-        ).unwrap();
+            r#"{"ok":false,"error":"malformed request: Invalid input","code":"EUNKNOWN"}"#,
+        )
+        .unwrap();
         assert!(!reply.ok);
-        assert_eq!(reply.error.as_deref(), Some("malformed request: Invalid input"));
+        assert_eq!(
+            reply.error.as_deref(),
+            Some("malformed request: Invalid input")
+        );
     }
 
     #[test]

--- a/src-tauri/src/cli/mod.rs
+++ b/src-tauri/src/cli/mod.rs
@@ -82,7 +82,7 @@ pub enum Commands {
 
     /// View conversation for a session
     View {
-        /// Session ID (UUID or unique prefix)
+        /// Session key (`provider:id`), session ID, or unique prefix
         session_id: String,
 
         /// Show only the last N messages
@@ -161,7 +161,7 @@ pub enum Commands {
 
     /// Show tasks/todos for a session
     Tasks {
-        /// Session ID (UUID or unique prefix)
+        /// Session key (`provider:id`), session ID, or unique prefix
         session_id: String,
     },
 
@@ -257,7 +257,7 @@ pub enum Commands {
         /// Sort direction: asc or desc
         #[arg(long, value_enum, default_value_t = CostSortDir::Desc, help = "Sort direction (asc = oldest/cheapest first, desc = newest/most expensive first)")]
         sort_dir: CostSortDir,
-        /// Show cost breakdown for a single session by full id or an 8+ char prefix. Use --session-prefix for shorter prefixes. Incompatible with --daily/--weekly/--project.
+        /// Show cost breakdown for a single session by provider-scoped key, full id, or an 8+ char prefix. Use --session-prefix for shorter prefixes. Incompatible with --daily/--weekly/--project.
         #[arg(long, conflicts_with_all = ["daily", "weekly", "project", "session_prefix"])]
         session: Option<String>,
         /// Show cost breakdown for a single session by id prefix (any length, must be unique). Incompatible with --daily/--weekly/--project.
@@ -471,6 +471,8 @@ fn cmd_status(project_filter: Option<&str>, pretty: bool) -> Result<(), String> 
         .map(|s| {
             serde_json::json!({
                 "id": s.id,
+                "sessionKey": s.session_key,
+                "provider": s.provider,
                 "sessionName": s.session_name,
                 "pendingToolName": s.pending_tool_name,
             })
@@ -487,8 +489,9 @@ fn cmd_status(project_filter: Option<&str>, pretty: bool) -> Result<(), String> 
 }
 
 fn cmd_view(session_id: &str, last: Option<usize>, pretty: bool) -> Result<(), String> {
-    let resolved_id = resolve_session_id_lightweight(session_id)?;
-    let mut conversation = session::conversation::get_conversation_data(&resolved_id)?;
+    let (resolved_id, provider) = resolve_session_reference_lightweight(session_id)?;
+    let mut conversation =
+        session::conversation::get_conversation_data_for_provider(&resolved_id, provider)?;
 
     if let Some(n) = last {
         let len = conversation.messages.len();
@@ -713,7 +716,9 @@ fn cmd_watch(
     use std::io::Write;
 
     let interval = std::time::Duration::from_secs(interval_secs);
-    let mut prev_state: HashMap<String, (String, Option<String>)> = HashMap::new();
+    // Provider-scoped key prevents a Codex/Cursor session from overwriting a
+    // Claude session with the same opaque ID in the watch state.
+    let mut prev_state: HashMap<String, (String, Option<String>, String)> = HashMap::new();
 
     loop {
         let (sessions, _) = match session::enrichment::detect_and_enrich_sessions() {
@@ -733,10 +738,10 @@ fn cmd_watch(
                 }
             }
 
-            current_ids.insert(s.id.clone());
+            current_ids.insert(s.session_key.clone());
 
             let status_str = serde_json::to_string(&s.status).unwrap_or_default();
-            let prev = prev_state.get(&s.id);
+            let prev = prev_state.get(&s.session_key);
 
             let event = match prev {
                 None => {
@@ -746,7 +751,7 @@ fn cmd_watch(
                         Some("started")
                     }
                 }
-                Some((old_status, old_tool)) => {
+                Some((old_status, old_tool, _)) => {
                     if *old_status != status_str || *old_tool != s.pending_tool_name {
                         Some("status_changed")
                     } else {
@@ -764,6 +769,8 @@ fn cmd_watch(
                 let line = serde_json::json!({
                     "event": event_name,
                     "sessionId": s.id,
+                    "sessionKey": s.session_key,
+                    "provider": s.provider,
                     "session": session_data,
                     "timestamp": chrono::Utc::now().to_rfc3339(),
                 });
@@ -771,25 +778,33 @@ fn cmd_watch(
                 let _ = std::io::stdout().flush();
             }
 
-            prev_state.insert(s.id.clone(), (status_str, s.pending_tool_name.clone()));
+            prev_state.insert(
+                s.session_key.clone(),
+                (status_str, s.pending_tool_name.clone(), s.id.clone()),
+            );
         }
 
         // Detect stopped sessions
-        let stopped: Vec<String> = prev_state
+        let stopped: Vec<(String, String)> = prev_state
             .keys()
-            .filter(|id| !current_ids.contains(*id))
-            .cloned()
+            .filter(|session_key| !current_ids.contains(*session_key))
+            .filter_map(|session_key| {
+                prev_state
+                    .get(session_key)
+                    .map(|state| (session_key.clone(), state.2.clone()))
+            })
             .collect();
 
-        for id in &stopped {
+        for (session_key, session_id) in &stopped {
             let line = serde_json::json!({
                 "event": "stopped",
-                "sessionId": id,
+                "sessionId": session_id,
+                "sessionKey": session_key,
                 "timestamp": chrono::Utc::now().to_rfc3339(),
             });
             println!("{}", serde_json::to_string(&line).unwrap_or_default());
             let _ = std::io::stdout().flush();
-            prev_state.remove(id);
+            prev_state.remove(session_key);
         }
 
         std::thread::sleep(interval);
@@ -797,11 +812,20 @@ fn cmd_watch(
 }
 
 fn cmd_tasks(session_id: &str, pretty: bool) -> Result<(), String> {
-    let resolved_id = resolve_session_id_lightweight(session_id)?;
+    let (resolved_id, provider) = resolve_session_reference_lightweight(session_id)?;
+    if let Some(provider) = provider {
+        if provider != session::SessionProvider::ClaudeCode {
+            return Err(format!(
+                "tasks are only available for Claude Code sessions; '{}' belongs to {:?}",
+                resolved_id, provider
+            ));
+        }
+    }
     let tasks = read_session_tasks(&resolved_id)?;
 
     let output = serde_json::json!({
         "sessionId": resolved_id,
+        "provider": provider.unwrap_or(session::SessionProvider::ClaudeCode),
         "tasks": tasks,
         "total": tasks.len(),
         "completed": tasks.iter().filter(|t| t.get("status").and_then(|s| s.as_str()) == Some("completed")).count(),
@@ -829,17 +853,18 @@ enum SessionLookupKind {
 
 /// Resolve a session identifier (full id or prefix) against all known sessions.
 ///
-/// Returns the full `session_id`, or an error if the input is empty, too short
-/// for the chosen kind, or matches zero/multiple sessions.
-fn resolve_cost_session_id(
+/// Returns the full `(session_id, provider)` identity, or an error if the input
+/// is empty, too short for the chosen kind, or matches zero/multiple sessions.
+fn resolve_cost_session_identity(
     sessions: &[session::cost::SessionCostRecord],
     needle: &str,
     kind: SessionLookupKind,
-) -> Result<String, String> {
-    if needle.is_empty() {
+) -> Result<(String, String), String> {
+    let (provider_filter, raw_needle) = parse_provider_scoped_cost_reference(needle);
+    if raw_needle.is_empty() {
         return Err("Session id must not be empty".to_string());
     }
-    if kind == SessionLookupKind::Session && needle.len() < SESSION_MIN_LEN {
+    if kind == SessionLookupKind::Session && raw_needle.len() < SESSION_MIN_LEN {
         return Err(format!(
             "--session value '{}' is too short — must be at least {} characters, or use --session-prefix for shorter prefixes",
             needle, SESSION_MIN_LEN
@@ -848,22 +873,34 @@ fn resolve_cost_session_id(
 
     let mut matches = std::collections::BTreeSet::new();
     for s in sessions {
-        if s.session_id.starts_with(needle) {
-            matches.insert(s.session_id.clone());
+        if provider_filter.is_some_and(|provider| s.provider != provider) {
+            continue;
+        }
+        if s.session_id.starts_with(raw_needle) {
+            // Cost data spans providers; keep the provider namespace in the
+            // resolver so identical opaque IDs cannot be aggregated together.
+            matches.insert((s.session_id.clone(), s.provider.clone()));
         }
     }
 
     // For `--session`, a full-id exact match wins even if other sessions share
-    // the same prefix (vanishingly rare, but deterministic).
-    if kind == SessionLookupKind::Session && matches.contains(needle) {
-        return Ok(needle.to_string());
+    // the same prefix, but only when exactly one provider owns that ID.
+    if kind == SessionLookupKind::Session {
+        let exact: Vec<_> = matches.iter().filter(|(id, _)| id == raw_needle).collect();
+        if exact.len() == 1 {
+            let (_, provider) = exact[0];
+            return Ok((raw_needle.to_string(), provider.clone()));
+        }
     }
 
     match matches.len() {
         0 => Err(format!("No session matching '{}'", needle)),
-        1 => Ok(matches.into_iter().next().unwrap()),
+        1 => {
+            let (id, provider) = matches.into_iter().next().unwrap();
+            Ok((id, provider))
+        }
         n => {
-            let ids: Vec<String> = matches.into_iter().collect();
+            let ids: Vec<String> = matches.into_iter().map(|(id, _)| id).collect();
             let shown = ids.iter().take(5).cloned().collect::<Vec<_>>().join(", ");
             let suffix = if n > 5 {
                 format!(" (and {} more)", n - 5)
@@ -878,10 +915,30 @@ fn resolve_cost_session_id(
     }
 }
 
+fn parse_provider_scoped_cost_reference(reference: &str) -> (Option<&str>, &str) {
+    let Some((provider, raw_id)) = reference.split_once(':') else {
+        return (None, reference);
+    };
+    if raw_id.is_empty() || !matches!(provider, "claudeCode" | "codex" | "cursor") {
+        return (None, reference);
+    }
+    (Some(provider), raw_id)
+}
+
+#[cfg(test)]
+fn resolve_cost_session_id(
+    sessions: &[session::cost::SessionCostRecord],
+    needle: &str,
+    kind: SessionLookupKind,
+) -> Result<String, String> {
+    resolve_cost_session_identity(sessions, needle, kind).map(|(session_id, _)| session_id)
+}
+
 /// Rows returned by filtering cost data down to a single session.
 #[derive(Debug)]
 struct SessionCostBreakdown {
     session_id: String,
+    provider: String,
     session_name: String,
     project: String,
     project_name: String,
@@ -906,11 +963,13 @@ struct DailyRow {
 fn build_session_breakdown(
     all_sessions: &[session::cost::SessionCostRecord],
     session_id: &str,
+    provider: &str,
     since_date: Option<chrono::NaiveDate>,
 ) -> Result<SessionCostBreakdown, String> {
     let mut records: Vec<&session::cost::SessionCostRecord> = all_sessions
         .iter()
         .filter(|s| s.session_id == session_id)
+        .filter(|s| s.provider == provider)
         .filter(|s| match since_date {
             Some(since_d) => chrono::NaiveDate::parse_from_str(&s.date, "%Y-%m-%d")
                 .map(|d| d >= since_d)
@@ -965,6 +1024,7 @@ fn build_session_breakdown(
     let first = records.first().unwrap();
     Ok(SessionCostBreakdown {
         session_id: session_id.to_string(),
+        provider: provider.to_string(),
         session_name: first.session_name.clone(),
         project: first.project.clone(),
         project_name: first.project_name.clone(),
@@ -992,6 +1052,7 @@ fn breakdown_to_json(b: &SessionCostBreakdown) -> serde_json::Value {
         .collect();
     serde_json::json!({
         "sessionId": b.session_id,
+        "provider": b.provider,
         "sessionName": b.session_name,
         "project": b.project,
         "projectName": b.project_name,
@@ -1027,8 +1088,8 @@ fn cmd_cost_session(
         .flat_map(|p| p.sessions.iter().cloned())
         .collect();
 
-    let session_id = resolve_cost_session_id(&all_sessions, needle, kind)?;
-    let breakdown = build_session_breakdown(&all_sessions, &session_id, since_date)?;
+    let (session_id, provider) = resolve_cost_session_identity(&all_sessions, needle, kind)?;
+    let breakdown = build_session_breakdown(&all_sessions, &session_id, &provider, since_date)?;
 
     print_json(&breakdown_to_json(&breakdown), pretty)
 }
@@ -1252,7 +1313,9 @@ fn compact_session(s: &session::enrichment::Session) -> serde_json::Value {
 /// Full session: all fields, sanitized, with null fields omitted.
 fn full_session(s: session::enrichment::Session) -> serde_json::Value {
     // Re-read full first prompt so we can sanitize BEFORE truncation.
-    let first_prompt = find_first_prompt_raw_for_session(&s.id)
+    let first_prompt = (s.provider == session::SessionProvider::ClaudeCode)
+        .then(|| find_first_prompt_raw_for_session(&s.id))
+        .flatten()
         .map(|full| {
             let clean = strip_system_tags(&full);
             let trimmed = clean.trim().to_string();
@@ -1306,8 +1369,10 @@ fn full_session(s: session::enrichment::Session) -> serde_json::Value {
     if let Some(input) = s.pending_tool_input {
         obj.insert("pendingToolInput".to_string(), input);
     }
-    if let Some(summary) = get_task_summary(&s.id) {
-        obj.insert("taskProgress".to_string(), summary);
+    if s.provider == session::SessionProvider::ClaudeCode {
+        if let Some(summary) = get_task_summary(&s.id) {
+            obj.insert("taskProgress".to_string(), summary);
+        }
     }
 
     json
@@ -1317,6 +1382,10 @@ fn insert_session_contract(json: &mut serde_json::Value, session: &session::enri
     let Some(object) = json.as_object_mut() else {
         return;
     };
+    object.insert(
+        "sessionKey".to_string(),
+        serde_json::json!(session.session_key),
+    );
     object.insert("provider".to_string(), serde_json::json!(session.provider));
     object.insert("surface".to_string(), serde_json::json!(session.surface));
     object.insert(
@@ -1346,7 +1415,14 @@ fn insert_session_contract(json: &mut serde_json::Value, session: &session::enri
 // ── Helpers ─────────────────────────────────────────────────────────
 
 fn enrich_history_entry(entry: session::HistoryEntry) -> serde_json::Value {
-    let first_prompt = find_first_prompt_raw_for_session(&entry.session_id)
+    // Only Claude Code owns ~/.claude/projects/*.jsonl. Looking up a Codex or
+    // Cursor ID in that namespace can return an unrelated transcript when the
+    // opaque IDs happen to collide.
+    let first_prompt = entry
+        .provider
+        .eq_ignore_ascii_case("claudeCode")
+        .then(|| find_first_prompt_raw_for_session(&entry.session_id))
+        .flatten()
         .map(|full| {
             let clean = strip_system_tags(&full);
             let trimmed = clean.trim().to_string();
@@ -1385,7 +1461,9 @@ fn enrich_history_entry(entry: session::HistoryEntry) -> serde_json::Value {
 }
 
 fn enrich_search_hit(hit: session::DeepSearchHit) -> serde_json::Value {
-    let (project_path, modified) = if hit.provider.eq_ignore_ascii_case("codex") {
+    let (project_path, modified) = if hit.provider.eq_ignore_ascii_case("codex")
+        || hit.provider.eq_ignore_ascii_case("cursor")
+    {
         (hit.project_path.clone(), hit.modified.clone())
     } else {
         let (project_path_encoded, modified) = find_session_metadata(&hit.session_id);
@@ -1596,22 +1674,36 @@ fn get_task_summary(session_id: &str) -> Option<serde_json::Value> {
     }))
 }
 
-fn resolve_session_id_lightweight(prefix: &str) -> Result<String, String> {
-    if prefix.len() >= 36 {
-        return Ok(prefix.to_string());
-    }
-
-    let home_dir = dirs::home_dir().ok_or("Failed to get home directory")?;
-    resolve_session_id_lightweight_under(prefix, &home_dir)
-}
-
+#[cfg(test)]
 fn resolve_session_id_lightweight_under(
     prefix: &str,
     home_dir: &std::path::Path,
 ) -> Result<String, String> {
+    resolve_session_reference_lightweight_under(prefix, home_dir).map(|(id, _)| id)
+}
+
+/// Resolve a raw ID/prefix while retaining the provider namespace when it is
+/// discoverable. A full ID that cannot be enumerated keeps `None` for
+/// backwards compatibility with older installations; conversation lookup can
+/// then use its legacy provider fallback.
+fn resolve_session_reference_lightweight(
+    prefix: &str,
+) -> Result<(String, Option<session::SessionProvider>), String> {
+    let home_dir = dirs::home_dir().ok_or("Failed to get home directory")?;
+    resolve_session_reference_lightweight_under(prefix, &home_dir)
+}
+
+fn resolve_session_reference_lightweight_under(
+    reference: &str,
+    home_dir: &std::path::Path,
+) -> Result<(String, Option<session::SessionProvider>), String> {
+    let (provider_filter, prefix) = parse_provider_scoped_reference(reference)
+        .map_or((None, reference), |(provider, raw_prefix)| {
+            (Some(provider), raw_prefix)
+        });
     let projects_dir = home_dir.join(".claude").join("projects");
 
-    let mut matches: Vec<String> = Vec::new();
+    let mut matches: Vec<session::SessionIdentity> = Vec::new();
 
     if let Ok(project_entries) = std::fs::read_dir(&projects_dir) {
         for project_entry in project_entries.flatten() {
@@ -1626,8 +1718,12 @@ fn resolve_session_id_lightweight_under(
                         if let Some(stem) = file_path.file_stem().and_then(|s| s.to_str()) {
                             if stem.starts_with(prefix) && !stem.starts_with("agent-") {
                                 let id = stem.to_string();
-                                if !matches.contains(&id) {
-                                    matches.push(id);
+                                let identity = session::SessionIdentity::new(
+                                    session::SessionProvider::ClaudeCode,
+                                    id,
+                                );
+                                if !matches.contains(&identity) {
+                                    matches.push(identity);
                                 }
                             }
                         }
@@ -1637,34 +1733,69 @@ fn resolve_session_id_lightweight_under(
         }
     }
 
-    matches.extend(session::codex_session_ids(home_dir, prefix));
-    matches.extend(session::cursor_session_ids(home_dir, prefix));
+    matches.extend(
+        session::codex_session_ids(home_dir, prefix)
+            .into_iter()
+            .map(|id| session::SessionIdentity::new(session::SessionProvider::Codex, id)),
+    );
+    matches.extend(
+        session::cursor_session_ids(home_dir, prefix)
+            .into_iter()
+            .map(|id| session::SessionIdentity::new(session::SessionProvider::Cursor, id)),
+    );
 
-    resolve_session_id_matches(prefix, matches)
+    if let Some(provider) = provider_filter {
+        matches.retain(|identity| identity.provider == provider);
+    }
+
+    resolve_session_reference_matches(reference, prefix, provider_filter, matches)
 }
 
-fn resolve_session_id_matches(prefix: &str, matches: Vec<String>) -> Result<String, String> {
-    let mut matches = matches;
-    matches.sort();
+/// Parse the canonical provider-scoped key emitted by `list`/`watch`.
+/// Unknown prefixes remain ordinary raw references for backwards compatibility.
+fn parse_provider_scoped_reference(reference: &str) -> Option<(session::SessionProvider, &str)> {
+    let (provider, raw_prefix) = reference.split_once(':')?;
+    if raw_prefix.is_empty() {
+        return None;
+    }
+    let provider = match provider {
+        "claudeCode" => session::SessionProvider::ClaudeCode,
+        "codex" => session::SessionProvider::Codex,
+        "cursor" => session::SessionProvider::Cursor,
+        _ => return None,
+    };
+    Some((provider, raw_prefix))
+}
+
+fn resolve_session_reference_matches(
+    reference: &str,
+    raw_prefix: &str,
+    provider_filter: Option<session::SessionProvider>,
+    mut matches: Vec<session::SessionIdentity>,
+) -> Result<(String, Option<session::SessionProvider>), String> {
+    matches.sort_by_key(|identity| identity.key());
     matches.dedup();
 
     match matches.len() {
         0 => {
             // If it looks like a full UUID, let it through (might be a valid ID
             // in a project dir we couldn't enumerate). Otherwise, fail clearly.
-            if prefix.len() >= 32 {
-                Ok(prefix.to_string())
+            if raw_prefix.len() >= 32 {
+                Ok((raw_prefix.to_string(), provider_filter))
             } else {
                 Err(format!(
                     "No session found matching prefix '{}' across Claude Code, Codex, and Cursor",
-                    prefix
+                    reference
                 ))
             }
         }
-        1 => Ok(matches.into_iter().next().unwrap()),
+        1 => {
+            let identity = matches.into_iter().next().unwrap();
+            Ok((identity.session_id, Some(identity.provider)))
+        }
         n => Err(format!(
             "Ambiguous session ID prefix '{}' matches {} sessions across Claude Code, Codex, and Cursor",
-            prefix, n
+            reference, n
         )),
     }
 }
@@ -1678,6 +1809,7 @@ mod session_formatter_tests {
     fn codex_subagent() -> session::enrichment::Session {
         session::enrichment::Session {
             id: "child-thread".to_string(),
+            session_key: "codex:child-thread".to_string(),
             pid: 0,
             session_name: "child".to_string(),
             custom_title: None,
@@ -1710,6 +1842,7 @@ mod session_formatter_tests {
     }
 
     fn assert_codex_contract(value: &serde_json::Value) {
+        assert_eq!(value["sessionKey"], "codex:child-thread");
         assert_eq!(value["provider"], "codex");
         assert_eq!(value["surface"], "app");
         assert_eq!(value["agentKind"], "subagent");
@@ -1784,6 +1917,65 @@ mod session_formatter_tests {
     }
 
     #[test]
+    fn cursor_search_wiring_preserves_metadata_and_filters_project() {
+        let home = tempfile::tempdir().unwrap();
+        let session_id = "dddddddd-dddd-dddd-dddd-dddddddddddd";
+        let project_path = home.path().join("cursor-project");
+        std::fs::create_dir_all(&project_path).unwrap();
+        let project_key = format!(
+            "{}-cursor-project",
+            home.path()
+                .strip_prefix("/")
+                .unwrap()
+                .to_string_lossy()
+                .replace('/', "-")
+        );
+        let transcript_dir = home
+            .path()
+            .join(".cursor/projects")
+            .join(project_key)
+            .join("agent-transcripts")
+            .join(session_id);
+        std::fs::create_dir_all(&transcript_dir).unwrap();
+        std::fs::write(
+            transcript_dir.join(format!("{session_id}.jsonl")),
+            r#"{"role":"user","message":{"content":[{"type":"text","text":"<user_query>cursor search wiring marker</user_query>"}]}}
+"#,
+        )
+        .unwrap();
+
+        let matching = cmd_search_output(
+            home.path(),
+            "cursor search wiring marker",
+            Some("cursor-project"),
+            20,
+            false,
+            false,
+        )
+        .unwrap();
+        let hits = matching["hits"].as_array().unwrap();
+        assert_eq!(hits.len(), 1);
+        assert_eq!(hits[0]["sessionId"], session_id);
+        assert_eq!(hits[0]["provider"], "cursor");
+        assert_eq!(hits[0]["surface"], "cursor");
+        assert!(hits[0]["projectPath"]
+            .as_str()
+            .unwrap()
+            .ends_with("cursor-project"));
+
+        let nonmatching = cmd_search_output(
+            home.path(),
+            "cursor search wiring marker",
+            Some("other-project"),
+            20,
+            false,
+            false,
+        )
+        .unwrap();
+        assert!(nonmatching["hits"].as_array().unwrap().is_empty());
+    }
+
+    #[test]
     fn session_prefix_resolves_unique_codex_id() {
         let home = tempfile::tempdir().unwrap();
         let sessions = home.path().join(".codex/sessions/2026/07/13");
@@ -1819,6 +2011,34 @@ mod session_formatter_tests {
         assert!(error.contains("Ambiguous session ID prefix 'shared'"));
         assert!(error.contains("matches 2 sessions"));
         assert!(error.contains("Claude Code, Codex, and Cursor"));
+    }
+
+    #[test]
+    fn exact_same_id_is_ambiguous_across_provider_namespaces() {
+        let home = tempfile::tempdir().unwrap();
+        let same_id = "same-provider-id";
+        let claude_project = home.path().join(".claude/projects/project");
+        std::fs::create_dir_all(&claude_project).unwrap();
+        std::fs::write(claude_project.join(format!("{same_id}.jsonl")), "").unwrap();
+
+        let codex_sessions = home.path().join(".codex/sessions/2026/07/13");
+        std::fs::create_dir_all(&codex_sessions).unwrap();
+        std::fs::write(
+            codex_sessions.join("rollout-same-provider-id.jsonl"),
+            format!(
+                r#"{{"timestamp":"2026-07-13T02:03:04Z","type":"session_meta","payload":{{"id":"{same_id}","cwd":"/tmp/codex","source":"cli","originator":"codex-tui"}}}}"#
+            ),
+        )
+        .unwrap();
+
+        let error = resolve_session_reference_lightweight_under(same_id, home.path()).unwrap_err();
+        assert!(error.contains("matches 2 sessions"));
+
+        let (resolved_id, provider) =
+            resolve_session_reference_lightweight_under(&format!("codex:{same_id}"), home.path())
+                .unwrap();
+        assert_eq!(resolved_id, same_id);
+        assert_eq!(provider, Some(SessionProvider::Codex));
     }
 
     #[test]
@@ -1912,6 +2132,39 @@ mod cost_session_tests {
     }
 
     #[test]
+    fn cost_session_id_collision_across_providers_is_not_silently_merged() {
+        let mut sessions = fixtures();
+        let mut codex = sessions[0].clone();
+        codex.provider = "codex".to_string();
+        sessions.push(codex);
+
+        let err = resolve_cost_session_id(
+            &sessions,
+            "aaaa1111-bbbb-cccc-dddd-eeeeeeeeeeee",
+            SessionLookupKind::Session,
+        )
+        .unwrap_err();
+        assert!(err.contains("Ambiguous"));
+    }
+
+    #[test]
+    fn provider_scoped_cost_key_selects_one_collision_namespace() {
+        let mut sessions = fixtures();
+        let mut codex = sessions[0].clone();
+        codex.provider = "codex".to_string();
+        sessions.push(codex);
+
+        let (session_id, provider) = resolve_cost_session_identity(
+            &sessions,
+            "codex:aaaa1111-bbbb-cccc-dddd-eeeeeeeeeeee",
+            SessionLookupKind::Session,
+        )
+        .unwrap();
+        assert_eq!(session_id, "aaaa1111-bbbb-cccc-dddd-eeeeeeeeeeee");
+        assert_eq!(provider, "codex");
+    }
+
+    #[test]
     fn session_prefix_unambiguous() {
         let sessions = fixtures();
         let got =
@@ -1963,8 +2216,13 @@ mod cost_session_tests {
     #[test]
     fn build_breakdown_sums_across_days() {
         let sessions = fixtures();
-        let b = build_session_breakdown(&sessions, "aaaa1111-bbbb-cccc-dddd-eeeeeeeeeeee", None)
-            .unwrap();
+        let b = build_session_breakdown(
+            &sessions,
+            "aaaa1111-bbbb-cccc-dddd-eeeeeeeeeeee",
+            "claudeCode",
+            None,
+        )
+        .unwrap();
         assert!((b.total_cost - 2.00).abs() < 1e-9);
         assert_eq!(b.total_tokens, 1500);
         assert_eq!(b.daily.len(), 2);
@@ -1982,6 +2240,7 @@ mod cost_session_tests {
         let b = build_session_breakdown(
             &sessions,
             "aaaa1111-bbbb-cccc-dddd-eeeeeeeeeeee",
+            "claudeCode",
             Some(since),
         )
         .unwrap();
@@ -1993,18 +2252,57 @@ mod cost_session_tests {
     #[test]
     fn build_breakdown_empty_for_missing_session() {
         let sessions = fixtures();
-        let err = build_session_breakdown(&sessions, "nonexistent", None).unwrap_err();
+        let err =
+            build_session_breakdown(&sessions, "nonexistent", "claudeCode", None).unwrap_err();
         assert!(err.contains("No cost data"), "got: {}", err);
+    }
+
+    #[test]
+    fn build_breakdown_keeps_provider_namespaces_separate() {
+        let mut sessions = fixtures();
+        let mut codex = sessions[0].clone();
+        codex.provider = "codex".to_string();
+        codex.cost = 99.0;
+        codex.total_tokens = 99_000;
+        sessions.push(codex);
+
+        let claude = build_session_breakdown(
+            &sessions,
+            "aaaa1111-bbbb-cccc-dddd-eeeeeeeeeeee",
+            "claudeCode",
+            None,
+        )
+        .unwrap();
+        assert!((claude.total_cost - 2.0).abs() < 1e-9);
+        assert_eq!(claude.total_tokens, 1_500);
+        assert_eq!(claude.provider, "claudeCode");
+
+        let codex = build_session_breakdown(
+            &sessions,
+            "aaaa1111-bbbb-cccc-dddd-eeeeeeeeeeee",
+            "codex",
+            None,
+        )
+        .unwrap();
+        assert!((codex.total_cost - 99.0).abs() < 1e-9);
+        assert_eq!(codex.total_tokens, 99_000);
+        assert_eq!(codex.provider, "codex");
     }
 
     #[test]
     fn json_output_shape_has_expected_fields() {
         let sessions = fixtures();
-        let b = build_session_breakdown(&sessions, "aaaa1111-bbbb-cccc-dddd-eeeeeeeeeeee", None)
-            .unwrap();
+        let b = build_session_breakdown(
+            &sessions,
+            "aaaa1111-bbbb-cccc-dddd-eeeeeeeeeeee",
+            "claudeCode",
+            None,
+        )
+        .unwrap();
         let v = breakdown_to_json(&b);
         for key in [
             "sessionId",
+            "provider",
             "sessionName",
             "project",
             "projectName",
@@ -2032,8 +2330,13 @@ mod cost_session_tests {
     #[test]
     fn json_compact_is_single_line() {
         let sessions = fixtures();
-        let b = build_session_breakdown(&sessions, "aaaa1111-bbbb-cccc-dddd-eeeeeeeeeeee", None)
-            .unwrap();
+        let b = build_session_breakdown(
+            &sessions,
+            "aaaa1111-bbbb-cccc-dddd-eeeeeeeeeeee",
+            "claudeCode",
+            None,
+        )
+        .unwrap();
         let v = breakdown_to_json(&b);
         let compact = serde_json::to_string(&v).unwrap();
         assert!(
@@ -2048,8 +2351,13 @@ mod cost_session_tests {
     #[test]
     fn json_pretty_is_indented_and_valid() {
         let sessions = fixtures();
-        let b = build_session_breakdown(&sessions, "aaaa1111-bbbb-cccc-dddd-eeeeeeeeeeee", None)
-            .unwrap();
+        let b = build_session_breakdown(
+            &sessions,
+            "aaaa1111-bbbb-cccc-dddd-eeeeeeeeeeee",
+            "claudeCode",
+            None,
+        )
+        .unwrap();
         let v = breakdown_to_json(&b);
         let pretty = serde_json::to_string_pretty(&v).unwrap();
         assert!(pretty.contains('\n'), "pretty output must be multi-line");

--- a/src-tauri/src/cli/mod.rs
+++ b/src-tauri/src/cli/mod.rs
@@ -488,7 +488,7 @@ fn cmd_status(project_filter: Option<&str>, pretty: bool) -> Result<(), String> 
 
 fn cmd_view(session_id: &str, last: Option<usize>, pretty: bool) -> Result<(), String> {
     let resolved_id = resolve_session_id_lightweight(session_id)?;
-    let mut conversation = session::conversation::get_conversation_data(&resolved_id)?;
+    let mut conversation = session::conversation::get_conversation_data(&resolved_id, true)?;
 
     if let Some(n) = last {
         let len = conversation.messages.len();

--- a/src-tauri/src/cli/mod.rs
+++ b/src-tauri/src/cli/mod.rs
@@ -1410,6 +1410,12 @@ fn insert_session_contract(json: &mut serde_json::Value, session: &session::enri
             object.insert(key.to_string(), serde_json::json!(value));
         }
     }
+    if let Some(title) = &session.codex_title {
+        object.insert("codexTitle".to_string(), serde_json::json!(title));
+    }
+    if let Some(title) = &session.cursor_title {
+        object.insert("cursorTitle".to_string(), serde_json::json!(title));
+    }
 }
 
 // ── Helpers ─────────────────────────────────────────────────────────
@@ -1455,6 +1461,16 @@ fn enrich_history_entry(entry: session::HistoryEntry) -> serde_json::Value {
         json.as_object_mut()
             .unwrap()
             .insert("customTitle".to_string(), serde_json::json!(title));
+    }
+    if let Some(title) = entry.codex_title {
+        json.as_object_mut()
+            .unwrap()
+            .insert("codexTitle".to_string(), serde_json::json!(title));
+    }
+    if let Some(title) = entry.cursor_title {
+        json.as_object_mut()
+            .unwrap()
+            .insert("cursorTitle".to_string(), serde_json::json!(title));
     }
 
     json
@@ -1813,6 +1829,8 @@ mod session_formatter_tests {
             pid: 0,
             session_name: "child".to_string(),
             custom_title: None,
+            codex_title: Some("Codex thread title".to_string()),
+            cursor_title: None,
             project_path: "/tmp/project".to_string(),
             git_branch: None,
             first_prompt: "investigate".to_string(),
@@ -1843,6 +1861,7 @@ mod session_formatter_tests {
 
     fn assert_codex_contract(value: &serde_json::Value) {
         assert_eq!(value["sessionKey"], "codex:child-thread");
+        assert_eq!(value["codexTitle"], "Codex thread title");
         assert_eq!(value["provider"], "codex");
         assert_eq!(value["surface"], "app");
         assert_eq!(value["agentKind"], "subagent");

--- a/src-tauri/src/cli/mod.rs
+++ b/src-tauri/src/cli/mod.rs
@@ -1638,6 +1638,7 @@ fn resolve_session_id_lightweight_under(
     }
 
     matches.extend(session::codex_session_ids(home_dir, prefix));
+    matches.extend(session::cursor_session_ids(home_dir, prefix));
 
     resolve_session_id_matches(prefix, matches)
 }
@@ -1655,14 +1656,14 @@ fn resolve_session_id_matches(prefix: &str, matches: Vec<String>) -> Result<Stri
                 Ok(prefix.to_string())
             } else {
                 Err(format!(
-                    "No session found matching prefix '{}' across Claude Code and Codex",
+                    "No session found matching prefix '{}' across Claude Code, Codex, and Cursor",
                     prefix
                 ))
             }
         }
         1 => Ok(matches.into_iter().next().unwrap()),
         n => Err(format!(
-            "Ambiguous session ID prefix '{}' matches {} sessions across Claude Code and Codex",
+            "Ambiguous session ID prefix '{}' matches {} sessions across Claude Code, Codex, and Cursor",
             prefix, n
         )),
     }
@@ -1817,7 +1818,7 @@ mod session_formatter_tests {
 
         assert!(error.contains("Ambiguous session ID prefix 'shared'"));
         assert!(error.contains("matches 2 sessions"));
-        assert!(error.contains("Claude Code and Codex"));
+        assert!(error.contains("Claude Code, Codex, and Cursor"));
     }
 
     #[test]
@@ -1827,7 +1828,7 @@ mod session_formatter_tests {
 
         assert_eq!(
             error,
-            "No session found matching prefix 'missing' across Claude Code and Codex"
+            "No session found matching prefix 'missing' across Claude Code, Codex, and Cursor"
         );
     }
 

--- a/src-tauri/src/cli/mod.rs
+++ b/src-tauri/src/cli/mod.rs
@@ -25,8 +25,6 @@ pub mod bg_backend;
 #[cfg(feature = "pm-orchestration")]
 pub mod bg_protocol;
 #[cfg(feature = "pm-orchestration")]
-pub mod worker_backend;
-#[cfg(feature = "pm-orchestration")]
 pub mod pm;
 #[cfg(feature = "pm-orchestration")]
 pub mod pm_caller;
@@ -40,6 +38,8 @@ pub mod pm_inbox;
 pub mod pm_rpc;
 #[cfg(feature = "pm-orchestration")]
 pub mod pm_worker;
+#[cfg(feature = "pm-orchestration")]
+pub mod worker_backend;
 
 #[derive(Parser)]
 #[command(
@@ -277,9 +277,11 @@ pub fn run(cli: Cli) {
     crate::debug_log::set_quiet(true);
 
     let result = match cli.command {
-        Commands::List { project, status, compact } => {
-            cmd_list(project.as_deref(), status.as_deref(), compact, cli.pretty)
-        }
+        Commands::List {
+            project,
+            status,
+            compact,
+        } => cmd_list(project.as_deref(), status.as_deref(), compact, cli.pretty),
         Commands::Status { project } => cmd_status(project.as_deref(), cli.pretty),
         Commands::View { session_id, last } => cmd_view(&session_id, last, cli.pretty),
         Commands::History { limit } => cmd_history(limit, cli.pretty),
@@ -346,21 +348,38 @@ pub fn run(cli: Cli) {
         #[cfg(feature = "pm-orchestration")]
         Commands::Workers { all } => pm::cmd_workers(all, cli.pretty),
         #[cfg(feature = "pm-orchestration")]
-        Commands::Inbox { consume, clear, worker } => {
-            pm::cmd_inbox(consume, clear, worker, cli.pretty)
-        }
+        Commands::Inbox {
+            consume,
+            clear,
+            worker,
+        } => pm::cmd_inbox(consume, clear, worker, cli.pretty),
         #[cfg(feature = "pm-orchestration")]
         Commands::Adopt { session_id, force } => pm::cmd_adopt(session_id, force, cli.pretty),
-        Commands::Cost { daily, weekly, project, since, sort, sort_dir, session, session_prefix } => {
-            cmd_cost(daily, weekly, project.as_deref(), since.as_deref(), sort, sort_dir, session.as_deref(), session_prefix.as_deref(), cli.pretty)
-        }
+        Commands::Cost {
+            daily,
+            weekly,
+            project,
+            since,
+            sort,
+            sort_dir,
+            session,
+            session_prefix,
+        } => cmd_cost(
+            daily,
+            weekly,
+            project.as_deref(),
+            since.as_deref(),
+            sort,
+            sort_dir,
+            session.as_deref(),
+            session_prefix.as_deref(),
+            cli.pretty,
+        ),
         #[cfg(feature = "pm-orchestration")]
-        Commands::Daemon => {
-            match tokio::runtime::Runtime::new() {
-                Ok(rt) => rt.block_on(pm_daemon::run_daemon()),
-                Err(e) => Err(format!("Failed to create tokio runtime: {}", e)),
-            }
-        }
+        Commands::Daemon => match tokio::runtime::Runtime::new() {
+            Ok(rt) => rt.block_on(pm_daemon::run_daemon()),
+            Err(e) => Err(format!("Failed to create tokio runtime: {}", e)),
+        },
     };
 
     if let Err(e) = result {
@@ -442,9 +461,7 @@ fn cmd_status(project_filter: Option<&str>, pretty: bool) -> Result<(), String> 
             .trim_matches('"')
             .to_string();
         *by_status.entry(status_str).or_insert(0u32) += 1;
-        *by_project
-            .entry(s.session_name.clone())
-            .or_insert(0u32) += 1;
+        *by_project.entry(s.session_name.clone()).or_insert(0u32) += 1;
     }
 
     // Find sessions needing attention
@@ -533,12 +550,7 @@ fn cmd_search_output(
     if query.trim().is_empty() {
         return Err("Search query cannot be empty".to_string());
     }
-    let hits = session::history::deep_search_under(
-        home_dir,
-        query,
-        case_sensitive,
-        whole_word,
-    )?;
+    let hits = session::history::deep_search_under(home_dir, query, case_sensitive, whole_word)?;
 
     let enriched: Vec<serde_json::Value> = hits
         .into_iter()
@@ -673,12 +685,15 @@ fn try_resolve_worker(target: &str) -> Option<String> {
         return None;
     }
     let request = pm_rpc::RpcRequest::List;
-    let response =
-        pm_rpc::rpc_call(&sock_path, &request, Duration::from_secs(2)).ok()?;
+    let response = pm_rpc::rpc_call(&sock_path, &request, Duration::from_secs(2)).ok()?;
     let workers = response.get("workers").and_then(|w| w.as_array())?;
     let ids: Vec<String> = workers
         .iter()
-        .filter_map(|w| w.get("sessionId").and_then(|s| s.as_str()).map(String::from))
+        .filter_map(|w| {
+            w.get("sessionId")
+                .and_then(|s| s.as_str())
+                .map(String::from)
+        })
         .collect();
 
     // Delegate matching to the shared helper in pm_daemon so exact/prefix/
@@ -709,8 +724,7 @@ fn cmd_watch(
             }
         };
 
-        let mut current_ids: std::collections::HashSet<String> =
-            std::collections::HashSet::new();
+        let mut current_ids: std::collections::HashSet<String> = std::collections::HashSet::new();
 
         for s in &sessions {
             if let Some(filter) = project_filter {
@@ -851,7 +865,11 @@ fn resolve_cost_session_id(
         n => {
             let ids: Vec<String> = matches.into_iter().collect();
             let shown = ids.iter().take(5).cloned().collect::<Vec<_>>().join(", ");
-            let suffix = if n > 5 { format!(" (and {} more)", n - 5) } else { String::new() };
+            let suffix = if n > 5 {
+                format!(" (and {} more)", n - 5)
+            } else {
+                String::new()
+            };
             Err(format!(
                 "Ambiguous '{}' matches {} sessions: {}{}",
                 needle, n, shown, suffix
@@ -1097,7 +1115,11 @@ fn cmd_cost(
                 }
             };
             // Flip for descending
-            if sort_dir == CostSortDir::Desc { ord.reverse() } else { ord }
+            if sort_dir == CostSortDir::Desc {
+                ord.reverse()
+            } else {
+                ord
+            }
         });
     };
 
@@ -1134,12 +1156,9 @@ fn cmd_cost(
             };
             use chrono::Datelike;
             let iso = d.iso_week();
-            let week_start = chrono::NaiveDate::from_isoywd_opt(
-                iso.year(),
-                iso.week(),
-                chrono::Weekday::Mon,
-            )
-            .unwrap_or(d);
+            let week_start =
+                chrono::NaiveDate::from_isoywd_opt(iso.year(), iso.week(), chrono::Weekday::Mon)
+                    .unwrap_or(d);
             let key = week_start.format("%Y-%m-%d").to_string();
             let e = by_week.entry(key).or_insert((0.0, 0, 0));
             e.0 += s.cost;
@@ -1187,11 +1206,16 @@ fn cmd_cost(
     sessions.sort_by(|a, b| {
         let ord = match effective_sort {
             CostSortField::Date => a.date.cmp(&b.date),
-            CostSortField::Cost => {
-                a.cost.partial_cmp(&b.cost).unwrap_or(std::cmp::Ordering::Equal)
-            }
+            CostSortField::Cost => a
+                .cost
+                .partial_cmp(&b.cost)
+                .unwrap_or(std::cmp::Ordering::Equal),
         };
-        if sort_dir == CostSortDir::Desc { ord.reverse() } else { ord }
+        if sort_dir == CostSortDir::Desc {
+            ord.reverse()
+        } else {
+            ord
+        }
     });
 
     let output = serde_json::json!({
@@ -1427,7 +1451,7 @@ fn decode_project_path(encoded: &str) -> String {
     //    This works because most path components are alphanumeric.
     if encoded.starts_with('-') {
         let decoded = encoded.replacen('-', "/", 1); // First `-` -> `/`
-        // Replace remaining `-` with `/`, but this is lossy for hyphenated dirs
+                                                     // Replace remaining `-` with `/`, but this is lossy for hyphenated dirs
         return decoded.replace('-', "/");
     }
 
@@ -1780,11 +1804,7 @@ mod session_formatter_tests {
         let home = tempfile::tempdir().unwrap();
         let claude_project = home.path().join(".claude/projects/project");
         std::fs::create_dir_all(&claude_project).unwrap();
-        std::fs::write(
-            claude_project.join("shared-claude-session.jsonl"),
-            "",
-        )
-        .unwrap();
+        std::fs::write(claude_project.join("shared-claude-session.jsonl"), "").unwrap();
         let codex_sessions = home.path().join(".codex/sessions/2026/07/13");
         std::fs::create_dir_all(&codex_sessions).unwrap();
         std::fs::write(
@@ -1851,10 +1871,34 @@ mod cost_session_tests {
 
     fn fixtures() -> Vec<SessionCostRecord> {
         vec![
-            rec("aaaa1111-bbbb-cccc-dddd-eeeeeeeeeeee", "2026-04-10", 1.25, 1000, "sonnet"),
-            rec("aaaa1111-bbbb-cccc-dddd-eeeeeeeeeeee", "2026-04-11", 0.75, 500, "sonnet"),
-            rec("aaaa2222-bbbb-cccc-dddd-ffffffffffff", "2026-04-10", 0.50, 200, "haiku"),
-            rec("bbbb3333-cccc-dddd-eeee-000000000000", "2026-04-11", 2.00, 5000, "opus"),
+            rec(
+                "aaaa1111-bbbb-cccc-dddd-eeeeeeeeeeee",
+                "2026-04-10",
+                1.25,
+                1000,
+                "sonnet",
+            ),
+            rec(
+                "aaaa1111-bbbb-cccc-dddd-eeeeeeeeeeee",
+                "2026-04-11",
+                0.75,
+                500,
+                "sonnet",
+            ),
+            rec(
+                "aaaa2222-bbbb-cccc-dddd-ffffffffffff",
+                "2026-04-10",
+                0.50,
+                200,
+                "haiku",
+            ),
+            rec(
+                "bbbb3333-cccc-dddd-eeee-000000000000",
+                "2026-04-11",
+                2.00,
+                5000,
+                "opus",
+            ),
         ]
     }
 
@@ -1869,15 +1913,16 @@ mod cost_session_tests {
     #[test]
     fn session_prefix_unambiguous() {
         let sessions = fixtures();
-        let got = resolve_cost_session_id(&sessions, "bbbb3333", SessionLookupKind::Session).unwrap();
+        let got =
+            resolve_cost_session_id(&sessions, "bbbb3333", SessionLookupKind::Session).unwrap();
         assert_eq!(got, "bbbb3333-cccc-dddd-eeee-000000000000");
     }
 
     #[test]
     fn session_prefix_too_short_for_session_flag() {
         let sessions = fixtures();
-        let err = resolve_cost_session_id(&sessions, "aaaa", SessionLookupKind::Session)
-            .unwrap_err();
+        let err =
+            resolve_cost_session_id(&sessions, "aaaa", SessionLookupKind::Session).unwrap_err();
         assert!(err.contains("too short"), "got: {}", err);
         assert!(err.contains("--session-prefix"), "got: {}", err);
     }
@@ -1892,8 +1937,8 @@ mod cost_session_tests {
     #[test]
     fn session_prefix_ambiguous_lists_candidates() {
         let sessions = fixtures();
-        let err = resolve_cost_session_id(&sessions, "aaaa", SessionLookupKind::Prefix)
-            .unwrap_err();
+        let err =
+            resolve_cost_session_id(&sessions, "aaaa", SessionLookupKind::Prefix).unwrap_err();
         assert!(err.contains("Ambiguous"), "got: {}", err);
         assert!(err.contains("aaaa1111-"), "got: {}", err);
         assert!(err.contains("aaaa2222-"), "got: {}", err);
@@ -1902,8 +1947,8 @@ mod cost_session_tests {
     #[test]
     fn session_prefix_no_match_errors() {
         let sessions = fixtures();
-        let err = resolve_cost_session_id(&sessions, "zzzzzzzz", SessionLookupKind::Prefix)
-            .unwrap_err();
+        let err =
+            resolve_cost_session_id(&sessions, "zzzzzzzz", SessionLookupKind::Prefix).unwrap_err();
         assert!(err.contains("No session matching"), "got: {}", err);
     }
 
@@ -1917,12 +1962,8 @@ mod cost_session_tests {
     #[test]
     fn build_breakdown_sums_across_days() {
         let sessions = fixtures();
-        let b = build_session_breakdown(
-            &sessions,
-            "aaaa1111-bbbb-cccc-dddd-eeeeeeeeeeee",
-            None,
-        )
-        .unwrap();
+        let b = build_session_breakdown(&sessions, "aaaa1111-bbbb-cccc-dddd-eeeeeeeeeeee", None)
+            .unwrap();
         assert!((b.total_cost - 2.00).abs() < 1e-9);
         assert_eq!(b.total_tokens, 1500);
         assert_eq!(b.daily.len(), 2);
@@ -1958,12 +1999,8 @@ mod cost_session_tests {
     #[test]
     fn json_output_shape_has_expected_fields() {
         let sessions = fixtures();
-        let b = build_session_breakdown(
-            &sessions,
-            "aaaa1111-bbbb-cccc-dddd-eeeeeeeeeeee",
-            None,
-        )
-        .unwrap();
+        let b = build_session_breakdown(&sessions, "aaaa1111-bbbb-cccc-dddd-eeeeeeeeeeee", None)
+            .unwrap();
         let v = breakdown_to_json(&b);
         for key in [
             "sessionId",
@@ -1980,10 +2017,7 @@ mod cost_session_tests {
         ] {
             assert!(v.get(key).is_some(), "missing key {} in {}", key, v);
         }
-        assert_eq!(
-            v["sessionId"],
-            "aaaa1111-bbbb-cccc-dddd-eeeeeeeeeeee"
-        );
+        assert_eq!(v["sessionId"], "aaaa1111-bbbb-cccc-dddd-eeeeeeeeeeee");
         assert_eq!(v["turns"], 2);
         let by_day = v["byDay"].as_array().unwrap();
         assert_eq!(by_day.len(), 2);
@@ -1997,15 +2031,15 @@ mod cost_session_tests {
     #[test]
     fn json_compact_is_single_line() {
         let sessions = fixtures();
-        let b = build_session_breakdown(
-            &sessions,
-            "aaaa1111-bbbb-cccc-dddd-eeeeeeeeeeee",
-            None,
-        )
-        .unwrap();
+        let b = build_session_breakdown(&sessions, "aaaa1111-bbbb-cccc-dddd-eeeeeeeeeeee", None)
+            .unwrap();
         let v = breakdown_to_json(&b);
         let compact = serde_json::to_string(&v).unwrap();
-        assert!(!compact.contains('\n'), "compact output must be single-line: {}", compact);
+        assert!(
+            !compact.contains('\n'),
+            "compact output must be single-line: {}",
+            compact
+        );
         let parsed: serde_json::Value = serde_json::from_str(&compact).unwrap();
         assert_eq!(parsed["sessionId"], "aaaa1111-bbbb-cccc-dddd-eeeeeeeeeeee");
     }
@@ -2013,12 +2047,8 @@ mod cost_session_tests {
     #[test]
     fn json_pretty_is_indented_and_valid() {
         let sessions = fixtures();
-        let b = build_session_breakdown(
-            &sessions,
-            "aaaa1111-bbbb-cccc-dddd-eeeeeeeeeeee",
-            None,
-        )
-        .unwrap();
+        let b = build_session_breakdown(&sessions, "aaaa1111-bbbb-cccc-dddd-eeeeeeeeeeee", None)
+            .unwrap();
         let v = breakdown_to_json(&b);
         let pretty = serde_json::to_string_pretty(&v).unwrap();
         assert!(pretty.contains('\n'), "pretty output must be multi-line");
@@ -2031,13 +2061,7 @@ mod cost_session_tests {
     #[test]
     fn clap_rejects_session_with_daily() {
         use clap::Parser;
-        let res = Cli::try_parse_from([
-            "c9watch",
-            "cost",
-            "--session",
-            "aaaa1111-bbbb",
-            "--daily",
-        ]);
+        let res = Cli::try_parse_from(["c9watch", "cost", "--session", "aaaa1111-bbbb", "--daily"]);
         assert!(res.is_err(), "expected clap to reject --session + --daily");
     }
 
@@ -2061,12 +2085,7 @@ mod cost_session_tests {
     #[test]
     fn clap_accepts_session_alone() {
         use clap::Parser;
-        let res = Cli::try_parse_from([
-            "c9watch",
-            "cost",
-            "--session",
-            "aaaa1111-bbbb",
-        ]);
+        let res = Cli::try_parse_from(["c9watch", "cost", "--session", "aaaa1111-bbbb"]);
         assert!(res.is_ok(), "parse failed: {:?}", res.err());
     }
 }
@@ -2094,9 +2113,24 @@ mod read_session_tasks_tests {
     fn parses_and_sorts_by_numeric_id() {
         let home = tempdir().unwrap();
         let sid = "session-abc";
-        write_task(home.path(), sid, "10.json", r#"{"id":"10","content":"ten","status":"pending"}"#);
-        write_task(home.path(), sid, "2.json", r#"{"id":"2","content":"two","status":"in_progress"}"#);
-        write_task(home.path(), sid, "1.json", r#"{"id":"1","content":"one","status":"completed"}"#);
+        write_task(
+            home.path(),
+            sid,
+            "10.json",
+            r#"{"id":"10","content":"ten","status":"pending"}"#,
+        );
+        write_task(
+            home.path(),
+            sid,
+            "2.json",
+            r#"{"id":"2","content":"two","status":"in_progress"}"#,
+        );
+        write_task(
+            home.path(),
+            sid,
+            "1.json",
+            r#"{"id":"1","content":"one","status":"completed"}"#,
+        );
 
         let got = read_session_tasks_in(home.path(), sid).unwrap();
         let ids: Vec<&str> = got
@@ -2110,15 +2144,17 @@ mod read_session_tasks_tests {
     fn skips_malformed_json_and_non_json_files() {
         let home = tempdir().unwrap();
         let sid = "session-xyz";
-        write_task(home.path(), sid, "1.json", r#"{"id":"1","content":"good","status":"pending"}"#);
+        write_task(
+            home.path(),
+            sid,
+            "1.json",
+            r#"{"id":"1","content":"good","status":"pending"}"#,
+        );
         write_task(home.path(), sid, "2.json", "not valid json {{{");
         write_task(home.path(), sid, "ignore.txt", r#"{"id":"99"}"#);
 
         let got = read_session_tasks_in(home.path(), sid).unwrap();
         assert_eq!(got.len(), 1);
-        assert_eq!(
-            got[0].get("id").and_then(|v| v.as_str()),
-            Some("1")
-        );
+        assert_eq!(got[0].get("id").and_then(|v| v.as_str()), Some("1"));
     }
 }

--- a/src-tauri/src/cli/pm.rs
+++ b/src-tauri/src/cli/pm.rs
@@ -42,7 +42,9 @@ pub fn ensure_daemon() -> Result<(), String> {
             }
             std::thread::sleep(Duration::from_millis(100));
         }
-        return Err("Daemon failed to start within 3 seconds (waited for another process)".to_string());
+        return Err(
+            "Daemon failed to start within 3 seconds (waited for another process)".to_string(),
+        );
     }
 
     // We hold the exclusive lock. Check if a healthy daemon is already running.
@@ -61,8 +63,8 @@ pub fn ensure_daemon() -> Result<(), String> {
     }
 
     // Get current executable path
-    let exe = std::env::current_exe()
-        .map_err(|e| format!("Failed to get current exe path: {}", e))?;
+    let exe =
+        std::env::current_exe().map_err(|e| format!("Failed to get current exe path: {}", e))?;
 
     // Open log file for append
     let log_path = pm_fs::daemon_log_path()?;
@@ -151,7 +153,9 @@ pub fn cmd_spawn(
         if meta.len() > PROMPT_FILE_MAX_BYTES {
             return Err(format!(
                 "PROMPT_FILE_TOO_LARGE: {:?} is {} bytes (limit {} bytes)",
-                path, meta.len(), PROMPT_FILE_MAX_BYTES
+                path,
+                meta.len(),
+                PROMPT_FILE_MAX_BYTES
             ));
         }
         Some(
@@ -288,15 +292,11 @@ pub fn cmd_inbox(
     pretty: bool,
 ) -> Result<(), String> {
     if consume && clear {
-        return Err(
-            "Specify at most one of --consume or --clear (they conflict)".to_string(),
-        );
+        return Err("Specify at most one of --consume or --clear (they conflict)".to_string());
     }
     ensure_daemon()?;
     let caller_pm_session_id = crate::cli::pm_caller::detect_caller_session_id_default()
-        .ok_or_else(|| {
-            "PM_SESSION_NOT_FOUND: run inside a Claude Code session".to_string()
-        })?;
+        .ok_or_else(|| "PM_SESSION_NOT_FOUND: run inside a Claude Code session".to_string())?;
     let caller_pm_pid = crate::cli::pm_caller::detect_caller_pid_default();
 
     let request = RpcRequest::InboxRead {
@@ -313,9 +313,7 @@ pub fn cmd_inbox(
 pub fn cmd_adopt(session_id: String, force: bool, pretty: bool) -> Result<(), String> {
     ensure_daemon()?;
     let caller_pm_session_id = crate::cli::pm_caller::detect_caller_session_id_default()
-        .ok_or_else(|| {
-            "PM_SESSION_NOT_FOUND: run inside a Claude Code session".to_string()
-        })?;
+        .ok_or_else(|| "PM_SESSION_NOT_FOUND: run inside a Claude Code session".to_string())?;
     let caller_pm_pid = crate::cli::pm_caller::detect_caller_pid_default();
 
     let request = RpcRequest::Adopt {

--- a/src-tauri/src/cli/pm_inbox.rs
+++ b/src-tauri/src/cli/pm_inbox.rs
@@ -59,11 +59,7 @@ pub struct TurnResult {
 
 impl InboxEvent {
     /// Normal turn-end event from a `result` stream entry.
-    pub fn from_turn_result(
-        worker_session_id: &str,
-        spawned_by: &str,
-        tr: TurnResult,
-    ) -> Self {
+    pub fn from_turn_result(worker_session_id: &str, spawned_by: &str, tr: TurnResult) -> Self {
         Self {
             event_id: new_event_id(),
             session_id: worker_session_id.to_string(),
@@ -260,14 +256,12 @@ mod tests {
     impl TestWorker {
         fn new() -> Self {
             let n = COUNTER.fetch_add(1, Ordering::SeqCst);
-            let id = format!(
-                "test-w-{}-{}",
-                std::process::id(),
-                n
-            );
+            let id = format!("test-w-{}-{}", std::process::id(), n);
             Self(id)
         }
-        fn id(&self) -> &str { &self.0 }
+        fn id(&self) -> &str {
+            &self.0
+        }
     }
 
     impl Drop for TestWorker {

--- a/src-tauri/src/cli/pm_rpc.rs
+++ b/src-tauri/src/cli/pm_rpc.rs
@@ -103,8 +103,8 @@ pub fn rpc_call(
         .map_err(|e| format!("Failed to set read timeout: {}", e))?;
 
     // Serialize request as a single JSON line
-    let mut line =
-        serde_json::to_string(request).map_err(|e| format!("Failed to serialize request: {}", e))?;
+    let mut line = serde_json::to_string(request)
+        .map_err(|e| format!("Failed to serialize request: {}", e))?;
     line.push('\n');
 
     // Write
@@ -150,10 +150,26 @@ mod tests {
             initial_prompt: None,
         };
         let json = serde_json::to_string(&req).expect("serialize should succeed");
-        assert!(json.contains("\"op\":\"spawn\""), "should contain op:spawn, got: {}", json);
-        assert!(json.contains("/Users/me/project"), "should contain cwd, got: {}", json);
-        assert!(json.contains("\"spawnedBy\":\"pm-session-abc\""), "should contain spawnedBy, got: {}", json);
-        assert!(json.contains("\"pmPid\":42"), "should contain pmPid, got: {}", json);
+        assert!(
+            json.contains("\"op\":\"spawn\""),
+            "should contain op:spawn, got: {}",
+            json
+        );
+        assert!(
+            json.contains("/Users/me/project"),
+            "should contain cwd, got: {}",
+            json
+        );
+        assert!(
+            json.contains("\"spawnedBy\":\"pm-session-abc\""),
+            "should contain spawnedBy, got: {}",
+            json
+        );
+        assert!(
+            json.contains("\"pmPid\":42"),
+            "should contain pmPid, got: {}",
+            json
+        );
     }
 
     #[test]
@@ -165,15 +181,27 @@ mod tests {
             timeout_ms: 30_000,
         };
         let json = serde_json::to_string(&req).expect("serialize should succeed");
-        assert!(json.contains("\"op\":\"send\""), "should contain op:send, got: {}", json);
-        assert!(json.contains("\"wait\":true"), "should contain wait:true, got: {}", json);
+        assert!(
+            json.contains("\"op\":\"send\""),
+            "should contain op:send, got: {}",
+            json
+        );
+        assert!(
+            json.contains("\"wait\":true"),
+            "should contain wait:true, got: {}",
+            json
+        );
     }
 
     #[test]
     fn test_list_request_serializes() {
         let req = RpcRequest::List;
         let json = serde_json::to_string(&req).expect("serialize should succeed");
-        assert!(json.contains("\"op\":\"list\""), "should contain op:list, got: {}", json);
+        assert!(
+            json.contains("\"op\":\"list\""),
+            "should contain op:list, got: {}",
+            json
+        );
     }
 
     #[test]
@@ -218,7 +246,11 @@ mod tests {
             session_id: "dead-beef-1234".to_string(),
         };
         let json = serde_json::to_string(&req).expect("serialize should succeed");
-        assert!(json.contains("\"op\":\"stop\""), "should contain op:stop, got: {}", json);
+        assert!(
+            json.contains("\"op\":\"stop\""),
+            "should contain op:stop, got: {}",
+            json
+        );
         assert!(
             json.contains("dead-beef-1234"),
             "should contain session_id, got: {}",

--- a/src-tauri/src/cli/worker_backend.rs
+++ b/src-tauri/src/cli/worker_backend.rs
@@ -57,7 +57,11 @@ fn version_supports_bg() -> bool {
 }
 
 fn parse_version_ge(ver: &str, min: (u32, u32, u32)) -> bool {
-    let parts: Vec<u32> = ver.split('.').take(3).filter_map(|s| s.parse().ok()).collect();
+    let parts: Vec<u32> = ver
+        .split('.')
+        .take(3)
+        .filter_map(|s| s.parse().ok())
+        .collect();
     if parts.len() != 3 {
         return false;
     }

--- a/src-tauri/src/debug_log.rs
+++ b/src-tauri/src/debug_log.rs
@@ -143,7 +143,9 @@ mod tests {
         );
         // The last message we wrote should be present
         assert!(
-            our_msgs.iter().any(|l| l.message == format!("{}549", prefix)),
+            our_msgs
+                .iter()
+                .any(|l| l.message == format!("{}549", prefix)),
             "expected to find the last written message"
         );
     }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -29,7 +29,7 @@ use serde::Serialize;
 use session::conversation::Conversation;
 // Re-export for web_server.rs which uses crate::get_conversation_data
 #[cfg(feature = "gui")]
-pub use session::conversation::get_conversation_data;
+pub use session::conversation::{get_conversation_data, get_conversation_data_for_provider};
 #[cfg(feature = "gui")]
 use std::sync::{Arc, Mutex};
 #[cfg(feature = "gui")]
@@ -73,8 +73,11 @@ async fn get_sessions(
 
 #[cfg(all(not(mobile), feature = "gui"))]
 #[tauri::command]
-async fn get_conversation(session_id: String) -> Result<Conversation, String> {
-    get_conversation_data(&session_id)
+async fn get_conversation(
+    session_id: String,
+    provider: Option<session::SessionProvider>,
+) -> Result<Conversation, String> {
+    get_conversation_data_for_provider(&session_id, provider)
 }
 
 #[cfg(all(not(mobile), feature = "gui"))]
@@ -211,20 +214,38 @@ async fn open_session(pid: u32, project_path: String) -> Result<(), String> {
 }
 
 #[cfg(all(not(mobile), feature = "gui"))]
+pub(crate) fn run_validated_rename<F>(
+    provider: Option<session::SessionProvider>,
+    session_id: &str,
+    owners: &session::ProviderSourceOwners,
+    write: F,
+) -> Result<(), String>
+where
+    F: FnOnce() -> Result<(), String>,
+{
+    session::validate_rename_request(provider, session_id, owners)?;
+    write()
+}
+
+#[cfg(all(not(mobile), feature = "gui"))]
 #[tauri::command]
 async fn rename_session(
     app: AppHandle,
     detector: tauri::State<'_, Arc<Mutex<session::DetectorState>>>,
     session_id: String,
     new_name: String,
+    provider: Option<session::SessionProvider>,
 ) -> Result<(), String> {
-    // Write to Claude Code's native JSONL format (primary)
-    write_native_custom_title(&session_id, &new_name);
+    let owners = session::global_provider_source_owners();
+    run_validated_rename(provider, &session_id, &owners, || {
+        // Write to Claude Code's native JSONL format (primary)
+        write_native_custom_title(&session_id, &new_name);
 
-    // Also write to c9watch's own custom titles (fallback for history view)
-    let mut custom_titles = session::CustomTitles::load();
-    custom_titles.set(session_id, new_name);
-    custom_titles.save()?;
+        // Also write to c9watch's own custom titles (fallback for history view)
+        let mut custom_titles = session::CustomTitles::load();
+        custom_titles.set(session_id.clone(), new_name.clone());
+        custom_titles.save()
+    })?;
 
     let detect_result = {
         let mut state = detector
@@ -293,6 +314,76 @@ pub fn write_native_custom_title(session_id: &str, title: &str) {
         "Could not find JSONL file for session {} to write native custom-title",
         session_id
     ));
+}
+
+#[cfg(all(test, not(mobile), feature = "gui"))]
+mod rename_collision_tests {
+    use super::*;
+    use std::sync::atomic::{AtomicUsize, Ordering};
+    use tempfile::TempDir;
+
+    const SESSION_ID: &str = "dddddddd-dddd-dddd-dddd-dddddddddddd";
+
+    fn synthetic_cursor_owner(temp: &TempDir) -> session::ProviderSourceOwners {
+        let transcript_dir = temp
+            .path()
+            .join("synthetic-project")
+            .join("agent-transcripts")
+            .join(SESSION_ID);
+        std::fs::create_dir_all(&transcript_dir).unwrap();
+        std::fs::write(
+            transcript_dir.join(format!("{SESSION_ID}.jsonl")),
+            b"{\"role\":\"user\",\"message\":{\"content\":[]}}\n",
+        )
+        .unwrap();
+
+        session::ProviderSourceOwners::from_test_sources(
+            None,
+            Some(session::cursor::CursorSessionSource::at_root(
+                temp.path().to_path_buf(),
+            )),
+        )
+    }
+
+    fn synthetic_codex_owner(temp: &TempDir) -> session::ProviderSourceOwners {
+        let rollout_dir = temp.path().join("2026").join("08").join("24");
+        std::fs::create_dir_all(&rollout_dir).unwrap();
+        std::fs::write(
+            rollout_dir.join(format!("rollout-synthetic-{SESSION_ID}.jsonl")),
+            b"{}\n",
+        )
+        .unwrap();
+
+        session::ProviderSourceOwners::from_test_sources(
+            Some(session::codex::CodexSessionSource::at_root(
+                temp.path().to_path_buf(),
+            )),
+            None,
+        )
+    }
+
+    fn assert_no_write_for_collision(owners: session::ProviderSourceOwners) {
+        let writes = AtomicUsize::new(0);
+        let result = run_validated_rename(None, SESSION_ID, &owners, || {
+            writes.fetch_add(1, Ordering::SeqCst);
+            Ok(())
+        });
+
+        assert!(result.is_err());
+        assert_eq!(writes.load(Ordering::SeqCst), 0);
+    }
+
+    #[test]
+    fn tauri_rename_collision_rejects_before_custom_title_write_for_cursor() {
+        let temp = tempfile::tempdir().unwrap();
+        assert_no_write_for_collision(synthetic_cursor_owner(&temp));
+    }
+
+    #[test]
+    fn tauri_rename_collision_rejects_before_custom_title_write_for_codex() {
+        let temp = tempfile::tempdir().unwrap();
+        assert_no_write_for_collision(synthetic_codex_owner(&temp));
+    }
 }
 
 /// Get the terminal title for a session (iTerm2 only, macOS)

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -3,9 +3,9 @@
 #![cfg_attr(target_os = "macos", allow(clippy::unused_unit))]
 
 // ── Core modules (always compiled) ──────────────────────────────────
-pub mod session;
-pub mod debug_log;
 pub mod actions;
+pub mod debug_log;
+pub mod session;
 
 // ── GUI-only modules ────────────────────────────────────────────────
 #[cfg(all(not(mobile), feature = "gui"))]
@@ -68,8 +68,7 @@ async fn get_sessions(
         state.detect()
     };
     let (detected, diag) = detect_result.map_err(|e| format!("Detect failed: {}", e))?;
-    session::enrichment::enrich_detected_sessions(detected, diag)
-        .map(|(sessions, _)| sessions)
+    session::enrichment::enrich_detected_sessions(detected, diag).map(|(sessions, _)| sessions)
 }
 
 #[cfg(all(not(mobile), feature = "gui"))]
@@ -117,10 +116,8 @@ async fn get_memory_files() -> Result<Vec<session::ProjectMemory>, String> {
 /// parsing each session's JSONL transcript for Agent/Task tool_use entries.
 #[cfg(all(not(mobile), feature = "gui"))]
 #[tauri::command]
-async fn get_subagents() -> Result<
-    std::collections::HashMap<String, Vec<session::SubagentInfo>>,
-    String,
-> {
+async fn get_subagents(
+) -> Result<std::collections::HashMap<String, Vec<session::SubagentInfo>>, String> {
     Ok(session::all_subagents_by_session())
 }
 
@@ -132,8 +129,12 @@ async fn get_subagent_transcript(
     parent_session_id: String,
     subagent_id: String,
 ) -> Result<session::SubagentTranscript, String> {
-    session::get_subagent_transcript(&parent_session_id, &subagent_id)
-        .ok_or_else(|| format!("subagent {} not found in session {}", subagent_id, parent_session_id))
+    session::get_subagent_transcript(&parent_session_id, &subagent_id).ok_or_else(|| {
+        format!(
+            "subagent {} not found in session {}",
+            subagent_id, parent_session_id
+        )
+    })
 }
 
 /// Returns the parsed TodoWrite tasks for a session, sorted by numeric `id`.
@@ -156,9 +157,7 @@ async fn save_temp_image(data: String) -> Result<String, String> {
     let file_path = temp_dir.join("c9watch-token-journey.png");
 
     // data is base64-encoded PNG (no data URL prefix)
-    let bytes = data
-        .strip_prefix("data:image/png;base64,")
-        .unwrap_or(&data);
+    let bytes = data.strip_prefix("data:image/png;base64,").unwrap_or(&data);
 
     use base64::Engine;
     let decoded = base64::engine::general_purpose::STANDARD

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -26,10 +26,10 @@ use polling::{start_polling, Session};
 #[cfg(feature = "gui")]
 use serde::Serialize;
 #[cfg(feature = "gui")]
-use session::conversation::Conversation;
+use session::conversation::{Conversation, ConversationProgress};
 // Re-export for web_server.rs which uses crate::get_conversation_data
 #[cfg(feature = "gui")]
-pub use session::conversation::get_conversation_data;
+pub use session::conversation::{get_conversation_data, get_conversation_data_with_progress};
 #[cfg(feature = "gui")]
 use std::sync::{Arc, Mutex};
 #[cfg(feature = "gui")]
@@ -73,8 +73,27 @@ async fn get_sessions(
 
 #[cfg(all(not(mobile), feature = "gui"))]
 #[tauri::command]
-async fn get_conversation(session_id: String) -> Result<Conversation, String> {
-    get_conversation_data(&session_id)
+async fn get_conversation(
+    app: tauri::AppHandle,
+    session_id: String,
+    include_tools: Option<bool>,
+) -> Result<Conversation, String> {
+    let include_tools = include_tools.unwrap_or(false);
+    tauri::async_runtime::spawn_blocking(move || {
+        let emit_id = session_id.clone();
+        get_conversation_data_with_progress(&session_id, include_tools, &mut |bytes_read, bytes_total| {
+            let _ = app.emit(
+                "conversation-progress",
+                ConversationProgress {
+                    session_id: emit_id.clone(),
+                    bytes_read,
+                    bytes_total,
+                },
+            );
+        })
+    })
+    .await
+    .map_err(|error| format!("Failed to load conversation: {error}"))?
 }
 
 #[cfg(all(not(mobile), feature = "gui"))]
@@ -409,6 +428,7 @@ pub fn run() {
 
             let (sessions_tx, _rx) = tokio::sync::broadcast::channel::<String>(16);
             let (notifications_tx, _nrx) = tokio::sync::broadcast::channel::<String>(16);
+            let (progress_tx, _prx) = tokio::sync::broadcast::channel::<String>(32);
 
             let server_info = ServerInfo {
                 token: token.clone(),
@@ -422,6 +442,7 @@ pub fn run() {
                 auth_token: token,
                 sessions_tx: sessions_tx.clone(),
                 notifications_tx: notifications_tx.clone(),
+                progress_tx,
             });
             tauri::async_runtime::spawn(web_server::start_server(ws_state));
 

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -1,6 +1,9 @@
 // Prevents additional console window on Windows in release — GUI builds only.
 // CLI-only builds need the console for stdout/stderr output.
-#![cfg_attr(all(not(debug_assertions), feature = "gui"), windows_subsystem = "windows")]
+#![cfg_attr(
+    all(not(debug_assertions), feature = "gui"),
+    windows_subsystem = "windows"
+)]
 
 fn main() {
     // CLI mode: if the first arg is a known subcommand or --help/--version,
@@ -16,8 +19,7 @@ fn main() {
             // unexpectedly launching the GUI.
             let known_commands = [
                 "list", "status", "self", "view", "history", "search", "stop", "watch", "tasks",
-                "spawn", "send", "workers", "inbox", "adopt", "daemon",
-                "cost", "help",
+                "spawn", "send", "workers", "inbox", "adopt", "daemon", "cost", "help",
             ];
             let is_cli = known_commands.contains(&first)
                 || first == "--help"

--- a/src-tauri/src/polling.rs
+++ b/src-tauri/src/polling.rs
@@ -13,8 +13,7 @@ use tauri_plugin_notification::NotificationExt;
 
 /// Cached overlay: session_id -> spawnedBy (i.e. worker_of).
 /// Invalidated when the `~/.claude/c9watch/workers/` dir mtime changes.
-static WORKERS_OVERLAY: LazyLock<Mutex<Option<WorkersCache>>> =
-    LazyLock::new(|| Mutex::new(None));
+static WORKERS_OVERLAY: LazyLock<Mutex<Option<WorkersCache>>> = LazyLock::new(|| Mutex::new(None));
 
 struct WorkersCache {
     dir_mtime: SystemTime,
@@ -67,8 +66,12 @@ fn load_workers_overlay() -> Arc<HashMap<String, String>> {
     if let Ok(entries) = std::fs::read_dir(&workers_dir) {
         for entry in entries.flatten() {
             let meta_path = entry.path().join("meta.json");
-            let Ok(content) = std::fs::read_to_string(&meta_path) else { continue };
-            let Ok(meta) = serde_json::from_str::<WorkerMetaOverlay>(&content) else { continue };
+            let Ok(content) = std::fs::read_to_string(&meta_path) else {
+                continue;
+            };
+            let Ok(meta) = serde_json::from_str::<WorkerMetaOverlay>(&content) else {
+                continue;
+            };
             if meta.stopped_at.is_some() {
                 continue;
             }
@@ -171,9 +174,7 @@ pub fn start_polling(
                             } else {
                                 // Check for status transitions
                                 for session in &sessions {
-                                    if let Some(prev_status) =
-                                        prev_status_map.get(&session.id)
-                                    {
+                                    if let Some(prev_status) = prev_status_map.get(&session.id) {
                                         // Check for notification-worthy transitions
                                         let should_notify = matches!(
                                             (prev_status, &session.status),
@@ -189,9 +190,7 @@ pub fn start_polling(
                                             // from status flickering across poll cycles
                                             let on_cooldown = last_notification_time
                                                 .get(&session.id)
-                                                .map(|t| {
-                                                    t.elapsed() < notification_cooldown
-                                                })
+                                                .map(|t| t.elapsed() < notification_cooldown)
                                                 .unwrap_or(false);
 
                                             if !on_cooldown {
@@ -213,10 +212,8 @@ pub fn start_polling(
                                                         project_path: &session.project_path,
                                                     },
                                                 );
-                                                last_notification_time.insert(
-                                                    session.id.clone(),
-                                                    Instant::now(),
-                                                );
+                                                last_notification_time
+                                                    .insert(session.id.clone(), Instant::now());
                                             }
                                         }
                                     }
@@ -228,10 +225,8 @@ pub fn start_polling(
                             }
 
                             // Clean up disappeared sessions
-                            prev_status_map
-                                .retain(|id, _| current_session_ids.contains(id));
-                            last_notification_time
-                                .retain(|id, _| current_session_ids.contains(id));
+                            prev_status_map.retain(|id, _| current_session_ids.contains(id));
+                            last_notification_time.retain(|id, _| current_session_ids.contains(id));
                         }
                         Err(poisoned) => {
                             crate::debug_log::log_error("Mutex poisoned, recovering...");
@@ -240,8 +235,7 @@ pub fn start_polling(
 
                             // Seed the map with current sessions (no notifications after recovery)
                             for session in &sessions {
-                                prev_status_map
-                                    .insert(session.id.clone(), session.status.clone());
+                                prev_status_map.insert(session.id.clone(), session.status.clone());
                             }
                             is_first_cycle = false; // Mark as initialized
                         }
@@ -284,9 +278,7 @@ pub fn start_polling(
                                 "Full Disk Access likely needed: processes found but none have readable CWD",
                             );
                         }
-                        if let Err(e) =
-                            app_handle.emit("diagnostic-update", &diagnostics)
-                        {
+                        if let Err(e) = app_handle.emit("diagnostic-update", &diagnostics) {
                             crate::debug_log::log_error(&format!(
                                 "Failed to emit diagnostic-update: {}",
                                 e
@@ -296,10 +288,7 @@ pub fn start_polling(
                     }
                 }
                 Err(e) => {
-                    crate::debug_log::log_error(&format!(
-                        "Error detecting sessions: {}",
-                        e
-                    ));
+                    crate::debug_log::log_error(&format!("Error detecting sessions: {}", e));
                     // Continue polling even on error
                 }
             }
@@ -396,10 +385,7 @@ fn fire_notification(
     };
 
     if let Err(e) = app_handle.emit("notification-fired", &metadata) {
-        crate::debug_log::log_error(&format!(
-            "Failed to emit notification-fired: {}",
-            e
-        ));
+        crate::debug_log::log_error(&format!("Failed to emit notification-fired: {}", e));
     }
 
     // Broadcast to WebSocket clients for web notifications

--- a/src-tauri/src/polling.rs
+++ b/src-tauri/src/polling.rs
@@ -152,14 +152,16 @@ pub fn start_polling(
                     // Overlay worker_of from ~/.claude/c9watch/workers/*/meta.json
                     let overlay = load_workers_overlay();
                     for s in sessions.iter_mut() {
-                        if let Some(by) = overlay.get(&s.id) {
-                            s.worker_of = Some(by.clone());
+                        if s.provider == crate::session::SessionProvider::ClaudeCode {
+                            if let Some(by) = overlay.get(&s.id) {
+                                s.worker_of = Some(by.clone());
+                            }
                         }
                     }
 
                     // Track current session IDs to clean up stale entries
                     let current_session_ids: HashSet<String> =
-                        sessions.iter().map(|s| s.id.clone()).collect();
+                        sessions.iter().map(|s| s.session_key.clone()).collect();
 
                     // Process status transitions and fire notifications
                     match previous_status.lock() {
@@ -167,14 +169,18 @@ pub fn start_polling(
                             if is_first_cycle {
                                 // First cycle: seed the map without notifications
                                 for session in &sessions {
-                                    prev_status_map
-                                        .insert(session.id.clone(), session.status.clone());
+                                    prev_status_map.insert(
+                                        session.session_key.clone(),
+                                        session.status.clone(),
+                                    );
                                 }
                                 is_first_cycle = false;
                             } else {
                                 // Check for status transitions
                                 for session in &sessions {
-                                    if let Some(prev_status) = prev_status_map.get(&session.id) {
+                                    if let Some(prev_status) =
+                                        prev_status_map.get(&session.session_key)
+                                    {
                                         // Check for notification-worthy transitions
                                         let should_notify = matches!(
                                             (prev_status, &session.status),
@@ -189,7 +195,7 @@ pub fn start_polling(
                                             // Check cooldown to prevent duplicate notifications
                                             // from status flickering across poll cycles
                                             let on_cooldown = last_notification_time
-                                                .get(&session.id)
+                                                .get(&session.session_key)
                                                 .map(|t| t.elapsed() < notification_cooldown)
                                                 .unwrap_or(false);
 
@@ -199,6 +205,8 @@ pub fn start_polling(
                                                     &notifications_tx,
                                                     NotificationParams {
                                                         session_id: &session.id,
+                                                        session_key: &session.session_key,
+                                                        provider: session.provider,
                                                         first_prompt: &session.first_prompt,
                                                         custom_title: session
                                                             .custom_title
@@ -212,15 +220,19 @@ pub fn start_polling(
                                                         project_path: &session.project_path,
                                                     },
                                                 );
-                                                last_notification_time
-                                                    .insert(session.id.clone(), Instant::now());
+                                                last_notification_time.insert(
+                                                    session.session_key.clone(),
+                                                    Instant::now(),
+                                                );
                                             }
                                         }
                                     }
 
                                     // Update the status map
-                                    prev_status_map
-                                        .insert(session.id.clone(), session.status.clone());
+                                    prev_status_map.insert(
+                                        session.session_key.clone(),
+                                        session.status.clone(),
+                                    );
                                 }
                             }
 
@@ -235,7 +247,8 @@ pub fn start_polling(
 
                             // Seed the map with current sessions (no notifications after recovery)
                             for session in &sessions {
-                                prev_status_map.insert(session.id.clone(), session.status.clone());
+                                prev_status_map
+                                    .insert(session.session_key.clone(), session.status.clone());
                             }
                             is_first_cycle = false; // Mark as initialized
                         }
@@ -304,6 +317,8 @@ pub fn start_polling(
 struct NotificationMetadata {
     notification_id: i32,
     session_id: String,
+    session_key: String,
+    provider: crate::session::SessionProvider,
     pid: u32,
     project_path: String,
     title: String,
@@ -312,6 +327,8 @@ struct NotificationMetadata {
 /// Parameters for firing a notification
 struct NotificationParams<'a> {
     session_id: &'a str,
+    session_key: &'a str,
+    provider: crate::session::SessionProvider,
     first_prompt: &'a str,
     custom_title: Option<&'a str>,
     session_name: &'a str,
@@ -329,6 +346,8 @@ fn fire_notification(
 ) {
     let NotificationParams {
         session_id,
+        session_key,
+        provider,
         first_prompt,
         custom_title,
         session_name,
@@ -358,9 +377,9 @@ fn fire_notification(
         _ => return, // Should not happen based on the caller's logic
     };
 
-    // Generate a stable i32 ID from the session_id string using hash
+    // Generate a stable i32 ID from the provider-scoped key using hash
     let mut hasher = DefaultHasher::new();
-    session_id.hash(&mut hasher);
+    session_key.hash(&mut hasher);
     let notification_id = (hasher.finish() as i32).abs();
 
     // Fire native notification via Tauri plugin
@@ -379,6 +398,8 @@ fn fire_notification(
     let metadata = NotificationMetadata {
         notification_id,
         session_id: session_id.to_string(),
+        session_key: session_key.to_string(),
+        provider,
         pid,
         project_path: project_path.to_string(),
         title: title.clone(),
@@ -393,6 +414,8 @@ fn fire_notification(
         "title": title,
         "body": body,
         "sessionId": session_id,
+        "sessionKey": session_key,
+        "provider": provider,
         "pid": pid,
     });
     if let Ok(json) = serde_json::to_string(&ws_notification) {
@@ -403,6 +426,7 @@ fn fire_notification(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::session::SessionSource;
 
     #[cfg(unix)]
     #[test]
@@ -423,22 +447,35 @@ mod tests {
     }
 
     #[test]
-    fn test_detect_and_enrich_sessions() {
-        // This test will only work if there are active Claude sessions
-        match detect_and_enrich_sessions() {
-            Ok((sessions, _diagnostics)) => {
-                println!("Detected {} sessions", sessions.len());
-                for session in sessions {
-                    println!(
-                        "Session: {} - {} (PID: {}, Status: {:?})",
-                        session.id, session.session_name, session.pid, session.status
-                    );
-                }
-            }
-            Err(e) => {
-                println!("Error detecting sessions: {}", e);
-            }
-        }
+    fn synthetic_cursor_detection_and_enrichment_uses_fixture_cursor_root() {
+        const SESSION_ID: &str = "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa";
+        let tmp = tempfile::tempdir().unwrap();
+        let transcript_dir = tmp
+            .path()
+            .join("projects")
+            .join("demo-project")
+            .join("agent-transcripts")
+            .join(SESSION_ID);
+        std::fs::create_dir_all(&transcript_dir).unwrap();
+        std::fs::write(
+            transcript_dir.join(format!("{SESSION_ID}.jsonl")),
+            r#"{"role":"user","message":{"content":[{"type":"text","text":"<user_query>synthetic Cursor fixture</user_query>"}]}}
+"#,
+        )
+        .unwrap();
+
+        let mut source =
+            crate::session::cursor::CursorSessionSource::at_root(tmp.path().join("projects"));
+        let (detected, diagnostics) = source.detect().unwrap();
+        let (sessions, _) = enrich_detected_sessions(detected, diagnostics).unwrap();
+
+        assert_eq!(sessions.len(), 1);
+        assert_eq!(sessions[0].id, SESSION_ID);
+        assert_eq!(
+            sessions[0].provider,
+            crate::session::SessionProvider::Cursor
+        );
+        assert_eq!(sessions[0].first_prompt, "synthetic Cursor fixture");
     }
 
     #[test]

--- a/src-tauri/src/polling.rs
+++ b/src-tauri/src/polling.rs
@@ -210,7 +210,9 @@ pub fn start_polling(
                                                         first_prompt: &session.first_prompt,
                                                         custom_title: session
                                                             .custom_title
-                                                            .as_deref(),
+                                                            .as_deref()
+                                                            .or(session.codex_title.as_deref())
+                                                            .or(session.cursor_title.as_deref()),
                                                         session_name: &session.session_name,
                                                         status: &session.status,
                                                         pending_tool_name: session

--- a/src-tauri/src/session/cache.rs
+++ b/src-tauri/src/session/cache.rs
@@ -1,0 +1,107 @@
+//! Shared cache-consistency rules for provider-specific transcript readers.
+//!
+//! The parsers intentionally remain provider-specific.  They do, however,
+//! need the same conservative rule before treating metadata equality as proof
+//! that a cached transcript summary is still current.
+
+use std::fs;
+use std::io;
+use std::path::Path;
+use std::time::UNIX_EPOCH;
+
+/// Provider-neutral metadata version used by file-backed caches.
+///
+/// The parsers keep their own cache entries and parsing semantics, but they
+/// now consume the same file-version primitive. `identity` is the Unix inode
+/// when available and zero on platforms without a replacement identity.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) struct FileVersion {
+    pub(crate) len: u64,
+    pub(crate) modified_nanos: u128,
+    pub(crate) changed_nanos: u128,
+    pub(crate) identity: u64,
+}
+
+impl FileVersion {
+    pub(crate) fn read(path: &Path) -> io::Result<Self> {
+        let metadata = fs::metadata(path)?;
+        Self::from_metadata(&metadata)
+    }
+
+    pub(crate) fn from_metadata(metadata: &fs::Metadata) -> io::Result<Self> {
+        let modified_nanos = metadata
+            .modified()?
+            .duration_since(UNIX_EPOCH)
+            .unwrap_or_default()
+            .as_nanos();
+
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::MetadataExt;
+            let changed_nanos = metadata
+                .ctime()
+                .saturating_mul(1_000_000_000)
+                .saturating_add(metadata.ctime_nsec() as i64)
+                .max(0) as u128;
+            return Ok(Self {
+                len: metadata.len(),
+                modified_nanos,
+                changed_nanos,
+                identity: metadata.ino(),
+            });
+        }
+
+        #[cfg(not(unix))]
+        Ok(Self {
+            len: metadata.len(),
+            modified_nanos,
+            changed_nanos: 0,
+            identity: 0,
+        })
+    }
+
+    pub(crate) fn supports_unchanged_fast_path(self) -> bool {
+        has_strong_file_stamp(self.changed_nanos, self.identity)
+    }
+}
+
+/// Return whether a file stamp is strong enough for an unchanged fast path.
+///
+/// A non-zero inode/file identity distinguishes replacement, while a
+/// sub-second change time avoids trusting filesystems whose timestamps only
+/// advance once per second.  Callers must content-validate or fully parse when
+/// this returns false.
+pub(crate) fn has_strong_file_stamp(changed_nanos: u128, file_id: u64) -> bool {
+    file_id != 0 && changed_nanos != 0 && changed_nanos % 1_000_000_000 != 0
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{has_strong_file_stamp, FileVersion};
+
+    #[test]
+    fn rejects_missing_or_seconds_only_metadata() {
+        assert!(!has_strong_file_stamp(0, 1));
+        assert!(!has_strong_file_stamp(1_000_000_000, 1));
+        assert!(!has_strong_file_stamp(1_000_000_001, 0));
+    }
+
+    #[test]
+    fn accepts_subsecond_change_time_with_identity() {
+        assert!(has_strong_file_stamp(1_000_000_001, 42));
+    }
+
+    #[test]
+    fn file_version_reads_shared_metadata_shape() {
+        let temp = tempfile::tempdir().unwrap();
+        let path = temp.path().join("synthetic.jsonl");
+        std::fs::write(&path, b"one\ntwo\n").unwrap();
+
+        let version = FileVersion::read(&path).unwrap();
+
+        assert_eq!(version.len, 8);
+        assert!(version.modified_nanos > 0);
+        #[cfg(unix)]
+        assert!(version.identity > 0);
+    }
+}

--- a/src-tauri/src/session/codex.rs
+++ b/src-tauri/src/session/codex.rs
@@ -941,26 +941,6 @@ fn path_matches_thread(path: &Path, suffix: &str) -> bool {
         .is_some_and(|name| name.starts_with("rollout-") && name.ends_with(suffix))
 }
 
-fn scan_recent_thread_rollouts(sessions_root: &Path, suffix: &str) -> Vec<PathBuf> {
-    let now = Local::now();
-    [now, now - chrono::Duration::days(1)]
-        .into_iter()
-        .flat_map(|day| {
-            let dir = sessions_root
-                .join(day.format("%Y").to_string())
-                .join(day.format("%m").to_string())
-                .join(day.format("%d").to_string());
-            fs::read_dir(dir)
-                .ok()
-                .into_iter()
-                .flatten()
-                .flatten()
-                .map(|entry| entry.path())
-        })
-        .filter(|path| path.is_file() && path_matches_thread(path, suffix))
-        .collect()
-}
-
 fn collect_thread_rollouts(sessions_root: &Path, suffix: &str) -> Vec<PathBuf> {
     collect_rollout_paths(sessions_root)
         .into_iter()
@@ -968,9 +948,8 @@ fn collect_thread_rollouts(sessions_root: &Path, suffix: &str) -> Vec<PathBuf> {
         .collect()
 }
 
-/// Cache is a hint: union today's/yesterday's files so resume/compaction
-/// rollouts are not missed. If the cache is cold or every cached path is gone,
-/// fall through to a full walk.
+/// Cache is only a seed. Always walk so resume/compaction fragments outside
+/// today/yesterday are not dropped just because an older cached path still exists.
 fn resolve_thread_rollout_paths(sessions_root: &Path, thread_id: &str) -> Vec<PathBuf> {
     resolve_thread_rollout_paths_with_cache(
         sessions_root,
@@ -985,20 +964,13 @@ fn resolve_thread_rollout_paths_with_cache(
     cached: Option<Vec<PathBuf>>,
 ) -> Vec<PathBuf> {
     let suffix = thread_rollout_suffix(thread_id);
-    if let Some(mut paths) = cached {
-        for path in scan_recent_thread_rollouts(sessions_root, &suffix) {
-            if !paths.iter().any(|existing| existing == &path) {
-                paths.push(path);
-            }
-        }
-        paths.retain(|path| path.is_file());
-        if !paths.is_empty() {
-            paths.sort();
-            return paths;
+    let mut paths = cached.unwrap_or_default();
+    for path in collect_thread_rollouts(sessions_root, &suffix) {
+        if !paths.iter().any(|existing| existing == &path) {
+            paths.push(path);
         }
     }
-
-    let mut paths = collect_thread_rollouts(sessions_root, &suffix);
+    paths.retain(|path| path.is_file());
     paths.sort();
     paths
 }
@@ -2644,6 +2616,39 @@ mod tests {
             Some(vec![old_day.join("deleted.jsonl")]),
         );
         assert_eq!(resolved, vec![old_path]);
+    }
+
+    #[test]
+    fn conversation_lookup_walks_for_fragments_outside_cached_days() {
+        let temp = TempDir::new().unwrap();
+        let cached_day = temp.path().join("2026/07/12");
+        let later_day = temp.path().join("2026/07/14");
+        fs::create_dir_all(&cached_day).unwrap();
+        fs::create_dir_all(&later_day).unwrap();
+        let cached_path = cached_day.join("rollout-2026-07-12T23-00-00-thread-id.jsonl");
+        let later_path = later_day.join("rollout-2026-07-14T01-00-00-thread-id.jsonl");
+        write_lines(
+            &cached_path,
+            &root_fixture(Value::String("cli".into()), "codex-tui"),
+            true,
+        );
+        write_lines(
+            &later_path,
+            &[event(
+                "2026-07-14T01:00:00Z",
+                "event_msg",
+                serde_json::json!({"type":"user_message","message":"later fragment"}),
+            )],
+            true,
+        );
+
+        let resolved = resolve_thread_rollout_paths_with_cache(
+            temp.path(),
+            "thread-id",
+            Some(vec![cached_path.clone()]),
+        );
+        assert!(resolved.contains(&cached_path));
+        assert!(resolved.contains(&later_path));
     }
 
     #[test]

--- a/src-tauri/src/session/codex.rs
+++ b/src-tauri/src/session/codex.rs
@@ -129,7 +129,10 @@ pub struct CodexSessionSource {
     cache: HashMap<PathBuf, CacheEntry>,
     archive_index: HashMap<String, Vec<PathBuf>>,
     last_full_discovery: Option<SystemTime>,
+    /// When true, parse complete JSONL lines instead of the compact monitor path.
     capture_tool_messages: bool,
+    /// When true (and using the full-parse path), keep Codex tool use/result records.
+    include_tools: bool,
     #[cfg(test)]
     parse_count: usize,
     #[cfg(test)]
@@ -149,6 +152,7 @@ impl CodexSessionSource {
             archive_index: HashMap::new(),
             last_full_discovery: None,
             capture_tool_messages: false,
+            include_tools: false,
             #[cfg(test)]
             parse_count: 0,
             #[cfg(test)]
@@ -156,9 +160,10 @@ impl CodexSessionSource {
         }
     }
 
-    fn conversation_at_root(sessions_root: PathBuf) -> Self {
+    fn conversation_at_root(sessions_root: PathBuf, include_tools: bool) -> Self {
         Self {
             capture_tool_messages: true,
+            include_tools,
             ..Self::at_root(sessions_root)
         }
     }
@@ -227,6 +232,14 @@ impl CodexSessionSource {
     }
 
     fn summary_for(&mut self, path: &Path) -> Result<CodexRolloutSummary, std::io::Error> {
+        self.summary_for_with_progress(path, None)
+    }
+
+    fn summary_for_with_progress(
+        &mut self,
+        path: &Path,
+        mut on_progress: Option<&mut dyn FnMut(u64, u64)>,
+    ) -> Result<CodexRolloutSummary, std::io::Error> {
         let metadata = fs::metadata(path)?;
         let modified_nanos = metadata
             .modified()?
@@ -241,6 +254,9 @@ impl CodexSessionSource {
 
         if let Some(entry) = self.cache.get(path) {
             if entry.stamp == stamp {
+                if let Some(cb) = on_progress.as_mut() {
+                    cb(stamp.len, stamp.len);
+                }
                 return Ok(entry.summary.clone());
             }
         }
@@ -319,7 +335,10 @@ impl CodexSessionSource {
 
                 entry.offset = line_start + bytes_read as u64;
                 entry.logical_prefix_hash = hash_bytes(entry.logical_prefix_hash, &line);
-                apply_rollout_line(&mut entry.summary, &line, true);
+                apply_rollout_line(&mut entry.summary, &line, self.include_tools);
+                if let Some(cb) = on_progress.as_mut() {
+                    cb(entry.offset, stamp.len);
+                }
             }
         } else {
             loop {
@@ -567,14 +586,14 @@ fn apply_rollout_line(summary: &mut CodexRolloutSummary, line: &[u8], capture_to
     let Ok(value) = serde_json::from_slice::<Value>(line) else {
         return;
     };
-    apply_rollout_event_with_tools(summary, &value, capture_tool_messages);
+    apply_rollout_event_with_tools(summary, &value, capture_tool_messages, false);
 }
 
 fn apply_monitor_line(summary: &mut CodexRolloutSummary, line: &[u8]) {
     let Ok(value) = serde_json::from_slice::<Value>(line) else {
         return;
     };
-    apply_rollout_event_with_tools(summary, &value, false);
+    apply_rollout_event_with_tools(summary, &value, false, true);
 }
 
 fn truncate_monitor_message(message: &str) -> String {
@@ -912,6 +931,78 @@ fn collect_rollout_paths(root: &Path) -> Vec<PathBuf> {
     paths
 }
 
+fn thread_rollout_suffix(thread_id: &str) -> String {
+    format!("-{thread_id}.jsonl")
+}
+
+fn path_matches_thread(path: &Path, suffix: &str) -> bool {
+    path.file_name()
+        .and_then(|name| name.to_str())
+        .is_some_and(|name| name.starts_with("rollout-") && name.ends_with(suffix))
+}
+
+fn scan_recent_thread_rollouts(sessions_root: &Path, suffix: &str) -> Vec<PathBuf> {
+    let now = Local::now();
+    [now, now - chrono::Duration::days(1)]
+        .into_iter()
+        .flat_map(|day| {
+            let dir = sessions_root
+                .join(day.format("%Y").to_string())
+                .join(day.format("%m").to_string())
+                .join(day.format("%d").to_string());
+            fs::read_dir(dir)
+                .ok()
+                .into_iter()
+                .flatten()
+                .flatten()
+                .map(|entry| entry.path())
+        })
+        .filter(|path| path.is_file() && path_matches_thread(path, suffix))
+        .collect()
+}
+
+fn collect_thread_rollouts(sessions_root: &Path, suffix: &str) -> Vec<PathBuf> {
+    collect_rollout_paths(sessions_root)
+        .into_iter()
+        .filter(|path| path_matches_thread(path, suffix))
+        .collect()
+}
+
+/// Cache is a hint: union today's/yesterday's files so resume/compaction
+/// rollouts are not missed. If the cache is cold or every cached path is gone,
+/// fall through to a full walk.
+fn resolve_thread_rollout_paths(sessions_root: &Path, thread_id: &str) -> Vec<PathBuf> {
+    resolve_thread_rollout_paths_with_cache(
+        sessions_root,
+        thread_id,
+        super::codex_archive::cached_thread_paths(sessions_root, thread_id),
+    )
+}
+
+fn resolve_thread_rollout_paths_with_cache(
+    sessions_root: &Path,
+    thread_id: &str,
+    cached: Option<Vec<PathBuf>>,
+) -> Vec<PathBuf> {
+    let suffix = thread_rollout_suffix(thread_id);
+    if let Some(mut paths) = cached {
+        for path in scan_recent_thread_rollouts(sessions_root, &suffix) {
+            if !paths.iter().any(|existing| existing == &path) {
+                paths.push(path);
+            }
+        }
+        paths.retain(|path| path.is_file());
+        if !paths.is_empty() {
+            paths.sort();
+            return paths;
+        }
+    }
+
+    let mut paths = collect_thread_rollouts(sessions_root, &suffix);
+    paths.sort();
+    paths
+}
+
 fn thread_id_from_rollout_filename(path: &Path) -> Option<String> {
     let stem = path.file_stem()?.to_str()?;
     if stem.len() < 36 {
@@ -954,13 +1045,14 @@ fn parse_timestamp_millis(timestamp: &str) -> Option<i64> {
 
 #[cfg(test)]
 fn apply_rollout_event(summary: &mut CodexRolloutSummary, value: &Value) {
-    apply_rollout_event_with_tools(summary, value, false);
+    apply_rollout_event_with_tools(summary, value, false, true);
 }
 
 fn apply_rollout_event_with_tools(
     summary: &mut CodexRolloutSummary,
     value: &Value,
     capture_tool_messages: bool,
+    compact_for_monitor: bool,
 ) {
     let timestamp = value
         .get("timestamp")
@@ -975,9 +1067,7 @@ fn apply_rollout_event_with_tools(
     };
     match event_type {
         Some("session_meta") => apply_session_meta(summary, timestamp, payload),
-        Some("event_msg") => {
-            apply_event_message(summary, timestamp, payload, !capture_tool_messages)
-        }
+        Some("event_msg") => apply_event_message(summary, timestamp, payload, compact_for_monitor),
         Some("response_item") if capture_tool_messages => {
             apply_response_item(summary, timestamp, payload)
         }
@@ -1218,41 +1308,73 @@ fn rollback_messages(messages: &mut Vec<CodexMessage>, turns: usize) {
     }
 }
 
-pub fn find_codex_conversation(thread_id: &str) -> Result<Vec<CodexMessage>, String> {
+pub fn find_codex_conversation(
+    thread_id: &str,
+    include_tools: bool,
+) -> Result<Vec<CodexMessage>, String> {
+    find_codex_conversation_with_progress(thread_id, include_tools, &mut |_, _| {})
+}
+
+pub fn find_codex_conversation_with_progress(
+    thread_id: &str,
+    include_tools: bool,
+    on_progress: &mut dyn FnMut(u64, u64),
+) -> Result<Vec<CodexMessage>, String> {
     let home = dirs::home_dir().ok_or("Failed to get home directory")?;
-    find_codex_conversation_under(&home.join(".codex").join("sessions"), thread_id)
+    find_codex_conversation_under_with_progress(
+        &home.join(".codex").join("sessions"),
+        thread_id,
+        include_tools,
+        on_progress,
+    )
 }
 
 fn find_codex_conversation_under(
     sessions_root: &Path,
     thread_id: &str,
+    include_tools: bool,
 ) -> Result<Vec<CodexMessage>, String> {
-    let suffix = format!("-{thread_id}.jsonl");
-    let mut paths: Vec<_> = collect_rollout_paths(sessions_root)
-        .into_iter()
-        .filter(|path| {
-            path.file_name()
-                .and_then(|name| name.to_str())
-                .is_some_and(|name| name.ends_with(&suffix))
-        })
-        .collect();
-    paths.sort();
+    find_codex_conversation_under_with_progress(sessions_root, thread_id, include_tools, &mut |_, _| {})
+}
+
+fn find_codex_conversation_under_with_progress(
+    sessions_root: &Path,
+    thread_id: &str,
+    include_tools: bool,
+    on_progress: &mut dyn FnMut(u64, u64),
+) -> Result<Vec<CodexMessage>, String> {
+    let paths = resolve_thread_rollout_paths(sessions_root, thread_id);
     if paths.is_empty() {
         return Err(format!("Codex session {thread_id} not found"));
     }
 
-    let mut source = CodexSessionSource::conversation_at_root(sessions_root.to_path_buf());
+    let mut source =
+        CodexSessionSource::conversation_at_root(sessions_root.to_path_buf(), include_tools);
     let mut messages = Vec::new();
     let mut parsed_any = false;
     let mut last_error = None;
-    for path in paths {
-        match source.summary_for(&path) {
+    let file_lens: Vec<u64> = paths
+        .iter()
+        .map(|path| fs::metadata(path).map(|meta| meta.len()).unwrap_or(0))
+        .collect();
+    let total: u64 = file_lens.iter().sum();
+    on_progress(0, total);
+    let mut read_acc = 0u64;
+    for (path, file_len) in paths.into_iter().zip(file_lens) {
+        match source.summary_for_with_progress(
+            &path,
+            Some(&mut |file_read, _file_total| {
+                on_progress(read_acc.saturating_add(file_read.min(file_len)), total);
+            }),
+        ) {
             Ok(mut summary) => {
                 parsed_any = true;
                 messages.append(&mut summary.messages);
             }
             Err(error) => last_error = Some(error.to_string()),
         }
+        read_acc = read_acc.saturating_add(file_len);
+        on_progress(read_acc, total);
     }
     if !parsed_any {
         return Err(last_error.unwrap_or_else(|| format!("Codex session {thread_id} not found")));
@@ -1778,7 +1900,8 @@ mod tests {
         );
         assert!(monitor_summary.latest_message().unwrap().ends_with("..."));
 
-        let mut conversation = CodexSessionSource::conversation_at_root(temp.path().to_path_buf());
+        let mut conversation =
+            CodexSessionSource::conversation_at_root(temp.path().to_path_buf(), false);
         let conversation_summary = conversation.summary_for(&path).unwrap();
         assert_eq!(
             conversation_summary.latest_message().unwrap(),
@@ -2326,6 +2449,7 @@ mod tests {
                 "payload":{"type":"function_call","name":"exec_command","call_id":"call-1","arguments":"{\"cmd\":\"pwd\"}"}
             }),
             true,
+            false,
         );
         apply_rollout_event_with_tools(
             &mut summary,
@@ -2334,6 +2458,7 @@ mod tests {
                 "payload":{"type":"function_call_output","call_id":"call-1","output":"/tmp/project"}
             }),
             true,
+            false,
         );
 
         assert_eq!(summary.messages.len(), 2);
@@ -2401,7 +2526,7 @@ mod tests {
             serde_json::json!({"type":"message", "role":"user", "content":"injected"}),
         ));
         write_lines(&path, &lines, true);
-        let messages = find_codex_conversation_under(temp.path(), "thread-id").unwrap();
+        let messages = find_codex_conversation_under(temp.path(), "thread-id", true).unwrap();
         assert_eq!(messages.len(), 1);
         assert_eq!(messages[0].content, "hello");
     }
@@ -2425,10 +2550,100 @@ mod tests {
         ));
         write_lines(&path, &lines, true);
 
-        let messages = find_codex_conversation_under(temp.path(), "thread-id").unwrap();
+        let messages = find_codex_conversation_under(temp.path(), "thread-id", true).unwrap();
         assert_eq!(messages.len(), 3);
         assert_eq!(messages[1].message_type, MessageType::ToolUse);
         assert_eq!(messages[2].message_type, MessageType::ToolResult);
+
+        let without_tools = find_codex_conversation_under(temp.path(), "thread-id", false).unwrap();
+        assert_eq!(without_tools.len(), 1);
+        assert_eq!(without_tools[0].content, "hello");
+    }
+
+    #[test]
+    fn conversation_lookup_reports_byte_progress() {
+        let temp = TempDir::new().unwrap();
+        let day = temp.path().join("2026/07/13");
+        fs::create_dir_all(&day).unwrap();
+        let path = day.join("rollout-2026-07-13T00-00-00-thread-id.jsonl");
+        let lines = root_fixture(Value::String("cli".into()), "codex-tui");
+        write_lines(&path, &lines, true);
+        let total = fs::metadata(&path).unwrap().len();
+
+        let mut reports = Vec::new();
+        let messages = find_codex_conversation_under_with_progress(
+            temp.path(),
+            "thread-id",
+            false,
+            &mut |read, reported_total| reports.push((read, reported_total)),
+        )
+        .unwrap();
+
+        assert_eq!(messages.len(), 1);
+        assert!(!reports.is_empty());
+        assert_eq!(reports[0], (0, total));
+        assert_eq!(*reports.last().unwrap(), (total, total));
+        assert!(reports.windows(2).all(|pair| pair[0].0 <= pair[1].0));
+        assert!(reports.iter().all(|(_, reported)| *reported == total));
+    }
+
+    #[test]
+    fn conversation_lookup_unions_cached_paths_with_recent_day_files() {
+        let temp = TempDir::new().unwrap();
+        let old_day = temp.path().join("2026/07/12");
+        fs::create_dir_all(&old_day).unwrap();
+        let old_path = old_day.join("rollout-2026-07-12T23-00-00-thread-id.jsonl");
+        write_lines(
+            &old_path,
+            &root_fixture(Value::String("cli".into()), "codex-tui"),
+            true,
+        );
+
+        let now = Local::now();
+        let today = temp
+            .path()
+            .join(now.format("%Y").to_string())
+            .join(now.format("%m").to_string())
+            .join(now.format("%d").to_string());
+        fs::create_dir_all(&today).unwrap();
+        let new_path = today.join("rollout-today-thread-id.jsonl");
+        write_lines(
+            &new_path,
+            &[event(
+                "2026-08-19T00:00:04Z",
+                "event_msg",
+                serde_json::json!({"type":"user_message","message":"resumed"}),
+            )],
+            true,
+        );
+
+        let resolved = resolve_thread_rollout_paths_with_cache(
+            temp.path(),
+            "thread-id",
+            Some(vec![old_path.clone()]),
+        );
+        assert!(resolved.contains(&old_path));
+        assert!(resolved.contains(&new_path));
+    }
+
+    #[test]
+    fn conversation_lookup_falls_back_to_walk_when_cached_paths_are_gone() {
+        let temp = TempDir::new().unwrap();
+        let old_day = temp.path().join("2026/07/12");
+        fs::create_dir_all(&old_day).unwrap();
+        let old_path = old_day.join("rollout-2026-07-12T23-00-00-thread-id.jsonl");
+        write_lines(
+            &old_path,
+            &root_fixture(Value::String("cli".into()), "codex-tui"),
+            true,
+        );
+
+        let resolved = resolve_thread_rollout_paths_with_cache(
+            temp.path(),
+            "thread-id",
+            Some(vec![old_day.join("deleted.jsonl")]),
+        );
+        assert_eq!(resolved, vec![old_path]);
     }
 
     #[test]
@@ -2478,7 +2693,7 @@ mod tests {
             true,
         );
 
-        let messages = find_codex_conversation_under(temp.path(), "thread-id").unwrap();
+        let messages = find_codex_conversation_under(temp.path(), "thread-id", true).unwrap();
         assert_eq!(messages.len(), 2);
         assert_eq!(messages[0].content, "first prompt");
         assert_eq!(messages[1].content, "resumed answer");

--- a/src-tauri/src/session/codex.rs
+++ b/src-tauri/src/session/codex.rs
@@ -1,12 +1,12 @@
 use super::cache::FileVersion;
 use chrono::{DateTime, Local};
-use serde::de::{self, Deserializer, MapAccess, Visitor};
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 use std::collections::{HashMap, HashSet};
 use std::fs::{self, File};
 use std::io::{self, BufRead, BufReader, Read, Seek, SeekFrom};
 use std::path::{Path, PathBuf};
+use std::sync::{LazyLock, Mutex};
 use std::time::SystemTime;
 
 use super::parser::MessageType;
@@ -37,6 +37,25 @@ const FNV_OFFSET_BASIS: u64 = 0xcbf29ce484222325;
 const FNV_PRIME: u64 = 0x100000001b3;
 // The 64-bit prefix digest keeps replacement detection bounded; a theoretical
 // digest collision is preferable to retaining the previous transcript bytes.
+const CODEX_SESSION_INDEX_FILENAME: &str = "session_index.jsonl";
+
+#[derive(Debug, Deserialize)]
+struct CodexSessionIndexEntry {
+    #[serde(default)]
+    id: String,
+    #[serde(default)]
+    thread_name: Option<String>,
+}
+
+type CodexThreadTitleStamp = FileVersion;
+
+/// Codex keeps its UI thread names in a small append-only index separate from
+/// the rollout transcript. Cache the parsed map, but invalidate it whenever
+/// the index file changes so title updates appear without re-reading it for
+/// every detected session.
+static CODEX_THREAD_TITLE_CACHE: LazyLock<
+    Mutex<Option<(CodexThreadTitleStamp, HashMap<String, String>)>>,
+> = LazyLock::new(|| Mutex::new(None));
 
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
 pub enum CodexLifecycle {
@@ -45,7 +64,7 @@ pub enum CodexLifecycle {
     Idle,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct CodexMessage {
     pub timestamp: String,
@@ -54,7 +73,21 @@ pub struct CodexMessage {
     pub content: String,
     #[serde(skip)]
     content_identity: MessageIdentity,
+    #[serde(skip)]
+    title_candidate: bool,
 }
+
+impl PartialEq for CodexMessage {
+    fn eq(&self, other: &Self) -> bool {
+        self.timestamp == other.timestamp
+            && self.role == other.role
+            && self.message_type == other.message_type
+            && self.content == other.content
+            && self.content_identity == other.content_identity
+    }
+}
+
+impl Eq for CodexMessage {}
 
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord)]
 struct MessageIdentity {
@@ -84,7 +117,7 @@ impl CodexRolloutSummary {
     pub fn first_prompt(&self) -> Option<&str> {
         self.messages
             .iter()
-            .find(|message| message.role == "user")
+            .find(|message| message.role == "user" && message.title_candidate)
             .map(|message| message.content.as_str())
     }
 
@@ -100,6 +133,77 @@ impl CodexRolloutSummary {
             })
             .map(|message| message.content.as_str())
     }
+}
+
+/// Parse Codex's local session index. The file can contain multiple records
+/// for one session as its title changes, so the last valid record wins.
+pub(crate) fn parse_codex_thread_titles(content: &str) -> HashMap<String, String> {
+    let mut titles = HashMap::new();
+    for line in content.lines() {
+        let Ok(entry) = serde_json::from_str::<CodexSessionIndexEntry>(line) else {
+            continue;
+        };
+        let session_id = entry.id.trim();
+        if session_id.is_empty() {
+            continue;
+        }
+        match entry
+            .thread_name
+            .map(|title| title.trim().to_string())
+            .filter(|title| !title.is_empty())
+        {
+            Some(title) => {
+                titles.insert(session_id.to_string(), title);
+            }
+            None => {
+                titles.remove(session_id);
+            }
+        }
+    }
+    titles
+}
+
+fn codex_session_index_path() -> Option<PathBuf> {
+    dirs::home_dir().map(|home| home.join(".codex").join(CODEX_SESSION_INDEX_FILENAME))
+}
+
+fn read_codex_thread_titles(path: &Path) -> HashMap<String, String> {
+    fs::read_to_string(path)
+        .map(|content| parse_codex_thread_titles(&content))
+        .unwrap_or_default()
+}
+
+/// Read the Codex UI title for a session, if the local Codex index provides
+/// one. This is intentionally best-effort because the index is an internal
+/// local file rather than a documented provider API.
+pub(crate) fn get_cached_codex_thread_title(session_id: &str) -> Option<String> {
+    if session_id.trim().is_empty() {
+        return None;
+    }
+    let path = codex_session_index_path()?;
+    let stamp = match FileVersion::read(&path) {
+        Ok(stamp) => stamp,
+        Err(_) => {
+            if let Ok(mut cache) = CODEX_THREAD_TITLE_CACHE.lock() {
+                *cache = None;
+            }
+            return None;
+        }
+    };
+
+    if let Ok(mut cache) = CODEX_THREAD_TITLE_CACHE.lock() {
+        let cache_is_current = cache.as_ref().is_some_and(|(cached_stamp, _)| {
+            *cached_stamp == stamp && stamp.supports_unchanged_fast_path()
+        });
+        if !cache_is_current {
+            *cache = Some((stamp, read_codex_thread_titles(&path)));
+        }
+        return cache
+            .as_ref()
+            .and_then(|(_, titles)| titles.get(session_id).cloned());
+    }
+
+    read_codex_thread_titles(&path).remove(session_id)
 }
 
 type FileStamp = FileVersion;
@@ -363,10 +467,7 @@ impl CodexSessionSource {
                 let Some(header) = record.header else {
                     continue;
                 };
-                let relevant = matches!(
-                    header.event_type.as_deref(),
-                    Some("session_meta" | "event_msg")
-                );
+                let relevant = monitor_record_is_relevant(&header);
                 if relevant {
                     let line = match record.line {
                         Some(line) => line,
@@ -520,57 +621,232 @@ struct RolloutEventHeader {
     timestamp: Option<String>,
     #[serde(rename = "type")]
     event_type: Option<String>,
+    #[serde(skip)]
+    payload_type: Option<String>,
 }
 
-struct RolloutHeaderVisitor<'a> {
-    header: &'a mut Option<RolloutEventHeader>,
+struct JsonHeaderScanner<'a> {
+    bytes: &'a [u8],
+    position: usize,
 }
 
-impl<'de, 'a> Visitor<'de> for RolloutHeaderVisitor<'a> {
-    type Value = RolloutEventHeader;
-
-    fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        formatter.write_str("a rollout JSON object")
+impl<'a> JsonHeaderScanner<'a> {
+    fn new(bytes: &'a [u8]) -> Self {
+        Self { bytes, position: 0 }
     }
 
-    fn visit_map<M>(self, mut map: M) -> Result<Self::Value, M::Error>
-    where
-        M: MapAccess<'de>,
-    {
-        let mut timestamp = None;
-        let mut event_type = None;
-        let mut timestamp_seen = false;
-        let mut event_type_seen = false;
+    fn peek(&self) -> Option<u8> {
+        self.bytes.get(self.position).copied()
+    }
 
-        while let Some(key) = map.next_key::<String>()? {
-            match key.as_str() {
-                "timestamp" => {
-                    timestamp_seen = true;
-                    timestamp = map.next_value()?;
-                }
-                "type" => {
-                    event_type_seen = true;
-                    event_type = map.next_value()?;
-                }
-                _ => {
-                    map.next_value::<de::IgnoredAny>()?;
-                }
-            }
+    fn skip_whitespace(&mut self) {
+        while self
+            .peek()
+            .is_some_and(|byte| matches!(byte, b' ' | b'\n' | b'\r' | b'\t'))
+        {
+            self.position += 1;
+        }
+    }
 
-            if timestamp_seen && event_type_seen {
-                let header = RolloutEventHeader {
-                    timestamp,
-                    event_type,
-                };
-                *self.header = Some(header.clone());
-                return Ok(header);
+    fn read_string(&mut self) -> Option<String> {
+        let start = self.position;
+        if self.peek()? != b'"' {
+            return None;
+        }
+        self.position += 1;
+        while let Some(byte) = self.peek() {
+            match byte {
+                b'\\' => {
+                    self.position += 1;
+                    self.position += 1;
+                }
+                b'"' => {
+                    self.position += 1;
+                    return serde_json::from_slice(&self.bytes[start..self.position]).ok();
+                }
+                _ => self.position += 1,
             }
         }
+        None
+    }
 
-        Ok(RolloutEventHeader {
-            timestamp,
-            event_type,
-        })
+    fn skip_string(&mut self) -> Option<()> {
+        self.read_string().map(|_| ())
+    }
+
+    fn skip_value(&mut self) -> Option<()> {
+        self.skip_whitespace();
+        match self.peek()? {
+            b'"' => self.skip_string(),
+            b'{' => self.skip_object(),
+            b'[' => self.skip_array(),
+            _ => {
+                while self.peek().is_some_and(|byte| {
+                    !matches!(byte, b',' | b']' | b'}' | b' ' | b'\n' | b'\r' | b'\t')
+                }) {
+                    self.position += 1;
+                }
+                Some(())
+            }
+        }
+    }
+
+    fn skip_object(&mut self) -> Option<()> {
+        if self.peek()? != b'{' {
+            return None;
+        }
+        self.position += 1;
+        self.skip_whitespace();
+        if self.peek() == Some(b'}') {
+            self.position += 1;
+            return Some(());
+        }
+        loop {
+            self.skip_whitespace();
+            self.read_string()?;
+            self.skip_whitespace();
+            if self.peek()? != b':' {
+                return None;
+            }
+            self.position += 1;
+            self.skip_value()?;
+            self.skip_whitespace();
+            match self.peek()? {
+                b',' => self.position += 1,
+                b'}' => {
+                    self.position += 1;
+                    return Some(());
+                }
+                _ => return None,
+            }
+        }
+    }
+
+    fn skip_array(&mut self) -> Option<()> {
+        if self.peek()? != b'[' {
+            return None;
+        }
+        self.position += 1;
+        self.skip_whitespace();
+        if self.peek() == Some(b']') {
+            self.position += 1;
+            return Some(());
+        }
+        loop {
+            self.skip_value()?;
+            self.skip_whitespace();
+            match self.peek()? {
+                b',' => self.position += 1,
+                b']' => {
+                    self.position += 1;
+                    return Some(());
+                }
+                _ => return None,
+            }
+        }
+    }
+
+    fn payload_type(&mut self) -> Option<String> {
+        self.skip_whitespace();
+        if self.peek()? != b'{' {
+            self.skip_value()?;
+            return None;
+        }
+        self.position += 1;
+        self.skip_whitespace();
+        if self.peek() == Some(b'}') {
+            self.position += 1;
+            return None;
+        }
+        loop {
+            self.skip_whitespace();
+            let key = self.read_string()?;
+            self.skip_whitespace();
+            if self.peek()? != b':' {
+                return None;
+            }
+            self.position += 1;
+            self.skip_whitespace();
+            if key == "type" {
+                return self.read_string();
+            }
+            self.skip_value()?;
+            self.skip_whitespace();
+            match self.peek()? {
+                b',' => self.position += 1,
+                b'}' => {
+                    self.position += 1;
+                    return None;
+                }
+                _ => return None,
+            }
+        }
+    }
+}
+
+fn scan_monitor_header(bytes: &[u8]) -> Option<RolloutEventHeader> {
+    let mut scanner = JsonHeaderScanner::new(bytes);
+    scanner.skip_whitespace();
+    if scanner.peek()? != b'{' {
+        return None;
+    }
+    scanner.position += 1;
+
+    let mut timestamp = None;
+    let mut event_type = None;
+    let mut payload_type = None;
+    loop {
+        scanner.skip_whitespace();
+        let key = scanner.read_string()?;
+        scanner.skip_whitespace();
+        if scanner.peek()? != b':' {
+            return None;
+        }
+        scanner.position += 1;
+        scanner.skip_whitespace();
+        match key.as_str() {
+            "timestamp" => timestamp = Some(scanner.read_string()?),
+            "type" => {
+                event_type = Some(scanner.read_string()?);
+                if event_type.as_deref() != Some("response_item") {
+                    return Some(RolloutEventHeader {
+                        timestamp,
+                        event_type,
+                        payload_type,
+                    });
+                }
+            }
+            "payload" if event_type.as_deref() == Some("response_item") => {
+                payload_type = scanner.payload_type();
+                return Some(RolloutEventHeader {
+                    timestamp,
+                    event_type,
+                    payload_type,
+                });
+            }
+            _ => scanner.skip_value()?,
+        }
+
+        scanner.skip_whitespace();
+        match scanner.peek()? {
+            b',' => scanner.position += 1,
+            b'}' => {
+                return Some(RolloutEventHeader {
+                    timestamp,
+                    event_type,
+                    payload_type,
+                });
+            }
+            _ => return None,
+        }
+    }
+}
+
+fn monitor_record_is_relevant(header: &RolloutEventHeader) -> bool {
+    match header.event_type.as_deref() {
+        Some("session_meta" | "event_msg") => true,
+        Some("response_item") => header.payload_type.as_deref() == Some("message"),
+        _ => false,
     }
 }
 
@@ -628,8 +904,18 @@ fn push_codex_message(
     message_type: MessageType,
     content: String,
     compact_for_monitor: bool,
+    title_candidate: bool,
 ) {
     let content_identity = message_identity(&content);
+    if let Some(existing) = summary.messages.iter_mut().find(|message| {
+        message.timestamp == timestamp
+            && message.role == role
+            && message.message_type == message_type
+            && message.content_identity == content_identity
+    }) {
+        existing.title_candidate |= title_candidate;
+        return;
+    }
     let content = if compact_for_monitor {
         truncate_monitor_message(&content)
     } else {
@@ -641,7 +927,22 @@ fn push_codex_message(
         message_type,
         content,
         content_identity,
+        title_candidate,
     });
+}
+
+fn dedup_codex_messages(messages: &mut Vec<CodexMessage>) {
+    let mut deduplicated: Vec<CodexMessage> = Vec::with_capacity(messages.len());
+    for message in messages.drain(..) {
+        if let Some(existing) = deduplicated.last_mut() {
+            if existing == &message {
+                existing.title_candidate |= message.title_candidate;
+                continue;
+            }
+        }
+        deduplicated.push(message);
+    }
+    *messages = deduplicated;
 }
 
 type LiveRolloutSummary = (PathBuf, CodexRolloutSummary, u64);
@@ -694,7 +995,7 @@ fn merge_live_rollout_summary(existing: &mut LiveRolloutSummary, mut incoming: L
             .then_with(|| left.content.cmp(&right.content))
             .then_with(|| left.content_identity.cmp(&right.content_identity))
     });
-    messages.dedup();
+    dedup_codex_messages(&mut messages);
 
     if incoming_is_newer {
         *existing = incoming;
@@ -821,22 +1122,25 @@ fn read_monitor_line(
     logical_prefix_hash: u64,
 ) -> io::Result<MonitorLine> {
     let mut line_reader = JsonlLineReader::new(reader, logical_prefix_hash);
-    // serde_json calls end_map after the visitor returns. Keep the early
-    // header separately so that end_map cannot force a payload traversal.
-    let mut peeked_header = None;
-    let parsed_header = {
-        let mut deserializer = serde_json::Deserializer::from_reader(&mut line_reader);
-        (&mut deserializer).deserialize_map(RolloutHeaderVisitor {
-            header: &mut peeked_header,
-        })
-    };
-    let header = parsed_header.ok().or(peeked_header);
-    let relevant = header.as_ref().is_some_and(|header| {
-        matches!(
-            header.event_type.as_deref(),
-            Some("session_meta" | "event_msg")
-        )
-    });
+    // Read only a bounded prefix while a byte scanner identifies the outer
+    // event type and, for response_item records, the payload type. This keeps
+    // large reasoning/tool records out of serde_json::Value on the monitor
+    // path while still allowing message records through for titles/previews.
+    let mut probe = [0u8; MONITOR_HEADER_CAPTURE_BYTES];
+    let mut header = None;
+    while !line_reader.complete && line_reader.bytes_read < MONITOR_HEADER_CAPTURE_BYTES as u64 {
+        if line_reader.read(&mut probe)? == 0 {
+            break;
+        }
+        header = scan_monitor_header(&line_reader.captured);
+        if header.is_some() {
+            break;
+        }
+    }
+    if header.is_none() {
+        header = scan_monitor_header(&line_reader.captured);
+    }
+    let relevant = header.as_ref().is_some_and(monitor_record_is_relevant);
     line_reader.drain_to_newline(relevant)?;
     let line = if relevant && line_reader.complete && !line_reader.capture_overflowed {
         Some(std::mem::take(&mut line_reader.captured))
@@ -1008,8 +1312,8 @@ fn apply_rollout_event_with_tools(
         Some("event_msg") => {
             apply_event_message(summary, timestamp, payload, !capture_tool_messages)
         }
-        Some("response_item") if capture_tool_messages => {
-            apply_response_item(summary, timestamp, payload)
+        Some("response_item") => {
+            apply_response_item(summary, timestamp, payload, capture_tool_messages)
         }
         _ => {}
     }
@@ -1130,6 +1434,9 @@ fn apply_event_message(
                     },
                     content.to_string(),
                     compact_for_monitor,
+                    role == "user"
+                        && !crate::session::parser::is_system_content(content)
+                        && !is_codex_context_message(content),
                 );
             }
         }
@@ -1168,11 +1475,130 @@ fn response_item_id(payload: &Value) -> &str {
         .unwrap_or("unknown")
 }
 
-fn apply_response_item(summary: &mut CodexRolloutSummary, timestamp: &str, payload: &Value) {
+fn response_item_content_text(content: &Value) -> Option<String> {
+    match content {
+        Value::String(text) => Some(text.clone()),
+        Value::Array(blocks) => {
+            let mut texts = Vec::new();
+            for block in blocks {
+                let text = match block {
+                    Value::String(text) => Some(text.as_str()),
+                    Value::Object(object) => {
+                        let kind = object.get("type").and_then(Value::as_str);
+                        let is_text_block = kind.is_none()
+                            || matches!(
+                                kind,
+                                Some("input_text" | "output_text" | "text" | "refusal")
+                            );
+                        if is_text_block {
+                            object.get("text").and_then(Value::as_str)
+                        } else {
+                            None
+                        }
+                    }
+                    _ => None,
+                };
+                if let Some(text) = text.filter(|text| !text.is_empty()) {
+                    texts.push(text);
+                }
+            }
+            (!texts.is_empty()).then(|| texts.join("\n"))
+        }
+        Value::Object(object) => object
+            .get("text")
+            .and_then(Value::as_str)
+            .map(str::to_string),
+        _ => None,
+    }
+}
+
+const CODEX_CONTEXT_PREFIXES: &[&str] = &[
+    "<app-context>",
+    "<recommended_plugins>",
+    "<environment_context>",
+    "<permissions instructions>",
+    "<collaboration_mode>",
+    "<apps_instructions>",
+    "<plugins_instructions>",
+    "<skills_instructions>",
+    "# AGENTS.md instructions",
+    "## Memory",
+    "# Memory",
+];
+
+fn is_codex_context_message(content: &str) -> bool {
+    let trimmed = content.trim_start();
+    CODEX_CONTEXT_PREFIXES
+        .iter()
+        .any(|prefix| trimmed.starts_with(prefix))
+}
+
+fn response_item_title_candidate(payload: &Value, role: &str, content: &str) -> bool {
+    if role != "user" {
+        return false;
+    }
+    payload
+        .get("internal_chat_message_metadata_passthrough")
+        .and_then(|metadata| metadata.get("content_item_kinds"))
+        .and_then(Value::as_array)
+        .map(|kinds| {
+            kinds
+                .iter()
+                .filter_map(Value::as_str)
+                .any(|kind| kind == "user.text")
+        })
+        .unwrap_or(!is_codex_context_message(content))
+}
+
+pub(crate) fn response_item_message_text(payload: &Value) -> Option<(String, String, bool)> {
+    if payload.get("type").and_then(Value::as_str) != Some("message") {
+        return None;
+    }
+    let role = match payload.get("role").and_then(Value::as_str) {
+        Some("user") => "user",
+        Some("assistant") => "assistant",
+        // Developer messages are runtime instructions, not user-facing
+        // conversation content.
+        _ => return None,
+    };
+    let content = response_item_content_text(payload.get("content")?)?;
+    if content.trim().is_empty() {
+        return None;
+    }
+    let title_candidate = response_item_title_candidate(payload, role, &content);
+    Some((role.to_string(), content, title_candidate))
+}
+
+fn apply_response_item(
+    summary: &mut CodexRolloutSummary,
+    timestamp: &str,
+    payload: &Value,
+    capture_tool_messages: bool,
+) {
     let Some(kind) = payload.get("type").and_then(Value::as_str) else {
         return;
     };
     let (message_type, role, content) = match kind {
+        "message" => {
+            let Some((role, content, title_candidate)) = response_item_message_text(payload) else {
+                return;
+            };
+            push_codex_message(
+                summary,
+                timestamp,
+                &role,
+                if role == "user" {
+                    MessageType::User
+                } else {
+                    MessageType::Assistant
+                },
+                content,
+                !capture_tool_messages,
+                title_candidate,
+            );
+            return;
+        }
+        _ if !capture_tool_messages => return,
         "function_call" | "custom_tool_call" => {
             let name = payload
                 .get("name")
@@ -1229,11 +1655,17 @@ fn apply_response_item(summary: &mut CodexRolloutSummary, timestamp: &str, paylo
                 ),
             )
         }
-        // Message and reasoning response items have equivalent public event_msg
-        // records. Ignoring them avoids duplicate conversation content.
         _ => return,
     };
-    push_codex_message(summary, timestamp, role, message_type, content, false);
+    push_codex_message(
+        summary,
+        timestamp,
+        role,
+        message_type,
+        content,
+        false,
+        false,
+    );
 }
 
 fn rollback_messages(messages: &mut Vec<CodexMessage>, turns: usize) {
@@ -1294,7 +1726,7 @@ fn find_codex_conversation_under(
             .then_with(|| left.content.cmp(&right.content))
             .then_with(|| left.content_identity.cmp(&right.content_identity))
     });
-    messages.dedup();
+    dedup_codex_messages(&mut messages);
     Ok(messages)
 }
 
@@ -1370,6 +1802,22 @@ mod tests {
             .iter()
             .filter_map(|session| session.session_id.as_deref())
             .collect()
+    }
+
+    #[test]
+    fn codex_thread_title_index_uses_latest_valid_record() {
+        let titles = parse_codex_thread_titles(
+            r#"
+            {"id":"session-a","thread_name":"old title","updated_at":"2026-09-02T01:00:00Z"}
+            not-json
+            {"id":"session-b","thread_name":"  Keep this title  "}
+            {"id":"session-a","thread_name":"new title","updated_at":"2026-09-02T02:00:00Z"}
+            {"id":"session-b","thread_name":""}
+            "#,
+        );
+
+        assert_eq!(titles.get("session-a"), Some(&"new title".to_string()));
+        assert!(!titles.contains_key("session-b"));
     }
 
     #[test]
@@ -1912,7 +2360,8 @@ mod tests {
         let mut source = CodexSessionSource::at_root(temp.path().to_path_buf());
         let summary = source.summary_for(&path).unwrap();
         assert_eq!(summary.last_timestamp, "2026-07-13T00:00:02Z");
-        assert!(summary.messages.is_empty());
+        assert_eq!(summary.messages.len(), 1);
+        assert_eq!(summary.latest_message(), Some("large duplicate"));
     }
 
     #[test]
@@ -2377,16 +2826,50 @@ mod tests {
     }
 
     #[test]
-    fn response_item_messages_are_not_duplicated_into_conversations() {
+    fn response_item_messages_are_included_in_conversations() {
         let mut summary = CodexRolloutSummary::default();
         apply_rollout_event(
             &mut summary,
             &serde_json::json!({
                 "timestamp":"2026-07-13T00:00:00Z", "type":"response_item",
-                "payload":{"type":"message","role":"user","content":"injected"}
+                "payload":{"type":"message","role":"user","content":[
+                    {"type":"input_text","text":"injected"}
+                ]}
             }),
         );
-        assert!(summary.messages.is_empty());
+        assert_eq!(summary.messages.len(), 1);
+        assert_eq!(summary.messages[0].role, "user");
+        assert_eq!(summary.messages[0].message_type, MessageType::User);
+        assert_eq!(summary.messages[0].content, "injected");
+    }
+
+    #[test]
+    fn response_item_messages_join_text_blocks_and_ignore_non_display_roles() {
+        let mut summary = CodexRolloutSummary::default();
+        apply_rollout_event(
+            &mut summary,
+            &serde_json::json!({
+                "timestamp":"2026-07-13T00:00:00Z", "type":"response_item",
+                "payload":{"type":"message","role":"assistant","content":[
+                    {"type":"output_text","text":"first"},
+                    {"type":"input_image","image_url":"data:image/png;base64,ignored"},
+                    {"type":"output_text","text":"second"}
+                ]}
+            }),
+        );
+        apply_rollout_event(
+            &mut summary,
+            &serde_json::json!({
+                "timestamp":"2026-07-13T00:00:01Z", "type":"response_item",
+                "payload":{"type":"message","role":"developer","content":[
+                    {"type":"input_text","text":"hidden instructions"}
+                ]}
+            }),
+        );
+
+        assert_eq!(summary.messages.len(), 1);
+        assert_eq!(summary.messages[0].message_type, MessageType::Assistant);
+        assert_eq!(summary.messages[0].content, "first\nsecond");
     }
 
     #[test]
@@ -2415,6 +2898,54 @@ mod tests {
         assert!(summary.messages[0].content.contains("pwd"));
         assert_eq!(summary.messages[1].message_type, MessageType::ToolResult);
         assert!(summary.messages[1].content.contains("/tmp/project"));
+    }
+
+    #[test]
+    fn monitor_parses_codex_response_item_message_with_metadata() {
+        let temp = TempDir::new().unwrap();
+        let path = temp.path().join("rollout-codex-message.jsonl");
+        write_lines(
+            &path,
+            &[
+                event(
+                    "2026-07-13T00:00:00Z",
+                    "session_meta",
+                    serde_json::json!({
+                        "id":"codex-message", "cwd":"/tmp/project",
+                        "source":"vscode", "originator":"Codex Desktop"
+                    }),
+                ),
+                event(
+                    "2026-07-13T00:00:00Z",
+                    "response_item",
+                    serde_json::json!({
+                        "type":"message", "id":"context-1", "role":"user",
+                        "content":[{"type":"input_text", "text":"<recommended_plugins> injected context"}],
+                        "internal_chat_message_metadata_passthrough":{
+                            "turn_id":"turn-1",
+                            "content_item_kinds":["plugins.recommendations"]
+                        }
+                    }),
+                ),
+                event(
+                    "2026-07-13T00:00:01Z",
+                    "response_item",
+                    serde_json::json!({
+                        "type":"message", "id":"msg-1", "role":"user",
+                        "content":[{"type":"input_text", "text":"first prompt"}],
+                        "internal_chat_message_metadata_passthrough":{
+                            "turn_id":"turn-1", "content_item_kinds":["user.text"]
+                        }
+                    }),
+                ),
+            ],
+            true,
+        );
+
+        let mut source = CodexSessionSource::at_root(temp.path().to_path_buf());
+        let summary = source.summary_for(&path).unwrap();
+        assert_eq!(summary.first_prompt(), Some("first prompt"));
+        assert_eq!(summary.messages.len(), 2);
     }
 
     #[test]
@@ -2462,21 +2993,33 @@ mod tests {
     }
 
     #[test]
-    fn conversation_lookup_ignores_duplicate_response_item_messages() {
+    fn conversation_lookup_supports_mixed_message_formats_and_deduplicates_exact_overlap() {
         let temp = TempDir::new().unwrap();
         let day = temp.path().join("2026/07/13");
         fs::create_dir_all(&day).unwrap();
         let path = day.join("rollout-2026-07-13T00-00-00-thread-id.jsonl");
         let mut lines = root_fixture(Value::String("cli".into()), "codex-tui");
         lines.push(event(
+            "2026-07-13T00:00:01Z",
+            "response_item",
+            serde_json::json!({
+                "type":"message", "role":"user",
+                "content":[{"type":"input_text", "text":"hello"}]
+            }),
+        ));
+        lines.push(event(
             "2026-07-13T00:00:04Z",
             "response_item",
-            serde_json::json!({"type":"message", "role":"user", "content":"injected"}),
+            serde_json::json!({
+                "type":"message", "role":"assistant",
+                "content":[{"type":"output_text", "text":"injected"}]
+            }),
         ));
         write_lines(&path, &lines, true);
         let messages = find_codex_conversation_under(temp.path(), "thread-id").unwrap();
-        assert_eq!(messages.len(), 1);
+        assert_eq!(messages.len(), 2);
         assert_eq!(messages[0].content, "hello");
+        assert_eq!(messages[1].content, "injected");
     }
 
     #[test]

--- a/src-tauri/src/session/codex.rs
+++ b/src-tauri/src/session/codex.rs
@@ -1,3 +1,4 @@
+use super::cache::FileVersion;
 use chrono::{DateTime, Local};
 use serde::de::{self, Deserializer, MapAccess, Visitor};
 use serde::{Deserialize, Serialize};
@@ -6,7 +7,7 @@ use std::collections::{HashMap, HashSet};
 use std::fs::{self, File};
 use std::io::{self, BufRead, BufReader, Read, Seek, SeekFrom};
 use std::path::{Path, PathBuf};
-use std::time::{SystemTime, UNIX_EPOCH};
+use std::time::SystemTime;
 
 use super::parser::MessageType;
 use super::source::{
@@ -101,12 +102,7 @@ impl CodexRolloutSummary {
     }
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-struct FileStamp {
-    len: u64,
-    modified_nanos: u128,
-    identity: u64,
-}
+type FileStamp = FileVersion;
 
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
 struct FileSignature {
@@ -142,7 +138,7 @@ impl CodexSessionSource {
         Ok(Self::at_root(home.join(".codex").join("sessions")))
     }
 
-    fn at_root(sessions_root: PathBuf) -> Self {
+    pub(crate) fn at_root(sessions_root: PathBuf) -> Self {
         Self {
             sessions_root,
             cache: HashMap::new(),
@@ -154,6 +150,17 @@ impl CodexSessionSource {
             #[cfg(test)]
             reset_count: 0,
         }
+    }
+
+    pub(crate) fn contains_session_id(&self, session_id: &str) -> bool {
+        collect_rollout_paths(&self.sessions_root)
+            .iter()
+            .any(|path| thread_id_from_rollout_filename(path).as_deref() == Some(session_id))
+    }
+
+    #[cfg(test)]
+    pub(crate) fn parse_count_for_test(&self) -> usize {
+        self.parse_count
     }
 
     fn conversation_at_root(sessions_root: PathBuf) -> Self {
@@ -227,20 +234,34 @@ impl CodexSessionSource {
     }
 
     fn summary_for(&mut self, path: &Path) -> Result<CodexRolloutSummary, std::io::Error> {
-        let metadata = fs::metadata(path)?;
-        let modified_nanos = metadata
-            .modified()?
-            .duration_since(UNIX_EPOCH)
-            .unwrap_or_default()
-            .as_nanos();
-        let stamp = FileStamp {
-            len: metadata.len(),
-            modified_nanos,
-            identity: file_identity(&metadata),
-        };
+        const MAX_READ_ATTEMPTS: usize = 3;
 
+        for _ in 0..MAX_READ_ATTEMPTS {
+            let stamp = file_stamp(path)?;
+            let summary = self.summary_for_once(path, stamp)?;
+            let after = file_stamp(path)?;
+            if stamp == after {
+                return Ok(summary);
+            }
+            // The writer changed the file while it was being parsed. Do not
+            // expose a mixed summary; discard the entry and retry from a
+            // stable boundary.
+            self.cache.remove(path);
+        }
+
+        Err(std::io::Error::new(
+            std::io::ErrorKind::Interrupted,
+            format!("Codex rollout changed while reading: {}", path.display()),
+        ))
+    }
+
+    fn summary_for_once(
+        &mut self,
+        path: &Path,
+        stamp: FileStamp,
+    ) -> Result<CodexRolloutSummary, std::io::Error> {
         if let Some(entry) = self.cache.get(path) {
-            if entry.stamp == stamp {
+            if entry.stamp == stamp && stamp.supports_unchanged_fast_path() {
                 return Ok(entry.summary.clone());
             }
         }
@@ -251,7 +272,11 @@ impl CodexSessionSource {
             Some(entry) => {
                 let structurally_replaced = stamp.identity != entry.stamp.identity
                     || stamp.len < entry.offset
-                    || stamp.len < entry.stamp.len;
+                    || stamp.len < entry.stamp.len
+                    // A same-length rewrite is never an append. Reparse it
+                    // even when bounded samples happen to match.
+                    || stamp.len <= entry.stamp.len
+                    || !stamp.supports_unchanged_fast_path();
                 if structurally_replaced {
                     true
                 } else {
@@ -924,6 +949,10 @@ fn thread_id_from_rollout_filename(path: &Path) -> Option<String> {
         .map(|id| id.to_string())
 }
 
+fn file_stamp(path: &Path) -> io::Result<FileStamp> {
+    FileVersion::read(path)
+}
+
 #[cfg(unix)]
 fn file_identity(metadata: &fs::Metadata) -> u64 {
     use std::os::unix::fs::MetadataExt;
@@ -1498,6 +1527,49 @@ mod tests {
         assert_eq!(summary.messages.len(), 1);
         assert_eq!(summary.latest_message(), Some("recovered"));
         assert_eq!(summary.last_timestamp, "2026-07-13T00:00:04Z");
+    }
+
+    #[test]
+    fn same_length_rewrite_with_preserved_mtime_is_not_a_cache_hit() {
+        let temp = TempDir::new().unwrap();
+        let path = temp.path().join("rollout-same-length.jsonl");
+        let meta = event(
+            "2026-07-13T00:00:00Z",
+            "session_meta",
+            serde_json::json!({
+                "id":"same-length", "cwd":"/tmp/project", "source":"cli",
+                "originator":"codex-tui"
+            }),
+        );
+        let old = event(
+            "2026-07-13T00:00:01Z",
+            "event_msg",
+            serde_json::json!({"type":"user_message","message":"old prompt"}),
+        );
+        let fresh = event(
+            "2026-07-13T00:00:01Z",
+            "event_msg",
+            serde_json::json!({"type":"user_message","message":"new prompt"}),
+        );
+        assert_eq!(old.len(), fresh.len());
+        write_lines(&path, &[meta.clone(), old], true);
+        let original_modified = fs::metadata(&path).unwrap().modified().unwrap();
+
+        let mut source = CodexSessionSource::at_root(temp.path().to_path_buf());
+        assert_eq!(
+            source.summary_for(&path).unwrap().first_prompt(),
+            Some("old prompt")
+        );
+
+        write_lines(&path, &[meta, fresh], true);
+        let file = fs::OpenOptions::new().write(true).open(&path).unwrap();
+        file.set_modified(original_modified).unwrap();
+        drop(file);
+
+        assert_eq!(
+            source.summary_for(&path).unwrap().first_prompt(),
+            Some("new prompt")
+        );
     }
 
     #[test]

--- a/src-tauri/src/session/codex.rs
+++ b/src-tauri/src/session/codex.rs
@@ -483,6 +483,7 @@ impl CodexSessionSource {
                 can_stop: false,
                 can_rename: false,
                 codex_summary: Some(summary),
+                cursor_summary: None,
             });
         }
         Ok((sessions, DetectionDiagnostics::default()))

--- a/src-tauri/src/session/codex_archive.rs
+++ b/src-tauri/src/session/codex_archive.rs
@@ -1,3 +1,4 @@
+use super::cache::FileVersion;
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 use std::collections::{HashMap, HashSet};
@@ -5,14 +6,16 @@ use std::fs::File;
 use std::io::{BufRead, BufReader, Read, Seek, SeekFrom};
 use std::path::{Path, PathBuf};
 use std::sync::{Mutex, OnceLock};
-use std::time::UNIX_EPOCH;
 
-const CACHE_VERSION: u32 = 4;
+const CACHE_VERSION: u32 = 5;
 const MAX_DISPLAY_CHARS: usize = 400;
 const MAX_INDEXED_MESSAGES: usize = 20_000;
 const MAX_INDEXED_MESSAGE_CHARS: usize = 16_384;
 const MAX_INDEXED_MESSAGE_BYTES: usize = 2 * 1024 * 1024;
 const FILE_ANCHOR_BYTES: usize = 256;
+const MAX_REFRESH_ATTEMPTS: usize = 3;
+const FNV_OFFSET_BASIS: u64 = 0xcbf29ce484222325;
+const FNV_PRIME: u64 = 0x100000001b3;
 
 #[derive(Debug, Clone, Copy, Default, Serialize, Deserialize, PartialEq, Eq, Hash)]
 #[serde(rename_all = "camelCase")]
@@ -153,6 +156,8 @@ pub(crate) struct FileFingerprint {
     pub size: u64,
     pub modified_ns: u64,
     #[serde(default)]
+    pub changed_ns: u64,
+    #[serde(default)]
     pub identity: u64,
 }
 
@@ -171,6 +176,10 @@ struct CachedRollout {
     indexed_message_bytes: usize,
     #[serde(default)]
     anchor: Vec<u8>,
+    /// Stable hash of every byte in `[0, offset)`. The anchor is only a cheap
+    /// early rejection; this hash is the correctness check for growing files.
+    #[serde(default)]
+    prefix_hash: u64,
 }
 
 #[derive(Debug, Default, Serialize, Deserialize)]
@@ -183,29 +192,13 @@ struct ArchiveCache {
 static ARCHIVE_CACHE_LOCK: OnceLock<Mutex<()>> = OnceLock::new();
 
 fn fingerprint(path: &Path) -> Option<FileFingerprint> {
-    let metadata = path.metadata().ok()?;
-    let modified_ns = metadata
-        .modified()
-        .ok()
-        .and_then(|time| time.duration_since(UNIX_EPOCH).ok())
-        .map(|duration| duration.as_nanos().min(u64::MAX as u128) as u64)
-        .unwrap_or(0);
+    let version = FileVersion::read(path).ok()?;
     Some(FileFingerprint {
-        size: metadata.len(),
-        modified_ns,
-        identity: file_identity(&metadata),
+        size: version.len,
+        modified_ns: version.modified_nanos.min(u64::MAX as u128) as u64,
+        changed_ns: version.changed_nanos.min(u64::MAX as u128) as u64,
+        identity: version.identity,
     })
-}
-
-#[cfg(unix)]
-fn file_identity(metadata: &std::fs::Metadata) -> u64 {
-    use std::os::unix::fs::MetadataExt;
-    metadata.ino()
-}
-
-#[cfg(not(unix))]
-fn file_identity(_metadata: &std::fs::Metadata) -> u64 {
-    0
 }
 
 pub(crate) fn default_sessions_root(home: &Path) -> PathBuf {
@@ -350,23 +343,78 @@ fn empty_cached(path: &Path, fingerprint: FileFingerprint) -> CachedRollout {
         current_model: "unknown".to_string(),
         indexed_message_bytes: 0,
         anchor: Vec::new(),
+        prefix_hash: FNV_OFFSET_BASIS,
     }
 }
 
+fn hash_bytes(mut hash: u64, bytes: &[u8]) -> u64 {
+    for byte in bytes {
+        hash ^= u64::from(*byte);
+        hash = hash.wrapping_mul(FNV_PRIME);
+    }
+    hash
+}
+
+fn hash_file_prefix(path: &Path, length: u64) -> Option<u64> {
+    let mut file = File::open(path).ok()?;
+    let mut remaining = length;
+    let mut hash = FNV_OFFSET_BASIS;
+    let mut buffer = [0; 8192];
+    while remaining > 0 {
+        let limit = remaining.min(buffer.len() as u64) as usize;
+        let read = file.read(&mut buffer[..limit]).ok()?;
+        if read == 0 {
+            return None;
+        }
+        hash = hash_bytes(hash, &buffer[..read]);
+        remaining -= read as u64;
+    }
+    Some(hash)
+}
+
+fn has_strong_fingerprint(fingerprint: FileFingerprint) -> bool {
+    super::cache::has_strong_file_stamp(u128::from(fingerprint.changed_ns), fingerprint.identity)
+}
+
 fn refresh_rollout(
+    path: &Path,
+    initial_fingerprint: FileFingerprint,
+    previous: Option<CachedRollout>,
+) -> Option<CachedRollout> {
+    let mut expected = initial_fingerprint;
+    for _ in 0..MAX_REFRESH_ATTEMPTS {
+        let cached = refresh_rollout_once(path, expected, previous.clone())?;
+        let observed = fingerprint(path)?;
+        if observed == expected {
+            return Some(cached);
+        }
+        expected = observed;
+    }
+    None
+}
+
+fn refresh_rollout_once(
     path: &Path,
     fingerprint: FileFingerprint,
     previous: Option<CachedRollout>,
 ) -> Option<CachedRollout> {
     let mut file = File::open(path).ok()?;
     let mut reset = previous.as_ref().map_or(true, |cached| {
-        fingerprint.identity != cached.fingerprint.identity
+        !has_strong_fingerprint(fingerprint)
+            || !has_strong_fingerprint(cached.fingerprint)
+            || cached.prefix_hash == 0
+            || fingerprint.identity != cached.fingerprint.identity
             || fingerprint.size < cached.offset
             || (fingerprint.size == cached.fingerprint.size
-                && fingerprint.modified_ns != cached.fingerprint.modified_ns)
+                && (fingerprint.modified_ns != cached.fingerprint.modified_ns
+                    || fingerprint.changed_ns != cached.fingerprint.changed_ns))
     });
     if !reset {
         let cached = previous.as_ref()?;
+        // The fixed-size anchor is useful for a cheap early rejection, but it
+        // cannot detect a rewrite before the last 256 bytes. Verify the whole
+        // cached prefix before appending so a middle rewrite cannot leave stale
+        // messages or token totals in the archive cache.
         if !cached.anchor.is_empty() {
             let anchor_start = cached.offset.saturating_sub(cached.anchor.len() as u64);
             file.seek(SeekFrom::Start(anchor_start)).ok()?;
@@ -374,6 +422,14 @@ fn refresh_rollout(
             if file.read_exact(&mut current).is_err() || current != cached.anchor {
                 reset = true;
             }
+        }
+        if !reset
+            && match hash_file_prefix(path, cached.offset) {
+                Some(hash) => hash != cached.prefix_hash,
+                None => true,
+            }
+        {
+            reset = true;
         }
     }
     let mut cached = if reset {
@@ -385,6 +441,7 @@ fn refresh_rollout(
     let mut appended = Vec::new();
     file.read_to_end(&mut appended).ok()?;
     cached.offset += appended.len() as u64;
+    cached.prefix_hash = hash_bytes(cached.prefix_hash, &appended);
     cached.pending.extend_from_slice(&appended);
 
     let complete_len = cached
@@ -626,11 +683,11 @@ pub(crate) fn load_snapshots(root: &Path, cache_path: &Path) -> Vec<CodexRollout
             continue;
         };
         let key = path.to_string_lossy().to_string();
-        if cache
-            .files
-            .get(&key)
-            .is_some_and(|entry| entry.fingerprint == fingerprint)
-        {
+        if cache.files.get(&key).is_some_and(|entry| {
+            entry.fingerprint == fingerprint
+                && entry.prefix_hash != 0
+                && has_strong_fingerprint(fingerprint)
+        }) {
             continue;
         }
         let previous = cache.files.remove(&key);
@@ -1149,5 +1206,85 @@ mod tests {
         let truncated = load_snapshots(&root, &cache_path);
         assert_eq!(truncated[0].display, "replacement");
         assert_eq!(truncated[0].messages.len(), 1);
+    }
+
+    #[test]
+    fn archive_cache_invalidates_same_length_rewrite_with_preserved_mtime() {
+        let directory = tempfile::tempdir().unwrap();
+        let root = directory.path().join("sessions");
+        std::fs::create_dir_all(&root).unwrap();
+        let path = root.join("same-length.jsonl");
+        let old_prompt = "old prompt";
+        let new_prompt = "new prompt";
+        let session = r#"{"timestamp":"2026-07-13T01:00:00Z","type":"session_meta","payload":{"id":"same-length","cwd":"/tmp/p","source":"cli","originator":"codex-tui"}}"#;
+        let old_message = format!(
+            r#"{{"timestamp":"2026-07-13T01:01:00Z","type":"event_msg","payload":{{"type":"user_message","message":"{old_prompt}"}}}}"#
+        );
+        let new_message = format!(
+            r#"{{"timestamp":"2026-07-13T01:01:00Z","type":"event_msg","payload":{{"type":"user_message","message":"{new_prompt}"}}}}"#
+        );
+        assert_eq!(old_message.len(), new_message.len());
+        std::fs::write(&path, format!("{session}\n{old_message}")).unwrap();
+        let original_modified = std::fs::metadata(&path).unwrap().modified().unwrap();
+        let cache_path = directory.path().join("cache.json");
+        assert_eq!(load_snapshots(&root, &cache_path)[0].display, old_prompt);
+
+        std::fs::write(&path, format!("{session}\n{new_message}")).unwrap();
+        std::fs::File::open(&path)
+            .unwrap()
+            .set_modified(original_modified)
+            .unwrap();
+        let refreshed = load_snapshots(&root, &cache_path);
+        assert_eq!(refreshed[0].display, new_prompt);
+    }
+
+    #[test]
+    fn archive_cache_detects_middle_rewrite_before_anchor_on_append() {
+        let directory = tempfile::tempdir().unwrap();
+        let root = directory.path().join("sessions");
+        std::fs::create_dir_all(&root).unwrap();
+        let path = root.join("middle-rewrite.jsonl");
+        let old_prompt = format!("old prompt {}", "a".repeat(96));
+        let new_prompt = format!("new prompt {}", "b".repeat(96));
+        assert_eq!(old_prompt.len(), new_prompt.len());
+        let session = r#"{"timestamp":"2026-07-13T01:00:00Z","type":"session_meta","payload":{"id":"middle-rewrite","cwd":"/tmp/p","source":"cli","originator":"codex-tui"}}"#;
+        let old_message = format!(
+            r#"{{"timestamp":"2026-07-13T01:01:00Z","type":"event_msg","payload":{{"type":"user_message","message":"{old_prompt}"}}}}"#
+        );
+        let stable_tail = format!(
+            r#"{{"timestamp":"2026-07-13T01:02:00Z","type":"event_msg","payload":{{"type":"agent_message","message":"{}"}}}}"#,
+            "stable tail ".repeat(48)
+        );
+        assert!(stable_tail.len() > FILE_ANCHOR_BYTES);
+        std::fs::write(&path, format!("{session}\n{old_message}\n{stable_tail}")).unwrap();
+        let cache_path = directory.path().join("cache.json");
+        assert_eq!(load_snapshots(&root, &cache_path)[0].display, old_prompt);
+
+        let new_message = format!(
+            r#"{{"timestamp":"2026-07-13T01:01:00Z","type":"event_msg","payload":{{"type":"user_message","message":"{new_prompt}"}}}}"#
+        );
+        assert_eq!(old_message.len(), new_message.len());
+        std::fs::write(&path, format!("{session}\n{new_message}\n{stable_tail}")).unwrap();
+        use std::io::Write;
+        let mut file = std::fs::OpenOptions::new()
+            .append(true)
+            .open(&path)
+            .unwrap();
+        writeln!(
+            file,
+            r#"{{"timestamp":"2026-07-13T01:03:00Z","type":"event_msg","payload":{{"type":"agent_message","message":"appended"}}}}"#
+        )
+        .unwrap();
+
+        let refreshed = load_snapshots(&root, &cache_path);
+        assert_eq!(refreshed[0].display, new_prompt);
+        assert!(refreshed[0]
+            .messages
+            .iter()
+            .any(|message| message.text == new_prompt));
+        assert!(!refreshed[0]
+            .messages
+            .iter()
+            .any(|message| message.text == old_prompt));
     }
 }

--- a/src-tauri/src/session/codex_archive.rs
+++ b/src-tauri/src/session/codex_archive.rs
@@ -7,7 +7,7 @@ use std::io::{BufRead, BufReader, Read, Seek, SeekFrom};
 use std::path::{Path, PathBuf};
 use std::sync::{Mutex, OnceLock};
 
-const CACHE_VERSION: u32 = 5;
+const CACHE_VERSION: u32 = 6;
 const MAX_DISPLAY_CHARS: usize = 400;
 const MAX_INDEXED_MESSAGES: usize = 20_000;
 const MAX_INDEXED_MESSAGE_CHARS: usize = 16_384;
@@ -256,20 +256,24 @@ fn truncate(value: &str, limit: usize) -> String {
 
 fn message_text(value: &Value) -> Option<(String, String)> {
     let payload = value.get("payload")?;
-    if value.get("type").and_then(Value::as_str) == Some("event_msg") {
-        let kind = payload.get("type").and_then(Value::as_str)?;
-        let role = match kind {
-            "user_message" => "user",
-            "agent_message" => "assistant",
-            _ => return None,
-        };
-        let text = payload.get("message").and_then(Value::as_str)?.to_string();
-        if text.trim().is_empty() {
-            return None;
+    match value.get("type").and_then(Value::as_str) {
+        Some("event_msg") => {
+            let kind = payload.get("type").and_then(Value::as_str)?;
+            let role = match kind {
+                "user_message" => "user",
+                "agent_message" => "assistant",
+                _ => return None,
+            };
+            let text = payload.get("message").and_then(Value::as_str)?.to_string();
+            if text.trim().is_empty() {
+                return None;
+            }
+            Some((role.to_string(), text))
         }
-        return Some((role.to_string(), text));
+        Some("response_item") => super::codex::response_item_message_text(payload)
+            .map(|(role, content, _)| (role, content)),
+        _ => None,
     }
-    None
 }
 
 fn classify_session(source: &Value, originator: &str) -> (String, String, Option<String>) {
@@ -804,7 +808,7 @@ where
     }
 
     // The persisted message cache is intentionally bounded. For an incomplete
-    // snapshot, stream the authoritative event_msg records from every merged
+    // snapshot, stream the authoritative message records from every merged
     // rollout so deep search remains exact without retaining unbounded text.
     let mut searched = HashSet::new();
     let mut all_paths_read = true;
@@ -973,7 +977,7 @@ mod tests {
     }
 
     #[test]
-    fn response_items_are_not_used_as_display() {
+    fn response_item_messages_are_used_as_display() {
         let directory = tempfile::tempdir().unwrap();
         let path = directory.path().join("messages.jsonl");
         write_rollout(
@@ -984,11 +988,13 @@ mod tests {
                 r#"{"timestamp":"2026-07-13T01:02:00Z","type":"event_msg","payload":{"type":"user_message","message":"real request"}}"#,
             ],
         );
-        assert_eq!(scan_rollout(&path).unwrap().display, "real request");
+        let snapshot = scan_rollout(&path).unwrap();
+        assert_eq!(snapshot.display, "real request");
+        assert_eq!(snapshot.messages.len(), 2);
     }
 
     #[test]
-    fn deep_search_uses_cached_authoritative_messages_without_the_rollout_file() {
+    fn deep_search_includes_response_item_messages_without_the_rollout_file() {
         let directory = tempfile::tempdir().unwrap();
         let path = directory.path().join("search.jsonl");
         write_rollout(
@@ -1001,10 +1007,10 @@ mod tests {
         );
         let snapshot = scan_rollout(&path).unwrap();
         std::fs::remove_file(&path).unwrap();
-        let hit = search_rollout(&snapshot, "needle", false, false, |text, query, _| {
+        let hit = search_rollout(&snapshot, "private", false, false, |text, query, _| {
             text.contains(query)
         });
-        assert_eq!(hit.as_deref(), Some("visible needle"));
+        assert_eq!(hit.as_deref(), Some("private needle"));
     }
 
     #[test]

--- a/src-tauri/src/session/codex_archive.rs
+++ b/src-tauri/src/session/codex_archive.rs
@@ -2,7 +2,7 @@ use serde::{Deserialize, Serialize};
 use serde_json::Value;
 use std::collections::{HashMap, HashSet};
 use std::fs::File;
-use std::io::{BufRead, BufReader, Read, Seek, SeekFrom};
+use std::io::{BufRead, BufReader, BufWriter, Read, Seek, SeekFrom, Write};
 use std::path::{Path, PathBuf};
 use std::sync::{Mutex, OnceLock};
 use std::time::UNIX_EPOCH;
@@ -114,7 +114,9 @@ struct ArchivedTokenEvent {
     #[serde(default)]
     cumulative: bool,
     /// Cumulative counters restart independently for each rollout stream.
-    #[serde(default)]
+    /// Omitted from the on-disk cache because it is always the parent file path
+    /// and was repeating ~100 bytes on every token event.
+    #[serde(default, skip_serializing)]
     stream_id: String,
 }
 
@@ -163,7 +165,7 @@ struct CachedRollout {
     snapshot: CodexRolloutSnapshot,
     #[serde(default)]
     offset: u64,
-    #[serde(default)]
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pending: Vec<u8>,
     #[serde(default)]
     current_model: String,
@@ -180,7 +182,23 @@ struct ArchiveCache {
     files: HashMap<String, CachedRollout>,
 }
 
-static ARCHIVE_CACHE_LOCK: OnceLock<Mutex<()>> = OnceLock::new();
+#[derive(Clone, Copy)]
+enum SnapshotView {
+    Full,
+    Listing,
+}
+
+struct ProcessArchive {
+    cache: ArchiveCache,
+    merged: Vec<CodexRolloutSnapshot>,
+}
+
+static ARCHIVE_STATE: OnceLock<Mutex<HashMap<(PathBuf, PathBuf), ProcessArchive>>> =
+    OnceLock::new();
+
+fn archive_state() -> &'static Mutex<HashMap<(PathBuf, PathBuf), ProcessArchive>> {
+    ARCHIVE_STATE.get_or_init(|| Mutex::new(HashMap::new()))
+}
 
 fn fingerprint(path: &Path) -> Option<FileFingerprint> {
     let metadata = path.metadata().ok()?;
@@ -591,35 +609,93 @@ fn write_cache(path: &Path, cache: &ArchiveCache) {
     if std::fs::create_dir_all(parent).is_err() {
         return;
     }
-    let Ok(json) = serde_json::to_vec(cache) else {
+    let temporary = path.with_extension("json.tmp");
+    let Ok(file) = File::create(&temporary) else {
         return;
     };
-    let temporary = path.with_extension("json.tmp");
-    if std::fs::write(&temporary, json).is_ok() {
+    let mut writer = BufWriter::new(file);
+    let ok = serde_json::to_writer(&mut writer, cache).is_ok() && writer.flush().is_ok();
+    drop(writer);
+    if ok {
         let _ = std::fs::rename(temporary, path);
+    } else {
+        let _ = std::fs::remove_file(&temporary);
     }
 }
 
-pub(crate) fn load_snapshots(root: &Path, cache_path: &Path) -> Vec<CodexRolloutSnapshot> {
-    let _guard = ARCHIVE_CACHE_LOCK
-        .get_or_init(|| Mutex::new(()))
-        .lock()
-        .unwrap_or_else(|poisoned| poisoned.into_inner());
-    let mut cache: ArchiveCache = std::fs::read(cache_path)
+fn read_cache_file(path: &Path) -> ArchiveCache {
+    let mut cache: ArchiveCache = File::open(path)
         .ok()
-        .and_then(|bytes| serde_json::from_slice(&bytes).ok())
+        .and_then(|file| serde_json::from_reader(BufReader::new(file)).ok())
         .filter(|cache: &ArchiveCache| cache.version == CACHE_VERSION)
         .unwrap_or_else(|| ArchiveCache {
             version: CACHE_VERSION,
             files: HashMap::new(),
         });
+    for entry in cache.files.values_mut() {
+        hydrate_stream_ids(entry);
+    }
+    cache
+}
 
+fn hydrate_stream_ids(cached: &mut CachedRollout) {
+    if cached.snapshot.path.as_os_str().is_empty() {
+        if let Some(path) = cached.snapshot.paths.first() {
+            cached.snapshot.path = path.clone();
+        }
+    }
+    let path = cached.snapshot.path.to_string_lossy().into_owned();
+    if path.is_empty() {
+        return;
+    }
+    for event in &mut cached.snapshot.token_events {
+        if event.stream_id.is_empty() {
+            event.stream_id = path.clone();
+        }
+    }
+}
+
+fn listing_snapshot(snapshot: &CodexRolloutSnapshot) -> CodexRolloutSnapshot {
+    CodexRolloutSnapshot {
+        thread_id: snapshot.thread_id.clone(),
+        cwd: snapshot.cwd.clone(),
+        surface: snapshot.surface.clone(),
+        agent_kind: snapshot.agent_kind.clone(),
+        parent_thread_id: snapshot.parent_thread_id.clone(),
+        display: snapshot.display.clone(),
+        created_at_ms: snapshot.created_at_ms,
+        updated_at_ms: snapshot.updated_at_ms,
+        token_days: snapshot.token_days.clone(),
+        path: snapshot.path.clone(),
+        paths: snapshot.paths.clone(),
+        messages_complete: snapshot.messages_complete,
+        messages: Vec::new(),
+        token_events: Vec::new(),
+    }
+}
+
+fn merge_all(cache: &ArchiveCache) -> Vec<CodexRolloutSnapshot> {
+    let mut by_thread: HashMap<String, CodexRolloutSnapshot> = HashMap::new();
+    for entry in cache.files.values() {
+        let snapshot = entry.snapshot.clone();
+        if let Some(existing) = by_thread.get_mut(&snapshot.thread_id) {
+            merge_snapshot(existing, snapshot);
+        } else {
+            by_thread.insert(snapshot.thread_id.clone(), snapshot);
+        }
+    }
+    by_thread.into_values().collect()
+}
+
+fn refresh_cache(cache: &mut ArchiveCache, root: &Path) -> bool {
     let candidates = collect_rollouts(root);
     let active_paths: HashSet<String> = candidates
         .iter()
         .map(|path| path.to_string_lossy().to_string())
         .collect();
+    let before = cache.files.len();
     cache.files.retain(|path, _| active_paths.contains(path));
+    let mut dirty = cache.files.len() != before;
 
     for path in candidates {
         let Some(fingerprint) = fingerprint(&path) else {
@@ -633,29 +709,69 @@ pub(crate) fn load_snapshots(root: &Path, cache_path: &Path) -> Vec<CodexRollout
         {
             continue;
         }
+        dirty = true;
         let previous = cache.files.remove(&key);
-        if let Some(cached) = refresh_rollout(&path, fingerprint, previous) {
+        if let Some(mut cached) = refresh_rollout(&path, fingerprint, previous) {
             if !cached.snapshot.thread_id.is_empty() {
+                hydrate_stream_ids(&mut cached);
                 cache.files.insert(key, cached);
             }
-        } else {
-            cache.files.remove(&key);
         }
     }
-    write_cache(cache_path, &cache);
+    dirty
+}
 
-    // A resumed thread may span several rollout paths. Merge their authoritative
-    // events so older prompts and token usage survive without double counting overlap.
-    let mut by_thread: HashMap<String, CodexRolloutSnapshot> = HashMap::new();
-    for entry in cache.files.into_values() {
-        let snapshot = entry.snapshot;
-        if let Some(existing) = by_thread.get_mut(&snapshot.thread_id) {
-            merge_snapshot(existing, snapshot);
-        } else {
-            by_thread.insert(snapshot.thread_id.clone(), snapshot);
+fn load_snapshots_with(
+    root: &Path,
+    cache_path: &Path,
+    view: SnapshotView,
+) -> Vec<CodexRolloutSnapshot> {
+    let key = (root.to_path_buf(), cache_path.to_path_buf());
+    let mut state = archive_state()
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner());
+    let archive = state.entry(key).or_insert_with(|| ProcessArchive {
+        cache: read_cache_file(cache_path),
+        merged: Vec::new(),
+    });
+    let dirty = refresh_cache(&mut archive.cache, root);
+    if dirty || archive.merged.is_empty() {
+        archive.merged = merge_all(&archive.cache);
+        if dirty {
+            write_cache(cache_path, &archive.cache);
         }
     }
-    by_thread.into_values().collect()
+    match view {
+        SnapshotView::Full => archive.merged.clone(),
+        SnapshotView::Listing => archive.merged.iter().map(listing_snapshot).collect(),
+    }
+}
+
+pub(crate) fn load_snapshots(root: &Path, cache_path: &Path) -> Vec<CodexRolloutSnapshot> {
+    load_snapshots_with(root, cache_path, SnapshotView::Full)
+}
+
+pub(crate) fn load_listing_snapshots(root: &Path, cache_path: &Path) -> Vec<CodexRolloutSnapshot> {
+    load_snapshots_with(root, cache_path, SnapshotView::Listing)
+}
+
+/// Fast path for conversation loading when History/Cost already warmed the archive.
+pub(crate) fn cached_thread_paths(sessions_root: &Path, thread_id: &str) -> Option<Vec<PathBuf>> {
+    let cache_path = sessions_root.parent()?.join("c9watch-archive-cache.json");
+    let key = (sessions_root.to_path_buf(), cache_path);
+    let state = archive_state()
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner());
+    let snapshot = state
+        .get(&key)?
+        .merged
+        .iter()
+        .find(|item| item.thread_id == thread_id)?;
+    let mut paths = snapshot.paths.clone();
+    if !paths.contains(&snapshot.path) {
+        paths.push(snapshot.path.clone());
+    }
+    Some(paths)
 }
 
 fn merge_snapshot(existing: &mut CodexRolloutSnapshot, incoming: CodexRolloutSnapshot) {
@@ -719,6 +835,10 @@ fn merge_snapshot(existing: &mut CodexRolloutSnapshot, incoming: CodexRolloutSna
 
 pub(crate) fn load_default_snapshots(home: &Path) -> Vec<CodexRolloutSnapshot> {
     load_snapshots(&default_sessions_root(home), &default_cache_path(home))
+}
+
+pub(crate) fn load_default_listing(home: &Path) -> Vec<CodexRolloutSnapshot> {
+    load_listing_snapshots(&default_sessions_root(home), &default_cache_path(home))
 }
 
 pub(crate) fn search_rollout<F>(
@@ -1149,5 +1269,147 @@ mod tests {
         let truncated = load_snapshots(&root, &cache_path);
         assert_eq!(truncated[0].display, "replacement");
         assert_eq!(truncated[0].messages.len(), 1);
+    }
+
+    #[test]
+    fn unchanged_reload_does_not_rewrite_cache() {
+        let directory = tempfile::tempdir().unwrap();
+        let root = directory.path().join("sessions");
+        std::fs::create_dir_all(&root).unwrap();
+        write_rollout(
+            &root.join("stable.jsonl"),
+            &[
+                r#"{"timestamp":"2026-07-13T01:00:00Z","type":"session_meta","payload":{"id":"stable","cwd":"/tmp/p","source":"cli","originator":"codex-tui"}}"#,
+                r#"{"timestamp":"2026-07-13T01:01:00Z","type":"event_msg","payload":{"type":"user_message","message":"hello"}}"#,
+            ],
+        );
+        let cache_path = directory.path().join("cache.json");
+        load_snapshots(&root, &cache_path);
+        let first = std::fs::read(&cache_path).unwrap();
+        let second = load_snapshots(&root, &cache_path);
+        assert_eq!(second[0].display, "hello");
+        let after = std::fs::read(&cache_path).unwrap();
+        assert_eq!(
+            first, after,
+            "unchanged rollouts must not rewrite the archive cache"
+        );
+    }
+
+    #[test]
+    fn process_cache_survives_deleted_cache_file() {
+        let directory = tempfile::tempdir().unwrap();
+        let root = directory.path().join("sessions");
+        std::fs::create_dir_all(&root).unwrap();
+        write_rollout(
+            &root.join("cached.jsonl"),
+            &[
+                r#"{"timestamp":"2026-07-13T01:00:00Z","type":"session_meta","payload":{"id":"cached","cwd":"/tmp/p","source":"cli","originator":"codex-tui"}}"#,
+                r#"{"timestamp":"2026-07-13T01:01:00Z","type":"event_msg","payload":{"type":"user_message","message":"keep me"}}"#,
+            ],
+        );
+        let cache_path = directory.path().join("cache.json");
+        load_snapshots(&root, &cache_path);
+        std::fs::remove_file(&cache_path).unwrap();
+        let second = load_snapshots(&root, &cache_path);
+        assert_eq!(second[0].display, "keep me");
+        assert!(
+            !cache_path.exists(),
+            "memory hit must not rewrite an unchanged cache"
+        );
+    }
+
+    #[test]
+    fn listing_snapshots_omit_search_index_but_keep_cost_fields() {
+        let directory = tempfile::tempdir().unwrap();
+        let root = directory.path().join("sessions");
+        std::fs::create_dir_all(&root).unwrap();
+        write_rollout(
+            &root.join("listed.jsonl"),
+            &[
+                r#"{"timestamp":"2026-07-13T01:00:00Z","type":"session_meta","payload":{"id":"listed","cwd":"/tmp/p","source":"cli","originator":"codex-tui"}}"#,
+                r#"{"timestamp":"2026-07-13T01:01:00Z","type":"turn_context","payload":{"model":"gpt-5.4"}}"#,
+                r#"{"timestamp":"2026-07-13T01:02:00Z","type":"event_msg","payload":{"type":"user_message","message":"prompt text"}}"#,
+                r#"{"timestamp":"2026-07-13T01:03:00Z","type":"event_msg","payload":{"type":"token_count","info":{"total_token_usage":{"input_tokens":10,"output_tokens":4,"total_tokens":14}}}}"#,
+            ],
+        );
+        let cache_path = directory.path().join("cache.json");
+        let listing = load_listing_snapshots(&root, &cache_path);
+        assert_eq!(listing[0].display, "prompt text");
+        assert!(listing[0].messages.is_empty());
+        assert!(listing[0].token_events.is_empty());
+        assert_eq!(listing[0].token_days[0].usage.total_tokens, 14);
+
+        let full = load_snapshots(&root, &cache_path);
+        assert_eq!(full[0].messages.len(), 1);
+        assert_eq!(full[0].token_events.len(), 1);
+    }
+
+    #[test]
+    #[ignore]
+    fn real_home_archive_load_timing() {
+        let home = dirs::home_dir().expect("home directory");
+        let sessions = default_sessions_root(&home);
+        if !sessions.exists() {
+            return;
+        }
+        let started = std::time::Instant::now();
+        let first = load_default_listing(&home);
+        let first_elapsed = started.elapsed();
+        let started = std::time::Instant::now();
+        let second = load_default_listing(&home);
+        let second_elapsed = started.elapsed();
+        let started = std::time::Instant::now();
+        let full = load_default_snapshots(&home);
+        let full_elapsed = started.elapsed();
+        let messages: usize = full.iter().map(|snapshot| snapshot.messages.len()).sum();
+        eprintln!(
+            "codex archive listing {} sessions: first {first_elapsed:?}, second {second_elapsed:?}; full {} messages in {full_elapsed:?}",
+            first.len(),
+            messages
+        );
+        assert_eq!(first.len(), second.len());
+        assert_eq!(first.len(), full.len());
+        assert!(
+            second_elapsed * 4 < first_elapsed || second_elapsed.as_millis() < 200,
+            "warm listing should reuse the process cache (first {first_elapsed:?}, second {second_elapsed:?})"
+        );
+    }
+
+    #[test]
+    fn token_stream_id_is_not_persisted_and_still_merges_independent_streams() {
+        let directory = tempfile::tempdir().unwrap();
+        let root = directory.path().join("sessions");
+        std::fs::create_dir_all(&root).unwrap();
+        write_rollout(
+            &root.join("old.jsonl"),
+            &[
+                r#"{"timestamp":"2026-07-13T01:00:00Z","type":"session_meta","payload":{"id":"resumed","cwd":"/tmp/p","source":"cli","originator":"codex-tui"}}"#,
+                r#"{"timestamp":"2026-07-13T01:00:30Z","type":"turn_context","payload":{"model":"gpt-5.6-sol"}}"#,
+                r#"{"timestamp":"2026-07-13T01:01:00Z","type":"event_msg","payload":{"type":"token_count","info":{"total_token_usage":{"input_tokens":80,"output_tokens":20,"total_tokens":100}}}}"#,
+            ],
+        );
+        write_rollout(
+            &root.join("new.jsonl"),
+            &[
+                r#"{"timestamp":"2026-07-13T02:00:00Z","type":"session_meta","payload":{"id":"resumed","cwd":"/tmp/p","source":"cli","originator":"codex-tui"}}"#,
+                r#"{"timestamp":"2026-07-13T02:00:30Z","type":"turn_context","payload":{"model":"gpt-5.6-luna"}}"#,
+                r#"{"timestamp":"2026-07-13T02:01:00Z","type":"event_msg","payload":{"type":"token_count","info":{"total_token_usage":{"input_tokens":120,"output_tokens":30,"total_tokens":150}}}}"#,
+            ],
+        );
+        let cache_path = directory.path().join("cache.json");
+        let snapshots = load_snapshots(&root, &cache_path);
+        let json = String::from_utf8(std::fs::read(&cache_path).unwrap()).unwrap();
+        assert!(
+            !json.contains("streamId"),
+            "per-event stream ids must not bloat the on-disk cache"
+        );
+        assert_eq!(
+            snapshots[0]
+                .token_days
+                .iter()
+                .map(|day| day.usage.total_tokens)
+                .sum::<u64>(),
+            250
+        );
     }
 }

--- a/src-tauri/src/session/conversation.rs
+++ b/src-tauri/src/session/conversation.rs
@@ -1,5 +1,7 @@
-use crate::session::{extract_messages, parse_all_entries, ImageBlock, MessageType};
+use crate::session::parser::parse_all_entries_with_progress;
+use crate::session::{extract_messages, ImageBlock, MessageType};
 use serde::Serialize;
+use std::time::{Duration, Instant};
 
 /// Conversation structure
 #[derive(Debug, Clone, Serialize)]
@@ -7,6 +9,15 @@ use serde::Serialize;
 pub struct Conversation {
     pub session_id: String,
     pub messages: Vec<ConversationMessage>,
+}
+
+/// Byte-level load progress for a conversation parse.
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ConversationProgress {
+    pub session_id: String,
+    pub bytes_read: u64,
+    pub bytes_total: u64,
 }
 
 /// Individual message in a conversation
@@ -23,7 +34,38 @@ pub struct ConversationMessage {
 
 /// Get conversation data for a session by ID.
 /// Searches all project directories under ~/.claude/projects/ for the session file.
-pub fn get_conversation_data(session_id: &str) -> Result<Conversation, String> {
+/// When `include_tools` is false, tool use/result records are omitted so large
+/// Codex transcripts can open without shipping megabytes of tool dumps.
+pub fn get_conversation_data(
+    session_id: &str,
+    include_tools: bool,
+) -> Result<Conversation, String> {
+    get_conversation_data_with_progress(session_id, include_tools, &mut |_, _| {})
+}
+
+/// Like [`get_conversation_data`], reporting `(bytes_read, bytes_total)` while scanning.
+pub fn get_conversation_data_with_progress(
+    session_id: &str,
+    include_tools: bool,
+    on_progress: &mut dyn FnMut(u64, u64),
+) -> Result<Conversation, String> {
+    let mut last_read = u64::MAX;
+    let mut last_at = Instant::now()
+        .checked_sub(Duration::from_secs(1))
+        .unwrap_or_else(Instant::now);
+    let mut report = |read: u64, total: u64| {
+        let step = total.saturating_div(50).max(256 * 1024);
+        let due = last_read == u64::MAX
+            || read >= total
+            || read.saturating_sub(last_read) >= step
+            || last_at.elapsed() >= Duration::from_millis(80);
+        if due {
+            last_read = read;
+            last_at = Instant::now();
+            on_progress(read, total);
+        }
+    };
+
     let home_dir = dirs::home_dir().ok_or("Failed to get home directory")?;
     let claude_projects_dir = home_dir.join(".claude").join("projects");
 
@@ -38,13 +80,17 @@ pub fn get_conversation_data(session_id: &str) -> Result<Conversation, String> {
 
             let session_file = project_path.join(&session_filename);
             if session_file.exists() {
-                let entries = parse_all_entries(&session_file)
+                let entries = parse_all_entries_with_progress(&session_file, &mut report)
                     .map_err(|e| format!("Failed to parse session file: {}", e))?;
 
                 let messages = extract_messages(&entries);
 
                 let conversation_messages: Vec<ConversationMessage> = messages
                     .into_iter()
+                    .filter(|(_, msg_type, _, _)| {
+                        include_tools
+                            || !matches!(msg_type, MessageType::ToolUse | MessageType::ToolResult)
+                    })
                     .map(
                         |(timestamp, msg_type, content, images)| ConversationMessage {
                             timestamp,
@@ -63,7 +109,11 @@ pub fn get_conversation_data(session_id: &str) -> Result<Conversation, String> {
         }
     }
 
-    if let Ok(messages) = crate::session::codex::find_codex_conversation(session_id) {
+    if let Ok(messages) = crate::session::codex::find_codex_conversation_with_progress(
+        session_id,
+        include_tools,
+        &mut report,
+    ) {
         return Ok(Conversation {
             session_id: session_id.to_string(),
             messages: messages

--- a/src-tauri/src/session/conversation.rs
+++ b/src-tauri/src/session/conversation.rs
@@ -45,12 +45,14 @@ pub fn get_conversation_data(session_id: &str) -> Result<Conversation, String> {
 
                 let conversation_messages: Vec<ConversationMessage> = messages
                     .into_iter()
-                    .map(|(timestamp, msg_type, content, images)| ConversationMessage {
-                        timestamp,
-                        message_type: msg_type,
-                        content,
-                        images,
-                    })
+                    .map(
+                        |(timestamp, msg_type, content, images)| ConversationMessage {
+                            timestamp,
+                            message_type: msg_type,
+                            content,
+                            images,
+                        },
+                    )
                     .collect();
 
                 return Ok(Conversation {

--- a/src-tauri/src/session/conversation.rs
+++ b/src-tauri/src/session/conversation.rs
@@ -78,6 +78,25 @@ pub fn get_conversation_data(session_id: &str) -> Result<Conversation, String> {
         });
     }
 
+    if let Ok(messages) = crate::session::cursor::find_cursor_conversation_with_progress(
+        session_id,
+        true,
+        &mut |_, _| {},
+    ) {
+        return Ok(Conversation {
+            session_id: session_id.to_string(),
+            messages: messages
+                .into_iter()
+                .map(|message| ConversationMessage {
+                    timestamp: message.timestamp,
+                    message_type: message.message_type,
+                    content: message.content,
+                    images: Vec::new(),
+                })
+                .collect(),
+        });
+    }
+
     Err(format!(
         "Session {} not found in any project directory",
         session_id

--- a/src-tauri/src/session/conversation.rs
+++ b/src-tauri/src/session/conversation.rs
@@ -1,3 +1,4 @@
+use crate::session::SessionProvider;
 use crate::session::{extract_messages, parse_all_entries, ImageBlock, MessageType};
 use serde::Serialize;
 
@@ -6,6 +7,7 @@ use serde::Serialize;
 #[serde(rename_all = "camelCase")]
 pub struct Conversation {
     pub session_id: String,
+    pub provider: SessionProvider,
     pub messages: Vec<ConversationMessage>,
 }
 
@@ -21,9 +23,7 @@ pub struct ConversationMessage {
     pub images: Vec<ImageBlock>,
 }
 
-/// Get conversation data for a session by ID.
-/// Searches all project directories under ~/.claude/projects/ for the session file.
-pub fn get_conversation_data(session_id: &str) -> Result<Conversation, String> {
+fn claude_conversation(session_id: &str) -> Result<Conversation, String> {
     let home_dir = dirs::home_dir().ok_or("Failed to get home directory")?;
     let claude_projects_dir = home_dir.join(".claude").join("projects");
 
@@ -57,48 +57,145 @@ pub fn get_conversation_data(session_id: &str) -> Result<Conversation, String> {
 
                 return Ok(Conversation {
                     session_id: session_id.to_string(),
+                    provider: SessionProvider::ClaudeCode,
                     messages: conversation_messages,
                 });
             }
         }
     }
 
-    if let Ok(messages) = crate::session::codex::find_codex_conversation(session_id) {
-        return Ok(Conversation {
-            session_id: session_id.to_string(),
-            messages: messages
-                .into_iter()
-                .map(|message| ConversationMessage {
-                    timestamp: message.timestamp,
-                    message_type: message.message_type,
-                    content: message.content,
-                    images: Vec::new(),
-                })
-                .collect(),
-        });
-    }
+    Err(format!(
+        "Claude Code session {} not found in any project directory",
+        session_id
+    ))
+}
 
-    if let Ok(messages) = crate::session::cursor::find_cursor_conversation_with_progress(
+fn codex_conversation(session_id: &str) -> Result<Conversation, String> {
+    let messages = crate::session::codex::find_codex_conversation(session_id)?;
+    Ok(Conversation {
+        session_id: session_id.to_string(),
+        provider: SessionProvider::Codex,
+        messages: messages
+            .into_iter()
+            .map(|message| ConversationMessage {
+                timestamp: message.timestamp,
+                message_type: message.message_type,
+                content: message.content,
+                images: Vec::new(),
+            })
+            .collect(),
+    })
+}
+
+fn cursor_conversation(session_id: &str) -> Result<Conversation, String> {
+    let messages = crate::session::cursor::find_cursor_conversation_with_progress(
         session_id,
         true,
         &mut |_, _| {},
-    ) {
-        return Ok(Conversation {
-            session_id: session_id.to_string(),
-            messages: messages
-                .into_iter()
-                .map(|message| ConversationMessage {
-                    timestamp: message.timestamp,
-                    message_type: message.message_type,
-                    content: message.content,
-                    images: Vec::new(),
-                })
-                .collect(),
-        });
+    )?;
+    Ok(Conversation {
+        session_id: session_id.to_string(),
+        provider: SessionProvider::Cursor,
+        messages: messages
+            .into_iter()
+            .map(|message| ConversationMessage {
+                timestamp: message.timestamp,
+                message_type: message.message_type,
+                content: message.content,
+                images: Vec::new(),
+            })
+            .collect(),
+    })
+}
+
+fn select_provider_conversation(
+    session_id: &str,
+    mut matches: Vec<(SessionProvider, Conversation)>,
+) -> Result<Conversation, String> {
+    match matches.len() {
+        0 => Err(format!("Session {} not found in any provider", session_id)),
+        1 => Ok(matches.pop().unwrap().1),
+        _ => Err(format!(
+            "Session {} is ambiguous across providers; pass provider explicitly",
+            session_id
+        )),
+    }
+}
+
+/// Get conversation data by provider-scoped identity when available.
+///
+/// The provider argument is optional for backward compatibility with older
+/// clients. New clients should pass it so an opaque ID cannot select a
+/// transcript from the wrong provider namespace.
+pub fn get_conversation_data_for_provider(
+    session_id: &str,
+    provider: Option<SessionProvider>,
+) -> Result<Conversation, String> {
+    if let Some(provider) = provider {
+        return match provider {
+            SessionProvider::ClaudeCode => claude_conversation(session_id),
+            SessionProvider::Codex => codex_conversation(session_id),
+            SessionProvider::Cursor => cursor_conversation(session_id),
+        };
     }
 
-    Err(format!(
-        "Session {} not found in any project directory",
-        session_id
-    ))
+    let mut matches = Vec::new();
+    for (provider, loader) in [
+        (
+            SessionProvider::ClaudeCode,
+            claude_conversation as fn(&str) -> Result<Conversation, String>,
+        ),
+        (SessionProvider::Codex, codex_conversation),
+        (SessionProvider::Cursor, cursor_conversation),
+    ] {
+        if let Ok(conversation) = loader(session_id) {
+            matches.push((provider, conversation));
+        }
+    }
+
+    select_provider_conversation(session_id, matches)
+}
+
+/// Backward-compatible ID-only lookup for CLI callers and old clients.
+pub fn get_conversation_data(session_id: &str) -> Result<Conversation, String> {
+    get_conversation_data_for_provider(session_id, None)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn conversation(session_id: &str) -> Conversation {
+        Conversation {
+            session_id: session_id.to_string(),
+            provider: SessionProvider::ClaudeCode,
+            messages: Vec::new(),
+        }
+    }
+
+    #[test]
+    fn providerless_conversation_lookup_rejects_cross_provider_collision() {
+        let error = select_provider_conversation(
+            "same-id",
+            vec![
+                (SessionProvider::ClaudeCode, conversation("same-id")),
+                (SessionProvider::Codex, conversation("same-id")),
+            ],
+        )
+        .unwrap_err();
+
+        assert!(error.contains("ambiguous across providers"));
+        assert!(error.contains("pass provider explicitly"));
+    }
+
+    #[test]
+    fn providerless_conversation_lookup_accepts_one_provider() {
+        let result = select_provider_conversation(
+            "only-id",
+            vec![(SessionProvider::Cursor, conversation("only-id"))],
+        )
+        .unwrap();
+
+        assert_eq!(result.session_id, "only-id");
+    }
 }

--- a/src-tauri/src/session/cost.rs
+++ b/src-tauri/src/session/cost.rs
@@ -554,7 +554,7 @@ fn scan_file(path: &std::path::Path) -> Vec<SessionCostRecord> {
 }
 
 fn codex_cost_records(home_dir: &std::path::Path) -> Vec<SessionCostRecord> {
-    super::codex_archive::load_default_snapshots(home_dir)
+    super::codex_archive::load_default_listing(home_dir)
         .into_iter()
         .filter(|snapshot| !snapshot.is_internal())
         .flat_map(|snapshot| {

--- a/src-tauri/src/session/cost.rs
+++ b/src-tauri/src/session/cost.rs
@@ -559,14 +559,17 @@ fn codex_cost_records(home_dir: &std::path::Path) -> Vec<SessionCostRecord> {
         .filter(|snapshot| !snapshot.is_internal())
         .flat_map(|snapshot| {
             let project_name = project_name_from_path(&snapshot.cwd);
-            let session_name = {
-                let truncated: String = snapshot.display.chars().take(40).collect();
-                if snapshot.display.chars().count() > 40 {
-                    format!("{truncated}…")
-                } else {
-                    truncated
-                }
-            };
+            // Prefer Codex's UI thread name, then retain the transcript display
+            // fallback for sessions that predate or lack the local index entry.
+            let session_name = super::codex::get_cached_codex_thread_title(&snapshot.thread_id)
+                .unwrap_or_else(|| {
+                    let truncated: String = snapshot.display.chars().take(40).collect();
+                    if snapshot.display.chars().count() > 40 {
+                        format!("{truncated}…")
+                    } else {
+                        truncated
+                    }
+                });
             snapshot.token_days.into_iter().map(move |day| {
                 let estimated_cost = estimate_codex_cost(
                     &day.model,

--- a/src-tauri/src/session/cursor.rs
+++ b/src-tauri/src/session/cursor.rs
@@ -1,0 +1,1368 @@
+//! Cursor Agent session discovery from `~/.cursor/projects/*/agent-transcripts`.
+//!
+//! JSONL transcripts are the source of truth for discovery and liveness.
+//! `state.vscdb` is an optional read-only overlay for title, cwd, and model.
+
+use super::parser::MessageType;
+use super::source::{
+    AgentKind, DetectedSession, DetectionDiagnostics, SessionDetectorError, SessionKind,
+    SessionProvider, SessionSource, SessionSurface,
+};
+use serde::Deserialize;
+use serde_json::Value;
+use std::collections::{HashMap, HashSet};
+use std::fs::{self, File};
+use std::io::{BufRead, BufReader, Seek, SeekFrom};
+use std::path::{Path, PathBuf};
+use std::time::{Duration, SystemTime, UNIX_EPOCH};
+
+const IDLE_FRESHNESS_SECS: u64 = 30 * 60;
+const WORKING_FRESHNESS_SECS: u64 = 4 * 60 * 60;
+const LINKED_PARENT_CEILING_SECS: u64 = 24 * 60 * 60;
+const MONITOR_MESSAGE_CHARS: usize = 200;
+
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub enum CursorLifecycle {
+    Working,
+    #[default]
+    Idle,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct CursorMessage {
+    pub timestamp: String,
+    pub role: String,
+    pub message_type: MessageType,
+    pub content: String,
+}
+
+#[derive(Debug, Clone, Default)]
+pub struct CursorTranscriptSummary {
+    pub session_id: String,
+    pub cwd: PathBuf,
+    pub agent_kind: AgentKind,
+    pub parent_thread_id: Option<String>,
+    pub root_session_id: Option<String>,
+    pub agent_nickname: Option<String>,
+    pub agent_role: Option<String>,
+    pub lifecycle: CursorLifecycle,
+    pub messages: Vec<CursorMessage>,
+    pub started_at_ms: Option<i64>,
+    pub last_timestamp: String,
+    pub empty: bool,
+}
+
+impl CursorTranscriptSummary {
+    pub fn first_prompt(&self) -> Option<&str> {
+        self.messages
+            .iter()
+            .find(|message| message.role == "user")
+            .map(|message| message.content.as_str())
+    }
+
+    pub fn latest_message(&self) -> Option<&str> {
+        self.messages
+            .iter()
+            .rev()
+            .find(|message| {
+                matches!(
+                    message.message_type,
+                    MessageType::User | MessageType::Assistant
+                )
+            })
+            .map(|message| message.content.as_str())
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+struct FileStamp {
+    len: u64,
+    modified_nanos: u128,
+}
+
+#[derive(Debug, Clone)]
+struct CacheEntry {
+    stamp: FileStamp,
+    offset: u64,
+    summary: CursorTranscriptSummary,
+}
+
+struct TranscriptRef {
+    path: PathBuf,
+    session_id: String,
+    agent_kind: AgentKind,
+    parent_thread_id: Option<String>,
+    project_key: String,
+}
+
+#[derive(Default)]
+pub struct CursorSessionSource {
+    projects_root: PathBuf,
+    vscdb_path: Option<PathBuf>,
+    cache: HashMap<PathBuf, CacheEntry>,
+    #[cfg(test)]
+    parse_count: u32,
+}
+
+impl CursorSessionSource {
+    pub fn new() -> Result<Self, SessionDetectorError> {
+        let home = dirs::home_dir().ok_or(SessionDetectorError::HomeDirectoryNotFound)?;
+        Ok(Self::at_roots(
+            home.join(".cursor").join("projects"),
+            default_vscdb_path(&home),
+        ))
+    }
+
+    pub fn at_root(projects_root: PathBuf) -> Self {
+        Self::at_roots(projects_root, None)
+    }
+
+    fn at_roots(projects_root: PathBuf, vscdb_path: Option<PathBuf>) -> Self {
+        Self {
+            projects_root,
+            vscdb_path,
+            cache: HashMap::new(),
+            #[cfg(test)]
+            parse_count: 0,
+        }
+    }
+
+    #[cfg(test)]
+    fn at_root_with_vscdb(projects_root: PathBuf, vscdb_path: PathBuf) -> Self {
+        Self::at_roots(projects_root, Some(vscdb_path))
+    }
+
+    fn detect_at(
+        &mut self,
+        wall_now: SystemTime,
+    ) -> Result<(Vec<DetectedSession>, DetectionDiagnostics), SessionDetectorError> {
+        let refs = collect_transcript_refs(&self.projects_root);
+        let mut live: Vec<(PathBuf, CursorTranscriptSummary, u64)> = Vec::new();
+        let mut existing_paths = HashSet::new();
+
+        for transcript in &refs {
+            existing_paths.insert(transcript.path.clone());
+            let Ok(summary) = self.summary_for(&transcript.path, transcript) else {
+                continue;
+            };
+            let age = file_age_secs(&transcript.path, wall_now);
+            live.push((transcript.path.clone(), summary, age));
+        }
+
+        let composers = load_composer_map(self.vscdb_path.as_deref());
+        for (_path, summary, _age) in &mut live {
+            apply_composer_overlay(summary, composers.get(&summary.session_id));
+        }
+
+        let working_parent_ids: HashSet<String> = live
+            .iter()
+            .filter(|(_, summary, age)| {
+                summary.agent_kind == AgentKind::Subagent
+                    && summary.lifecycle == CursorLifecycle::Working
+                    && *age <= WORKING_FRESHNESS_SECS
+            })
+            .flat_map(|(_, summary, _)| {
+                [
+                    summary.parent_thread_id.clone(),
+                    summary.root_session_id.clone(),
+                ]
+                .into_iter()
+                .flatten()
+            })
+            .collect();
+
+        self.cache
+            .retain(|path, _| existing_paths.contains(path));
+
+        let mut sessions = Vec::new();
+        for (_path, summary, age_secs) in live {
+            if summary.session_id.is_empty() {
+                continue;
+            }
+            let freshness = if summary.lifecycle == CursorLifecycle::Working {
+                WORKING_FRESHNESS_SECS
+            } else {
+                IDLE_FRESHNESS_SECS
+            };
+            let linked_parent = working_parent_ids.contains(&summary.session_id)
+                && age_secs <= LINKED_PARENT_CEILING_SECS;
+            if age_secs > freshness && !linked_parent {
+                continue;
+            }
+
+            let cwd = if summary.cwd.as_os_str().is_empty() {
+                PathBuf::from("Cursor")
+            } else {
+                summary.cwd.clone()
+            };
+            let project_name = cwd
+                .file_name()
+                .and_then(|name| name.to_str())
+                .unwrap_or("Cursor")
+                .to_string();
+            sessions.push(DetectedSession {
+                pid: 0,
+                cwd: cwd.clone(),
+                project_path: cwd,
+                session_id: Some(summary.session_id.clone()),
+                project_name,
+                kind: SessionKind::Interactive,
+                started_at_ms: summary.started_at_ms,
+                official_name: summary.agent_nickname.clone(),
+                cli_activity: None,
+                provider: SessionProvider::Cursor,
+                surface: SessionSurface::Cursor,
+                agent_kind: summary.agent_kind,
+                parent_thread_id: summary.parent_thread_id.clone(),
+                root_session_id: summary.root_session_id.clone(),
+                agent_path: None,
+                agent_nickname: summary.agent_nickname.clone(),
+                agent_role: summary.agent_role.clone(),
+                internal_kind: None,
+                can_open: false,
+                can_stop: false,
+                can_rename: false,
+                codex_summary: None,
+                cursor_summary: Some(summary),
+            });
+        }
+        Ok((sessions, DetectionDiagnostics::default()))
+    }
+
+    fn summary_for(
+        &mut self,
+        path: &Path,
+        transcript: &TranscriptRef,
+    ) -> Result<CursorTranscriptSummary, SessionDetectorError> {
+        let stamp = file_stamp(path)?;
+        if let Some(cached) = self.cache.get(path) {
+            if cached.stamp == stamp {
+                return Ok(cached.summary.clone());
+            }
+        }
+        let (existing, start_offset) = match self.cache.get(path) {
+            Some(cached) if stamp.len > cached.offset => {
+                (Some(cached.summary.clone()), cached.offset)
+            }
+            _ => (None, 0),
+        };
+        #[cfg(test)]
+        {
+            self.parse_count += 1;
+        }
+        let (mut summary, offset) =
+            parse_transcript_range(path, transcript, true, start_offset, existing)?;
+        if summary.cwd.as_os_str().is_empty() {
+            summary.cwd = decode_cursor_project_key(&transcript.project_key);
+        }
+        self.cache.insert(
+            path.to_path_buf(),
+            CacheEntry {
+                stamp,
+                offset,
+                summary: summary.clone(),
+            },
+        );
+        Ok(summary)
+    }
+}
+
+impl SessionSource for CursorSessionSource {
+    fn detect(
+        &mut self,
+    ) -> Result<(Vec<DetectedSession>, DetectionDiagnostics), SessionDetectorError> {
+        self.detect_at(SystemTime::now())
+    }
+
+    fn backend_name(&self) -> &'static str {
+        "cursor-transcript"
+    }
+}
+
+pub fn find_cursor_conversation_with_progress(
+    session_id: &str,
+    include_tools: bool,
+    on_progress: &mut dyn FnMut(u64, u64),
+) -> Result<Vec<CursorMessage>, String> {
+    let home = dirs::home_dir().ok_or("Failed to get home directory")?;
+    find_cursor_conversation_under(
+        &home.join(".cursor").join("projects"),
+        session_id,
+        include_tools,
+        on_progress,
+    )
+}
+
+pub fn find_cursor_conversation_under(
+    projects_root: &Path,
+    session_id: &str,
+    include_tools: bool,
+    on_progress: &mut dyn FnMut(u64, u64),
+) -> Result<Vec<CursorMessage>, String> {
+    let Some(transcript) = collect_transcript_refs(projects_root)
+        .into_iter()
+        .find(|item| item.session_id == session_id)
+    else {
+        return Err(format!("Cursor session {session_id} not found"));
+    };
+    let total = fs::metadata(&transcript.path)
+        .map(|meta| meta.len())
+        .unwrap_or(0);
+    on_progress(0, total);
+    let mut summary =
+        parse_transcript(&transcript.path, &transcript, false).map_err(|error| error.to_string())?;
+    on_progress(total, total);
+    if !include_tools {
+        summary
+            .messages
+            .retain(|message| !matches!(message.message_type, MessageType::ToolUse));
+    }
+    Ok(summary.messages)
+}
+
+pub fn cursor_history_entries(home_dir: &Path) -> Vec<crate::session::history::HistoryEntry> {
+    let projects_root = home_dir.join(".cursor").join("projects");
+    collect_transcript_refs(&projects_root)
+        .into_iter()
+        .filter(|item| item.agent_kind == AgentKind::Root)
+        .filter_map(|item| {
+            let summary = parse_transcript(&item.path, &item, true).ok()?;
+            let display = summary
+                .first_prompt()
+                .unwrap_or("(No conversation yet)")
+                .to_string();
+            let cwd = if summary.cwd.as_os_str().is_empty() {
+                decode_cursor_project_key(&item.project_key)
+            } else {
+                summary.cwd
+            };
+            let project_name = cwd
+                .file_name()
+                .and_then(|name| name.to_str())
+                .unwrap_or("Cursor")
+                .to_string();
+            let timestamp = fs::metadata(&item.path)
+                .ok()
+                .and_then(|meta| meta.modified().ok())
+                .and_then(system_time_millis)
+                .unwrap_or(0)
+                .max(0) as u64;
+            Some(crate::session::history::HistoryEntry {
+                session_id: item.session_id,
+                display,
+                timestamp,
+                project: cwd.to_string_lossy().into_owned(),
+                project_name,
+                custom_title: summary.agent_nickname,
+                provider: "cursor".to_string(),
+                surface: Some("cursor".to_string()),
+                agent_kind: Some("root".to_string()),
+            })
+        })
+        .collect()
+}
+
+pub fn list_session_ids(home_dir: &Path, prefix: &str) -> Vec<String> {
+    collect_transcript_refs(&home_dir.join(".cursor").join("projects"))
+        .into_iter()
+        .map(|item| item.session_id)
+        .filter(|id| id.starts_with(prefix))
+        .collect()
+}
+
+pub fn search_cursor_transcripts(
+    home_dir: &Path,
+    query_norm: &str,
+    case_sensitive: bool,
+    whole_word: bool,
+    phrase_match: fn(&str, &str, bool) -> bool,
+    extract_snippet: fn(&str, &str, &str) -> String,
+) -> Vec<crate::session::history::DeepSearchHit> {
+    let mut hits = Vec::new();
+    let projects_root = home_dir.join(".cursor").join("projects");
+    for item in collect_transcript_refs(&projects_root)
+        .into_iter()
+        .filter(|item| item.agent_kind == AgentKind::Root)
+    {
+        let Ok(summary) = parse_transcript(&item.path, &item, true) else {
+            continue;
+        };
+        let cwd = if summary.cwd.as_os_str().is_empty() {
+            decode_cursor_project_key(&item.project_key)
+        } else {
+            summary.cwd.clone()
+        };
+        for message in &summary.messages {
+            let text = &message.content;
+            let norm = if case_sensitive {
+                text.clone()
+            } else {
+                text.to_lowercase()
+            };
+            if !phrase_match(&norm, query_norm, whole_word) {
+                continue;
+            }
+            let snippet = extract_snippet(text, &norm, query_norm);
+            if snippet.is_empty() {
+                continue;
+            }
+            hits.push(crate::session::history::DeepSearchHit {
+                session_id: item.session_id.clone(),
+                snippet,
+                project_path: Some(cwd.to_string_lossy().into_owned()),
+                modified: Some(summary.last_timestamp.clone()),
+                provider: "cursor".to_string(),
+                surface: Some("cursor".to_string()),
+                agent_kind: if item.agent_kind == AgentKind::Subagent {
+                    "subagent".to_string()
+                } else {
+                    "root".to_string()
+                },
+            });
+            break;
+        }
+    }
+    hits
+}
+
+fn default_vscdb_path(home: &Path) -> Option<PathBuf> {
+    #[cfg(target_os = "macos")]
+    {
+        Some(
+            home.join("Library")
+                .join("Application Support")
+                .join("Cursor")
+                .join("User")
+                .join("globalStorage")
+                .join("state.vscdb"),
+        )
+    }
+    #[cfg(not(target_os = "macos"))]
+    {
+        let _ = home;
+        None
+    }
+}
+
+fn collect_transcript_refs(projects_root: &Path) -> Vec<TranscriptRef> {
+    let Ok(projects) = fs::read_dir(projects_root) else {
+        return Vec::new();
+    };
+    let mut refs = Vec::new();
+    for project in projects.flatten() {
+        let project_path = project.path();
+        if !project_path.is_dir() {
+            continue;
+        }
+        let Some(project_key) = project_path
+            .file_name()
+            .and_then(|name| name.to_str())
+            .map(str::to_string)
+        else {
+            continue;
+        };
+        let transcripts = project_path.join("agent-transcripts");
+        let Ok(sessions) = fs::read_dir(&transcripts) else {
+            continue;
+        };
+        for session_dir in sessions.flatten() {
+            let session_path = session_dir.path();
+            if !session_path.is_dir() {
+                continue;
+            }
+            let Some(parent_id) = session_path
+                .file_name()
+                .and_then(|name| name.to_str())
+                .map(str::to_string)
+            else {
+                continue;
+            };
+            if !looks_like_uuid(&parent_id) {
+                continue;
+            }
+            let parent_file = session_path.join(format!("{parent_id}.jsonl"));
+            if parent_file.is_file() {
+                refs.push(TranscriptRef {
+                    path: parent_file,
+                    session_id: parent_id.clone(),
+                    agent_kind: AgentKind::Root,
+                    parent_thread_id: None,
+                    project_key: project_key.clone(),
+                });
+            }
+            let subagents = session_path.join("subagents");
+            let Ok(children) = fs::read_dir(&subagents) else {
+                continue;
+            };
+            for child in children.flatten() {
+                let child_path = child.path();
+                if child_path.extension().and_then(|ext| ext.to_str()) != Some("jsonl") {
+                    continue;
+                }
+                let Some(child_id) = child_path
+                    .file_stem()
+                    .and_then(|name| name.to_str())
+                    .map(str::to_string)
+                else {
+                    continue;
+                };
+                if !looks_like_uuid(&child_id) {
+                    continue;
+                }
+                refs.push(TranscriptRef {
+                    path: child_path,
+                    session_id: child_id,
+                    agent_kind: AgentKind::Subagent,
+                    parent_thread_id: Some(parent_id.clone()),
+                    project_key: project_key.clone(),
+                });
+            }
+        }
+    }
+    refs
+}
+
+fn parse_transcript(
+    path: &Path,
+    transcript: &TranscriptRef,
+    compact: bool,
+) -> Result<CursorTranscriptSummary, SessionDetectorError> {
+    let (summary, _) = parse_transcript_range(path, transcript, compact, 0, None)?;
+    Ok(summary)
+}
+
+fn parse_transcript_range(
+    path: &Path,
+    transcript: &TranscriptRef,
+    compact: bool,
+    start_offset: u64,
+    existing: Option<CursorTranscriptSummary>,
+) -> Result<(CursorTranscriptSummary, u64), SessionDetectorError> {
+    let mut file = File::open(path)?;
+    let metadata = fs::metadata(path)?;
+    let modified = metadata.modified().ok().and_then(system_time_millis);
+    let created = metadata.created().ok().and_then(system_time_millis);
+    let last_timestamp = modified
+        .and_then(|ms| chrono::DateTime::<chrono::Utc>::from_timestamp_millis(ms))
+        .map(|dt| dt.to_rfc3339())
+        .unwrap_or_default();
+    let mut saw_lifecycle = existing.is_some();
+    let mut summary = existing.unwrap_or_else(|| CursorTranscriptSummary {
+        session_id: transcript.session_id.clone(),
+        agent_kind: transcript.agent_kind,
+        parent_thread_id: transcript.parent_thread_id.clone(),
+        root_session_id: Some(
+            transcript
+                .parent_thread_id
+                .clone()
+                .unwrap_or_else(|| transcript.session_id.clone()),
+        ),
+        started_at_ms: created.or(modified),
+        last_timestamp: last_timestamp.clone(),
+        ..CursorTranscriptSummary::default()
+    });
+    summary.last_timestamp = last_timestamp;
+
+    file.seek(SeekFrom::Start(start_offset))?;
+    let mut reader = BufReader::new(file);
+    let mut offset = start_offset;
+    loop {
+        let mut buf = Vec::new();
+        let bytes_read = reader.read_until(b'\n', &mut buf)?;
+        if bytes_read == 0 {
+            break;
+        }
+        if !buf.ends_with(&[b'\n']) {
+            break;
+        }
+        offset += bytes_read as u64;
+        let Ok(line) = std::str::from_utf8(&buf) else {
+            continue;
+        };
+        let line = line.trim();
+        if line.is_empty() {
+            continue;
+        }
+        let Ok(value) = serde_json::from_str::<Value>(line) else {
+            continue;
+        };
+        if apply_transcript_line(&mut summary, &value, compact) {
+            saw_lifecycle = true;
+        }
+    }
+    summary.empty = summary.messages.is_empty();
+    if summary.empty && !saw_lifecycle {
+        summary.lifecycle = CursorLifecycle::Working;
+    }
+    Ok((summary, offset))
+}
+
+fn apply_transcript_line(summary: &mut CursorTranscriptSummary, value: &Value, compact: bool) -> bool {
+    if value.get("type").and_then(Value::as_str) == Some("turn_ended") {
+        summary.lifecycle = CursorLifecycle::Idle;
+        return true;
+    }
+    let Some(role) = value.get("role").and_then(Value::as_str) else {
+        return false;
+    };
+    summary.lifecycle = CursorLifecycle::Working;
+    let content_blocks = value
+        .pointer("/message/content")
+        .and_then(Value::as_array)
+        .cloned()
+        .unwrap_or_default();
+
+    match role {
+        "user" => {
+            let raw = collect_text_blocks(&content_blocks);
+            let content = extract_user_query(&raw);
+            if content.is_empty() {
+                return true;
+            }
+            if summary.agent_kind == AgentKind::Subagent {
+                if let Some(role_name) = infer_subagent_role(&content) {
+                    if summary.agent_role.is_none() {
+                        summary.agent_role = Some(role_name);
+                    }
+                }
+            }
+            push_monitor_message(summary, "user", MessageType::User, content, compact);
+        }
+        "assistant" => {
+            let text = collect_text_blocks(&content_blocks);
+            if !text.is_empty() {
+                push_monitor_message(summary, "assistant", MessageType::Assistant, text, compact);
+            }
+            for block in &content_blocks {
+                if block.get("type").and_then(Value::as_str) != Some("tool_use") {
+                    continue;
+                }
+                let name = block
+                    .get("name")
+                    .and_then(Value::as_str)
+                    .unwrap_or("tool");
+                let input = block.get("input").cloned().unwrap_or(Value::Null);
+                if name == "Task" && summary.agent_kind == AgentKind::Subagent {
+                    if let Some(subagent_type) = input.get("subagent_type").and_then(Value::as_str)
+                    {
+                        if summary.agent_role.is_none() {
+                            summary.agent_role = Some(subagent_type.to_string());
+                        }
+                    }
+                }
+                let content = format!("{name} {}", compact_json(&input));
+                push_monitor_message(summary, "assistant", MessageType::ToolUse, content, compact);
+            }
+        }
+        _ => {}
+    }
+    true
+}
+
+fn push_monitor_message(
+    summary: &mut CursorTranscriptSummary,
+    role: &str,
+    message_type: MessageType,
+    content: String,
+    compact: bool,
+) {
+    let content = if compact {
+        truncate_chars(&content, MONITOR_MESSAGE_CHARS)
+    } else {
+        content
+    };
+    summary.messages.push(CursorMessage {
+        timestamp: summary.last_timestamp.clone(),
+        role: role.to_string(),
+        message_type,
+        content,
+    });
+}
+
+fn collect_text_blocks(blocks: &[Value]) -> String {
+    blocks
+        .iter()
+        .filter(|block| block.get("type").and_then(Value::as_str) == Some("text"))
+        .filter_map(|block| block.get("text").and_then(Value::as_str))
+        .collect::<Vec<_>>()
+        .join("\n")
+}
+
+pub(crate) fn extract_user_query(text: &str) -> String {
+    if let Some(start) = text.find("<user_query>") {
+        let rest = &text[start + "<user_query>".len()..];
+        if let Some(end) = rest.find("</user_query>") {
+            return rest[..end].trim().to_string();
+        }
+        return rest.trim().to_string();
+    }
+    if let Some(end) = text.find("</timestamp>") {
+        return text[end + "</timestamp>".len()..].trim().to_string();
+    }
+    text.trim().to_string()
+}
+
+fn infer_subagent_role(prompt: &str) -> Option<String> {
+    let lower = prompt.to_lowercase();
+    if lower.contains("subagent_type") {
+        return None;
+    }
+    for marker in ["explore", "generalpurpose", "general-purpose", "bugbot"] {
+        if lower.contains(marker) {
+            return Some(marker.replace('-', ""));
+        }
+    }
+    None
+}
+
+pub(crate) fn decode_cursor_project_key(encoded: &str) -> PathBuf {
+    if encoded.is_empty() {
+        return PathBuf::from("/");
+    }
+    let parts: Vec<&str> = encoded.split('-').collect();
+    let mut current = PathBuf::from("/");
+    let mut i = 0;
+    while i < parts.len() {
+        let mut matched = false;
+        for j in (i + 1..=parts.len()).rev() {
+            let candidate = parts[i..j].join("-");
+            let next = current.join(&candidate);
+            if next.exists() {
+                current = next;
+                i = j;
+                matched = true;
+                break;
+            }
+        }
+        if !matched {
+            current = current.join(parts[i..].join("-"));
+            break;
+        }
+    }
+    current
+}
+
+fn looks_like_uuid(value: &str) -> bool {
+    let bytes = value.as_bytes();
+    bytes.len() == 36
+        && bytes[8] == b'-'
+        && bytes[13] == b'-'
+        && bytes[18] == b'-'
+        && bytes[23] == b'-'
+}
+
+fn file_stamp(path: &Path) -> Result<FileStamp, SessionDetectorError> {
+    let metadata = fs::metadata(path)?;
+    let modified_nanos = metadata
+        .modified()
+        .ok()
+        .and_then(|time| time.duration_since(UNIX_EPOCH).ok())
+        .map(|duration| duration.as_nanos())
+        .unwrap_or(0);
+    Ok(FileStamp {
+        len: metadata.len(),
+        modified_nanos,
+    })
+}
+
+fn file_age_secs(path: &Path, wall_now: SystemTime) -> u64 {
+    fs::metadata(path)
+        .and_then(|meta| meta.modified())
+        .ok()
+        .and_then(|modified| wall_now.duration_since(modified).ok())
+        .map(|duration| duration.as_secs())
+        .unwrap_or(0)
+}
+
+fn system_time_millis(time: SystemTime) -> Option<i64> {
+    time.duration_since(UNIX_EPOCH)
+        .ok()
+        .map(|duration| duration.as_millis() as i64)
+}
+
+fn truncate_chars(text: &str, max_chars: usize) -> String {
+    if text.chars().count() <= max_chars {
+        return text.to_string();
+    }
+    text.chars().take(max_chars).collect()
+}
+
+fn compact_json(value: &Value) -> String {
+    serde_json::to_string(value).unwrap_or_default()
+}
+
+#[derive(Debug, Clone, Default)]
+struct ComposerOverlay {
+    name: Option<String>,
+    cwd: Option<PathBuf>,
+    agent_role: Option<String>,
+    generating: bool,
+}
+
+fn apply_composer_overlay(summary: &mut CursorTranscriptSummary, overlay: Option<&ComposerOverlay>) {
+    let Some(overlay) = overlay else {
+        return;
+    };
+    if let Some(name) = overlay.name.clone() {
+        summary.agent_nickname = Some(name);
+    }
+    if let Some(cwd) = overlay.cwd.clone() {
+        summary.cwd = cwd;
+    }
+    if let Some(role) = overlay.agent_role.clone() {
+        summary.agent_role = Some(role);
+    }
+    if overlay.generating {
+        summary.lifecycle = CursorLifecycle::Working;
+    }
+}
+
+fn load_composer_map(vscdb_path: Option<&Path>) -> HashMap<String, ComposerOverlay> {
+    let Some(path) = vscdb_path else {
+        return HashMap::new();
+    };
+    if !path.is_file() {
+        return HashMap::new();
+    }
+    read_composer_overlays(path).unwrap_or_default()
+}
+
+fn read_composer_overlays(path: &Path) -> Result<HashMap<String, ComposerOverlay>, rusqlite::Error> {
+    let uri = format!("file:{}?mode=ro", path.display());
+    let conn = rusqlite::Connection::open_with_flags(
+        &uri,
+        rusqlite::OpenFlags::SQLITE_OPEN_READ_ONLY | rusqlite::OpenFlags::SQLITE_OPEN_URI,
+    )?;
+    let _ = conn.busy_timeout(Duration::from_millis(50));
+    let mut stmt = conn.prepare("SELECT key, value FROM cursorDiskKV WHERE key LIKE 'composerData:%'")?;
+    let rows = stmt.query_map([], |row| {
+        let key: String = row.get(0)?;
+        let value: String = row.get(1)?;
+        Ok((key, value))
+    })?;
+    let mut map = HashMap::new();
+    for row in rows.flatten() {
+        let Some(id) = row.0.strip_prefix("composerData:") else {
+            continue;
+        };
+        if let Some(overlay) = parse_composer_overlay(&row.1) {
+            map.insert(id.to_string(), overlay);
+        }
+    }
+    Ok(map)
+}
+
+#[derive(Debug, Deserialize)]
+struct ComposerDataFile {
+    name: Option<String>,
+    #[serde(rename = "workspaceIdentifier")]
+    workspace_identifier: Option<WorkspaceIdentifier>,
+    #[serde(rename = "subagentInfo")]
+    subagent_info: Option<SubagentInfoFile>,
+    #[serde(rename = "generatingBubbleIds")]
+    generating_bubble_ids: Option<Vec<Value>>,
+}
+
+#[derive(Debug, Deserialize)]
+struct WorkspaceIdentifier {
+    uri: Option<WorkspaceUri>,
+}
+
+#[derive(Debug, Deserialize)]
+struct WorkspaceUri {
+    #[serde(rename = "fsPath")]
+    fs_path: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+struct SubagentInfoFile {
+    #[serde(rename = "subagentTypeName")]
+    subagent_type_name: Option<String>,
+}
+
+fn parse_composer_overlay(raw: &str) -> Option<ComposerOverlay> {
+    let data: ComposerDataFile = serde_json::from_str(raw).ok()?;
+    Some(ComposerOverlay {
+        name: data.name.filter(|name| !name.is_empty()),
+        cwd: data
+            .workspace_identifier
+            .and_then(|workspace| workspace.uri)
+            .and_then(|uri| uri.fs_path)
+            .map(PathBuf::from),
+        agent_role: data
+            .subagent_info
+            .and_then(|info| info.subagent_type_name)
+            .filter(|name| !name.is_empty()),
+        generating: data
+            .generating_bubble_ids
+            .is_some_and(|ids| !ids.is_empty()),
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::io::Write;
+    use std::time::Duration;
+
+    const PARENT: &str = "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa";
+    const CHILD_RUNNING: &str = "bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb";
+    const CHILD_DONE: &str = "cccccccc-cccc-cccc-cccc-cccccccccccc";
+
+    fn write_jsonl(path: &Path, lines: &[&str]) {
+        if let Some(parent) = path.parent() {
+            fs::create_dir_all(parent).unwrap();
+        }
+        let mut file = File::create(path).unwrap();
+        for line in lines {
+            writeln!(file, "{line}").unwrap();
+        }
+    }
+
+    fn user_line(text: &str) -> String {
+        format!(
+            r#"{{"role":"user","message":{{"content":[{{"type":"text","text":"<timestamp>Wednesday, Aug 19, 2026, 9:31 PM (UTC+8)</timestamp>\n<user_query>\n{text}\n</user_query>"}}]}}}}"#
+        )
+    }
+
+    fn assistant_line(text: &str) -> String {
+        format!(
+            r#"{{"role":"assistant","message":{{"content":[{{"type":"text","text":"{text}"}}]}}}}"#
+        )
+    }
+
+    fn tool_line(name: &str, extra: &str) -> String {
+        format!(
+            r#"{{"role":"assistant","message":{{"content":[{{"type":"tool_use","name":"{name}","input":{extra}}}]}}}}"#
+        )
+    }
+
+    fn layout(root: &Path, project_key: &str) -> PathBuf {
+        let transcripts = root
+            .join(project_key)
+            .join("agent-transcripts")
+            .join(PARENT);
+        fs::create_dir_all(transcripts.join("subagents")).unwrap();
+        transcripts
+    }
+
+    #[test]
+    fn extracts_user_query_and_strips_wrapper() {
+        let raw = "<timestamp>Wednesday, Aug 19, 2026, 9:31 PM (UTC+8)</timestamp>\n<user_query>\nFix the overlay\n</user_query>";
+        assert_eq!(extract_user_query(raw), "Fix the overlay");
+    }
+
+    #[test]
+    fn last_turn_ended_is_idle_even_with_earlier_turns() {
+        let tmp = tempfile::tempdir().unwrap();
+        let session_dir = layout(tmp.path(), "demo-project");
+        write_jsonl(
+            &session_dir.join(format!("{PARENT}.jsonl")),
+            &[
+                &user_line("first"),
+                &assistant_line("working"),
+                r#"{"type":"turn_ended","status":"success"}"#,
+                &user_line("second"),
+                &assistant_line("done"),
+                r#"{"type":"turn_ended","status":"success"}"#,
+            ],
+        );
+        let mut source = CursorSessionSource::at_root(tmp.path().to_path_buf());
+        let (sessions, _) = source.detect().unwrap();
+        assert_eq!(sessions.len(), 1);
+        assert_eq!(sessions[0].agent_kind, AgentKind::Root);
+        assert_eq!(
+            sessions[0].cursor_summary.as_ref().unwrap().lifecycle,
+            CursorLifecycle::Idle
+        );
+        assert_eq!(
+            sessions[0]
+                .cursor_summary
+                .as_ref()
+                .unwrap()
+                .first_prompt()
+                .unwrap(),
+            "first"
+        );
+    }
+
+    #[test]
+    fn running_subagent_without_turn_ended_is_working_and_pins_parent() {
+        let tmp = tempfile::tempdir().unwrap();
+        let session_dir = layout(tmp.path(), "demo-project");
+        write_jsonl(
+            &session_dir.join(format!("{PARENT}.jsonl")),
+            &[
+                &user_line("parent prompt"),
+                &tool_line("Task", r#"{"subagent_type":"explore","description":"scan"}"#),
+                r#"{"type":"turn_ended","status":"success"}"#,
+            ],
+        );
+        write_jsonl(
+            &session_dir
+                .join("subagents")
+                .join(format!("{CHILD_RUNNING}.jsonl")),
+            &[
+                &user_line("Explore the codebase"),
+                &tool_line("Grep", r#"{"pattern":"cursor"}"#),
+            ],
+        );
+        write_jsonl(
+            &session_dir
+                .join("subagents")
+                .join(format!("{CHILD_DONE}.jsonl")),
+            &[
+                &user_line("Done already"),
+                &assistant_line("finished"),
+                r#"{"type":"turn_ended","status":"success"}"#,
+            ],
+        );
+
+        let mut source = CursorSessionSource::at_root(tmp.path().to_path_buf());
+        let (sessions, _) = source.detect().unwrap();
+        assert_eq!(sessions.len(), 3);
+        let running = sessions
+            .iter()
+            .find(|session| session.session_id.as_deref() == Some(CHILD_RUNNING))
+            .unwrap();
+        assert_eq!(running.agent_kind, AgentKind::Subagent);
+        assert_eq!(running.parent_thread_id.as_deref(), Some(PARENT));
+        assert_eq!(
+            running.cursor_summary.as_ref().unwrap().lifecycle,
+            CursorLifecycle::Working
+        );
+        let done = sessions
+            .iter()
+            .find(|session| session.session_id.as_deref() == Some(CHILD_DONE))
+            .unwrap();
+        assert_eq!(
+            done.cursor_summary.as_ref().unwrap().lifecycle,
+            CursorLifecycle::Idle
+        );
+    }
+
+    #[test]
+    fn idle_sessions_age_out_but_working_child_keeps_parent() {
+        let tmp = tempfile::tempdir().unwrap();
+        let session_dir = layout(tmp.path(), "demo-project");
+        write_jsonl(
+            &session_dir.join(format!("{PARENT}.jsonl")),
+            &[
+                &user_line("parent"),
+                r#"{"type":"turn_ended","status":"success"}"#,
+            ],
+        );
+        write_jsonl(
+            &session_dir
+                .join("subagents")
+                .join(format!("{CHILD_RUNNING}.jsonl")),
+            &[&user_line("still going"), &assistant_line("working")],
+        );
+
+        let mut source = CursorSessionSource::at_root(tmp.path().to_path_buf());
+        let stale = SystemTime::now() + Duration::from_secs(IDLE_FRESHNESS_SECS + 60);
+        let (sessions, _) = source.detect_at(stale).unwrap();
+        let ids: HashSet<_> = sessions
+            .iter()
+            .filter_map(|session| session.session_id.clone())
+            .collect();
+        assert!(ids.contains(PARENT), "working child should pin idle parent");
+        assert!(ids.contains(CHILD_RUNNING));
+    }
+
+    #[test]
+    fn conversation_tools_off_drops_tool_use() {
+        let tmp = tempfile::tempdir().unwrap();
+        let session_dir = layout(tmp.path(), "demo-project");
+        write_jsonl(
+            &session_dir.join(format!("{PARENT}.jsonl")),
+            &[
+                &user_line("hello"),
+                &tool_line("Grep", r#"{"pattern":"x"}"#),
+                &assistant_line("done"),
+            ],
+        );
+        let with_tools = find_cursor_conversation_under(tmp.path(), PARENT, true, &mut |_, _| {})
+            .unwrap();
+        let without_tools =
+            find_cursor_conversation_under(tmp.path(), PARENT, false, &mut |_, _| {}).unwrap();
+        assert!(with_tools
+            .iter()
+            .any(|message| message.message_type == MessageType::ToolUse));
+        assert!(without_tools
+            .iter()
+            .all(|message| message.message_type != MessageType::ToolUse));
+        assert_eq!(without_tools[0].content, "hello");
+    }
+
+    #[test]
+    fn decode_prefers_existing_path_segments() {
+        let tmp = tempfile::tempdir().unwrap();
+        let real = tmp.path().join("GitHub").join("c9watch");
+        fs::create_dir_all(&real).unwrap();
+        let encoded = format!(
+            "{}-GitHub-c9watch",
+            tmp.path()
+                .strip_prefix("/")
+                .unwrap()
+                .to_string_lossy()
+                .replace('/', "-")
+        );
+        let decoded = decode_cursor_project_key(&encoded);
+        assert_eq!(decoded, real);
+    }
+
+    #[test]
+    fn jsonl_only_still_works_when_vscdb_missing() {
+        let tmp = tempfile::tempdir().unwrap();
+        let session_dir = layout(tmp.path(), "demo-project");
+        write_jsonl(
+            &session_dir.join(format!("{PARENT}.jsonl")),
+            &[&user_line("no db"), &assistant_line("ok")],
+        );
+        let mut source = CursorSessionSource::at_root_with_vscdb(
+            tmp.path().to_path_buf(),
+            tmp.path().join("missing.vscdb"),
+        );
+        let (sessions, _) = source.detect().unwrap();
+        assert_eq!(sessions.len(), 1);
+        assert_eq!(sessions[0].provider, SessionProvider::Cursor);
+        assert!(!sessions[0].can_open);
+    }
+
+    #[test]
+    fn vscdb_overlay_fills_title_cwd_and_can_promote_working() {
+        let tmp = tempfile::tempdir().unwrap();
+        let session_dir = layout(tmp.path(), "demo-project");
+        write_jsonl(
+            &session_dir.join(format!("{PARENT}.jsonl")),
+            &[
+                &user_line("named chat"),
+                r#"{"type":"turn_ended","status":"success"}"#,
+            ],
+        );
+        let db_path = tmp.path().join("state.vscdb");
+        let conn = rusqlite::Connection::open(&db_path).unwrap();
+        conn.execute(
+            "CREATE TABLE cursorDiskKV (key TEXT PRIMARY KEY, value TEXT)",
+            [],
+        )
+        .unwrap();
+        let payload = serde_json::json!({
+            "name": "Research Cursor agent sessions",
+            "workspaceIdentifier": {"uri": {"fsPath": "/tmp/real-cwd"}},
+            "generatingBubbleIds": ["bubble-1"],
+            "status": "aborted"
+        });
+        conn.execute(
+            "INSERT INTO cursorDiskKV (key, value) VALUES (?1, ?2)",
+            rusqlite::params![format!("composerData:{PARENT}"), payload.to_string()],
+        )
+        .unwrap();
+        drop(conn);
+
+        let mut source =
+            CursorSessionSource::at_root_with_vscdb(tmp.path().to_path_buf(), db_path);
+        let (sessions, _) = source.detect().unwrap();
+        assert_eq!(sessions.len(), 1);
+        assert_eq!(
+            sessions[0].agent_nickname.as_deref(),
+            Some("Research Cursor agent sessions")
+        );
+        assert_eq!(sessions[0].cwd, PathBuf::from("/tmp/real-cwd"));
+        assert_eq!(
+            sessions[0].cursor_summary.as_ref().unwrap().lifecycle,
+            CursorLifecycle::Working
+        );
+    }
+
+    #[test]
+    fn aborted_status_without_generating_ids_does_not_force_working() {
+        let overlay = parse_composer_overlay(
+            r#"{"name":"x","status":"aborted","generatingBubbleIds":[],"unfinishedRunAt":1}"#,
+        )
+        .unwrap();
+        assert!(!overlay.generating);
+        let mut summary = CursorTranscriptSummary {
+            lifecycle: CursorLifecycle::Idle,
+            ..CursorTranscriptSummary::default()
+        };
+        apply_composer_overlay(&mut summary, Some(&overlay));
+        assert_eq!(summary.lifecycle, CursorLifecycle::Idle);
+    }
+
+    #[test]
+    fn stale_idle_root_without_working_child_is_hidden() {
+        let tmp = tempfile::tempdir().unwrap();
+        let session_dir = layout(tmp.path(), "demo-project");
+        write_jsonl(
+            &session_dir.join(format!("{PARENT}.jsonl")),
+            &[
+                &user_line("old chat"),
+                r#"{"type":"turn_ended","status":"success"}"#,
+            ],
+        );
+        let mut source = CursorSessionSource::at_root(tmp.path().to_path_buf());
+        let stale = SystemTime::now() + Duration::from_secs(IDLE_FRESHNESS_SECS + 60);
+        let (sessions, _) = source.detect_at(stale).unwrap();
+        assert!(sessions.is_empty());
+    }
+
+    #[test]
+    fn decode_keeps_hyphenated_directory_names() {
+        let tmp = tempfile::tempdir().unwrap();
+        let real = tmp.path().join("my-app");
+        fs::create_dir_all(&real).unwrap();
+        let encoded = format!(
+            "{}-my-app",
+            tmp.path()
+                .strip_prefix("/")
+                .unwrap()
+                .to_string_lossy()
+                .replace('/', "-")
+        );
+        assert_eq!(decode_cursor_project_key(&encoded), real);
+    }
+
+    #[test]
+    fn empty_transcript_is_marked_empty_working() {
+        let tmp = tempfile::tempdir().unwrap();
+        let session_dir = layout(tmp.path(), "demo-project");
+        write_jsonl(&session_dir.join(format!("{PARENT}.jsonl")), &[]);
+        let mut source = CursorSessionSource::at_root(tmp.path().to_path_buf());
+        let (sessions, _) = source.detect().unwrap();
+        assert_eq!(sessions.len(), 1);
+        let summary = sessions[0].cursor_summary.as_ref().unwrap();
+        assert!(summary.empty);
+        assert_eq!(summary.lifecycle, CursorLifecycle::Working);
+        let (enriched, _) = crate::session::enrichment::enrich_detected_sessions(
+            sessions,
+            DetectionDiagnostics::default(),
+        )
+        .unwrap();
+        assert_eq!(enriched[0].status, crate::session::SessionStatus::Connecting);
+    }
+
+    #[test]
+    fn history_lists_roots_not_subagents() {
+        let tmp = tempfile::tempdir().unwrap();
+        let projects = tmp.path().join(".cursor").join("projects");
+        let session_dir = layout(&projects, "demo-project");
+        write_jsonl(
+            &session_dir.join(format!("{PARENT}.jsonl")),
+            &[&user_line("root prompt")],
+        );
+        write_jsonl(
+            &session_dir
+                .join("subagents")
+                .join(format!("{CHILD_RUNNING}.jsonl")),
+            &[&user_line("child prompt")],
+        );
+        let entries = cursor_history_entries(tmp.path());
+        assert_eq!(entries.len(), 1);
+        assert_eq!(entries[0].session_id, PARENT);
+        assert_eq!(entries[0].provider, "cursor");
+        assert_eq!(entries[0].display, "root prompt");
+        assert!(entries[0].timestamp > 0, "history should sort by last write, not birth");
+    }
+
+    #[test]
+    fn incremental_cache_reuses_unchanged_file_and_appends() {
+        let tmp = tempfile::tempdir().unwrap();
+        let session_dir = layout(tmp.path(), "demo-project");
+        let path = session_dir.join(format!("{PARENT}.jsonl"));
+        write_jsonl(&path, &[&user_line("hello"), &assistant_line("working")]);
+        let mut source = CursorSessionSource::at_root(tmp.path().to_path_buf());
+        let (first, _) = source.detect().unwrap();
+        assert_eq!(
+            first[0].cursor_summary.as_ref().unwrap().lifecycle,
+            CursorLifecycle::Working
+        );
+        let parsed = source.parse_count;
+        let _ = source.detect().unwrap();
+        assert_eq!(source.parse_count, parsed, "unchanged file must be a cache hit");
+
+        let mut file = fs::OpenOptions::new().append(true).open(&path).unwrap();
+        writeln!(file, r#"{{"type":"turn_ended","status":"success"}}"#).unwrap();
+        drop(file);
+
+        let (second, _) = source.detect().unwrap();
+        assert!(source.parse_count > parsed);
+        let summary = second[0].cursor_summary.as_ref().unwrap();
+        assert_eq!(summary.lifecycle, CursorLifecycle::Idle);
+        assert_eq!(
+            summary
+                .messages
+                .iter()
+                .filter(|message| message.role == "user")
+                .count(),
+            1,
+            "append must not duplicate earlier records"
+        );
+    }
+
+    #[test]
+    fn turn_ended_only_file_stays_idle_not_connecting() {
+        let tmp = tempfile::tempdir().unwrap();
+        let session_dir = layout(tmp.path(), "demo-project");
+        write_jsonl(
+            &session_dir.join(format!("{PARENT}.jsonl")),
+            &[r#"{"type":"turn_ended","status":"success"}"#],
+        );
+        let mut source = CursorSessionSource::at_root(tmp.path().to_path_buf());
+        let (sessions, _) = source.detect().unwrap();
+        let summary = sessions[0].cursor_summary.as_ref().unwrap();
+        assert!(summary.empty);
+        assert_eq!(summary.lifecycle, CursorLifecycle::Idle);
+        let (enriched, _) = crate::session::enrichment::enrich_detected_sessions(
+            sessions,
+            DetectionDiagnostics::default(),
+        )
+        .unwrap();
+        assert_eq!(enriched[0].status, crate::session::SessionStatus::WaitingForInput);
+    }
+
+    #[test]
+    fn rewrite_replaces_cached_messages_instead_of_merging() {
+        let tmp = tempfile::tempdir().unwrap();
+        let session_dir = layout(tmp.path(), "demo-project");
+        let path = session_dir.join(format!("{PARENT}.jsonl"));
+        write_jsonl(&path, &[&user_line("old prompt"), &assistant_line("old")]);
+        let mut source = CursorSessionSource::at_root(tmp.path().to_path_buf());
+        let (first, _) = source.detect().unwrap();
+        assert_eq!(
+            first[0].cursor_summary.as_ref().unwrap().first_prompt(),
+            Some("old prompt")
+        );
+
+        write_jsonl(&path, &[&user_line("replaced")]);
+        let (second, _) = source.detect().unwrap();
+        let summary = second[0].cursor_summary.as_ref().unwrap();
+        assert_eq!(summary.first_prompt(), Some("replaced"));
+        assert_eq!(
+            summary
+                .messages
+                .iter()
+                .filter(|message| message.role == "user")
+                .count(),
+            1
+        );
+    }
+
+    #[test]
+    fn parent_task_tool_does_not_become_root_agent_role() {
+        let tmp = tempfile::tempdir().unwrap();
+        let session_dir = layout(tmp.path(), "demo-project");
+        write_jsonl(
+            &session_dir.join(format!("{PARENT}.jsonl")),
+            &[
+                &user_line("parent prompt"),
+                &tool_line("Task", r#"{"subagent_type":"explore","description":"scan"}"#),
+                r#"{"type":"turn_ended","status":"success"}"#,
+            ],
+        );
+        let mut source = CursorSessionSource::at_root(tmp.path().to_path_buf());
+        let (sessions, _) = source.detect().unwrap();
+        assert!(sessions[0].agent_role.is_none());
+    }
+}

--- a/src-tauri/src/session/cursor.rs
+++ b/src-tauri/src/session/cursor.rs
@@ -50,6 +50,8 @@ pub struct CursorTranscriptSummary {
     pub agent_kind: AgentKind,
     pub parent_thread_id: Option<String>,
     pub root_session_id: Option<String>,
+    /// Cursor's current UI composer name from state.vscdb.
+    pub cursor_title: Option<String>,
     pub agent_nickname: Option<String>,
     pub agent_role: Option<String>,
     pub lifecycle: CursorLifecycle,
@@ -466,11 +468,13 @@ pub fn find_cursor_conversation_under(
 
 pub fn cursor_history_entries(home_dir: &Path) -> Vec<crate::session::history::HistoryEntry> {
     let projects_root = home_dir.join(".cursor").join("projects");
+    let composers = load_composer_map(default_vscdb_path(home_dir).as_deref());
     collect_transcript_refs(&projects_root)
         .into_iter()
         .filter(|item| item.agent_kind == AgentKind::Root)
         .filter_map(|item| {
-            let summary = parse_transcript(&item.path, &item, true).ok()?;
+            let mut summary = parse_transcript(&item.path, &item, true).ok()?;
+            apply_composer_overlay(&mut summary, composers.get(&item.session_id));
             let display = summary
                 .first_prompt()
                 .unwrap_or("(No conversation yet)")
@@ -497,7 +501,9 @@ pub fn cursor_history_entries(home_dir: &Path) -> Vec<crate::session::history::H
                 timestamp,
                 project: cwd.to_string_lossy().into_owned(),
                 project_name,
-                custom_title: summary.agent_nickname,
+                custom_title: None,
+                codex_title: None,
+                cursor_title: summary.cursor_title,
                 provider: "cursor".to_string(),
                 surface: Some("cursor".to_string()),
                 agent_kind: Some("root".to_string()),
@@ -1048,6 +1054,9 @@ fn apply_composer_overlay(
         return;
     };
     if let Some(name) = overlay.name.clone() {
+        summary.cursor_title = Some(name.clone());
+        // Preserve the existing nickname projection for subagent labels and
+        // older consumers while exposing the provider title separately.
         summary.agent_nickname = Some(name);
     }
     if let Some(cwd) = overlay.cwd.clone() {
@@ -1418,6 +1427,15 @@ mod tests {
             sessions[0].agent_nickname.as_deref(),
             Some("Research Cursor agent sessions")
         );
+        assert_eq!(
+            sessions[0]
+                .cursor_summary
+                .as_ref()
+                .unwrap()
+                .cursor_title
+                .as_deref(),
+            Some("Research Cursor agent sessions")
+        );
         assert_eq!(sessions[0].cwd, PathBuf::from("/tmp/real-cwd"));
         assert_eq!(
             sessions[0].cursor_summary.as_ref().unwrap().lifecycle,
@@ -1548,6 +1566,42 @@ mod tests {
         assert!(
             entries[0].timestamp > 0,
             "history should sort by last write, not birth"
+        );
+    }
+
+    #[cfg(target_os = "macos")]
+    #[test]
+    fn history_applies_cursor_composer_title_overlay() {
+        let tmp = tempfile::tempdir().unwrap();
+        let projects = tmp.path().join(".cursor").join("projects");
+        let session_dir = layout(&projects, "demo-project");
+        write_jsonl(
+            &session_dir.join(format!("{PARENT}.jsonl")),
+            &[&user_line("root prompt")],
+        );
+
+        let db_path = default_vscdb_path(tmp.path()).unwrap();
+        fs::create_dir_all(db_path.parent().unwrap()).unwrap();
+        let conn = rusqlite::Connection::open(&db_path).unwrap();
+        conn.execute(
+            "CREATE TABLE cursorDiskKV (key TEXT PRIMARY KEY, value TEXT)",
+            [],
+        )
+        .unwrap();
+        let payload = serde_json::json!({"name": "Cursor auto title"});
+        conn.execute(
+            "INSERT INTO cursorDiskKV (key, value) VALUES (?1, ?2)",
+            rusqlite::params![format!("composerData:{PARENT}"), payload.to_string()],
+        )
+        .unwrap();
+        drop(conn);
+
+        let entries = cursor_history_entries(tmp.path());
+        assert_eq!(entries.len(), 1);
+        assert_eq!(entries[0].custom_title, None);
+        assert_eq!(
+            entries[0].cursor_title.as_deref(),
+            Some("Cursor auto title")
         );
     }
 

--- a/src-tauri/src/session/cursor.rs
+++ b/src-tauri/src/session/cursor.rs
@@ -11,10 +11,8 @@ use super::source::{
 };
 use serde::Deserialize;
 use serde_json::Value;
-use std::collections::hash_map::DefaultHasher;
 use std::collections::{HashMap, HashSet};
 use std::fs::{self, File};
-use std::hash::Hasher;
 use std::io::{BufRead, BufReader, Read, Seek, SeekFrom};
 use std::path::{Path, PathBuf};
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
@@ -23,6 +21,12 @@ const IDLE_FRESHNESS_SECS: u64 = 30 * 60;
 const WORKING_FRESHNESS_SECS: u64 = 4 * 60 * 60;
 const LINKED_PARENT_CEILING_SECS: u64 = 24 * 60 * 60;
 const MONITOR_MESSAGE_CHARS: usize = 200;
+const EXACT_PREFIX_VERIFY_LIMIT: u64 = 4 * 1024 * 1024;
+const PREFIX_GUARD_BYTES: u64 = 64 * 1024;
+const MIN_FULL_VERIFY_GROWTH_BYTES: u64 = 1024 * 1024;
+const FULL_VERIFY_GROWTH_DIVISOR: u64 = 8;
+const FNV_OFFSET_BASIS: u64 = 0xcbf29ce484222325;
+const FNV_PRIME: u64 = 0x100000001b3;
 
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
 pub enum CursorLifecycle {
@@ -79,14 +83,33 @@ impl CursorTranscriptSummary {
 
 type FileStamp = FileVersion;
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+struct PrefixGuard {
+    len: u64,
+    head_hash: u64,
+    tail_hash: u64,
+}
+
+#[derive(Debug, Clone, Copy)]
+struct PrefixSnapshot {
+    hash: u64,
+    guard: PrefixGuard,
+}
+
 #[derive(Debug, Clone)]
 struct CacheEntry {
     stamp: FileStamp,
     offset: u64,
-    /// Hash of the transcript bytes in `[0, offset)`. A larger file alone does
-    /// not prove an append: truncate-and-rewrite can also grow past the old
-    /// offset, so the cached prefix must still match before reusing it.
+    /// FNV hash of the transcript bytes in `[0, offset)`. The state can be
+    /// extended over an append without re-reading the existing prefix.
     prefix_hash: u64,
+    /// Bounded content guard used between full prefix validations on large
+    /// transcripts. Small transcripts continue to use exact verification.
+    prefix_guard: PrefixGuard,
+    /// Large transcripts are fully revalidated after a geometrically bounded
+    /// amount of growth. This keeps cumulative validation I/O linear in the
+    /// transcript size while bounding the large-file rewrite detection window.
+    next_full_verify_offset: u64,
     summary: CursorTranscriptSummary,
 }
 
@@ -105,6 +128,8 @@ pub struct CursorSessionSource {
     cache: HashMap<PathBuf, CacheEntry>,
     #[cfg(test)]
     parse_count: u32,
+    #[cfg(test)]
+    prefix_verification_bytes: u64,
 }
 
 impl CursorSessionSource {
@@ -125,6 +150,11 @@ impl CursorSessionSource {
         self.parse_count
     }
 
+    #[cfg(test)]
+    pub(crate) fn prefix_verification_bytes_for_test(&self) -> u64 {
+        self.prefix_verification_bytes
+    }
+
     fn at_roots(projects_root: PathBuf, vscdb_path: Option<PathBuf>) -> Self {
         Self {
             projects_root,
@@ -132,6 +162,8 @@ impl CursorSessionSource {
             cache: HashMap::new(),
             #[cfg(test)]
             parse_count: 0,
+            #[cfg(test)]
+            prefix_verification_bytes: 0,
         }
     }
 
@@ -285,11 +317,28 @@ impl CursorSessionSource {
                 return Ok((stamp, cached.summary.clone()));
             }
         }
-        let (existing, start_offset, resumed_hasher) = match self.cache.get(path) {
+        let (existing, start_offset, resumed_hash) = match self.cache.get(path) {
             Some(cached) if stamp.len > cached.offset => {
-                let resumed = verify_prefix(path, cached.offset, cached.prefix_hash);
-                match resumed {
-                    Some(hasher) => (Some(cached.summary.clone()), cached.offset, Some(hasher)),
+                let full_verification = cached.offset <= EXACT_PREFIX_VERIFY_LIMIT
+                    || stamp.len >= cached.next_full_verify_offset;
+                let verified_bytes = if full_verification {
+                    verify_prefix(path, cached.offset, cached.prefix_hash)
+                } else {
+                    verify_prefix_guard(path, cached.prefix_guard)
+                };
+                match verified_bytes {
+                    Some(_bytes) => {
+                        #[cfg(test)]
+                        {
+                            self.prefix_verification_bytes =
+                                self.prefix_verification_bytes.saturating_add(_bytes);
+                        }
+                        (
+                            Some(cached.summary.clone()),
+                            cached.offset,
+                            Some(cached.prefix_hash),
+                        )
+                    }
                     None => (None, 0, None),
                 }
             }
@@ -304,16 +353,27 @@ impl CursorSessionSource {
         if summary.cwd.as_os_str().is_empty() {
             summary.cwd = decode_cursor_project_key(&transcript.project_key);
         }
-        let prefix_hash = if let Some(mut hasher) = resumed_hasher {
+        let snapshot = if let Some(mut hash) = resumed_hash {
             // Extend the verified prefix hash over the appended bytes instead
-            // of re-hashing the whole range.
-            feed_suffix(path, start_offset, offset, &mut hasher).ok_or_else(|| {
+            // of re-hashing the whole range. Large files use a bounded guard
+            // between geometrically scheduled full-prefix validations.
+            feed_suffix(path, start_offset, offset, &mut hash).ok_or_else(|| {
                 SessionDetectorError::Parse(format!(
                     "Cursor transcript suffix changed while hashing: {}",
                     path.display()
                 ))
             })?;
-            hasher.finish()
+            PrefixSnapshot {
+                hash,
+                guard: hash_prefix_guard(path, offset)
+                    .ok_or_else(|| {
+                        SessionDetectorError::Parse(format!(
+                            "Cursor transcript prefix guard could not be hashed: {}",
+                            path.display()
+                        ))
+                    })?
+                    .0,
+            }
         } else {
             hash_file_prefix(path, offset).ok_or_else(|| {
                 SessionDetectorError::Parse(format!(
@@ -327,7 +387,9 @@ impl CursorSessionSource {
             CacheEntry {
                 stamp,
                 offset,
-                prefix_hash,
+                prefix_hash: snapshot.hash,
+                prefix_guard: snapshot.guard,
+                next_full_verify_offset: next_full_verify_offset(offset),
                 summary: summary.clone(),
             },
         );
@@ -820,70 +882,110 @@ fn looks_like_uuid(value: &str) -> bool {
         && bytes[23] == b'-'
 }
 
-/// Feed exactly `len` bytes of `path` into `hasher`. Returns `None` if the
-/// file is shorter than `len`, unreadable, or ends prematurely.
-fn feed_prefix(path: &Path, len: u64, hasher: &mut DefaultHasher) -> Option<()> {
-    let mut file = File::open(path).ok()?;
-    if fs::metadata(path).ok()?.len() < len {
+fn hash_bytes(mut hash: u64, bytes: &[u8]) -> u64 {
+    for byte in bytes {
+        hash ^= u64::from(*byte);
+        hash = hash.wrapping_mul(FNV_PRIME);
+    }
+    hash
+}
+
+/// Feed `[start, end)` into an incremental FNV state. Returns `None` if the
+/// file is shorter than `end`, unreadable, or ends prematurely.
+fn feed_hash_range(path: &Path, start: u64, end: u64, hash: &mut u64) -> Option<u64> {
+    if end < start {
         return None;
     }
+    let mut file = File::open(path).ok()?;
+    if fs::metadata(path).ok()?.len() < end {
+        return None;
+    }
+    file.seek(SeekFrom::Start(start)).ok()?;
     let mut buf = vec![0u8; 64 * 1024];
-    let mut remaining = len;
+    let mut remaining = end - start;
+    let mut bytes_read = 0;
     while remaining > 0 {
         let want = buf.len().min(remaining as usize);
         let read = file.read(&mut buf[..want]).ok()?;
         if read == 0 {
             return None;
         }
-        hasher.write(&buf[..read]);
+        *hash = hash_bytes(*hash, &buf[..read]);
         remaining -= read as u64;
+        bytes_read += read as u64;
     }
-    Some(())
+    Some(bytes_read)
 }
 
-/// Verify that the first `len` bytes of `path` hash to `expected_hash`.
-/// On success returns the hasher positioned after `len` bytes so callers can
-/// cheaply extend the hash over an appended suffix without re-reading.
-fn verify_prefix(path: &Path, len: u64, expected_hash: u64) -> Option<DefaultHasher> {
-    let mut hasher = DefaultHasher::new();
-    feed_prefix(path, len, &mut hasher)?;
-    (hasher.finish() == expected_hash).then_some(hasher)
+fn hash_range(path: &Path, start: u64, end: u64) -> Option<(u64, u64)> {
+    let mut hash = FNV_OFFSET_BASIS;
+    let bytes_read = feed_hash_range(path, start, end, &mut hash)?;
+    Some((hash, bytes_read))
 }
 
-/// Hash the first `len` bytes of `path`, or `None` if the file is shorter or
-/// unreadable. Used to distinguish a genuine append from a truncate-and-rewrite
-/// that happens to end up longer than the previously cached offset.
-fn hash_file_prefix(path: &Path, len: u64) -> Option<u64> {
-    let mut hasher = DefaultHasher::new();
-    feed_prefix(path, len, &mut hasher)?;
-    Some(hasher.finish())
+/// Verify the complete cached prefix. Small transcripts use this on every
+/// append; large transcripts use it at geometrically scheduled checkpoints.
+fn verify_prefix(path: &Path, len: u64, expected_hash: u64) -> Option<u64> {
+    let (hash, bytes_read) = hash_range(path, 0, len)?;
+    (hash == expected_hash).then_some(bytes_read)
 }
 
-/// Feed the bytes of `path` in `[start, end)` into `hasher`.
+fn hash_prefix_guard(path: &Path, len: u64) -> Option<(PrefixGuard, u64)> {
+    let head_len = len.min(PREFIX_GUARD_BYTES);
+    let (head_hash, head_bytes) = hash_range(path, 0, head_len)?;
+    if len <= PREFIX_GUARD_BYTES {
+        return Some((
+            PrefixGuard {
+                len,
+                head_hash,
+                tail_hash: head_hash,
+            },
+            head_bytes,
+        ));
+    }
+
+    let tail_start = len.saturating_sub(PREFIX_GUARD_BYTES);
+    let (tail_hash, tail_bytes) = hash_range(path, tail_start, len)?;
+    Some((
+        PrefixGuard {
+            len,
+            head_hash,
+            tail_hash,
+        },
+        head_bytes + tail_bytes,
+    ))
+}
+
+/// Verify fixed-size head/tail guards between full prefix checkpoints. This is
+/// intentionally bounded I/O: an arbitrary rewrite in the unguarded middle of
+/// a very large transcript is detected at the next geometric full checkpoint.
+fn verify_prefix_guard(path: &Path, expected: PrefixGuard) -> Option<u64> {
+    let (current, bytes_read) = hash_prefix_guard(path, expected.len)?;
+    (current == expected).then_some(bytes_read)
+}
+
+/// Hash the first `len` bytes and compute the bounded guard in the same cache
+/// update. The full hash is needed to extend the incremental state later.
+fn hash_file_prefix(path: &Path, len: u64) -> Option<PrefixSnapshot> {
+    let (hash, _) = hash_range(path, 0, len)?;
+    let (guard, _) = hash_prefix_guard(path, len)?;
+    Some(PrefixSnapshot { hash, guard })
+}
+
+/// Feed the bytes of `path` in `[start, end)` into `hash`.
 ///
 /// A failure is reported to the caller so an incomplete hash can never be
 /// persisted as if it represented the full cached prefix.
-fn feed_suffix(path: &Path, start: u64, end: u64, hasher: &mut DefaultHasher) -> Option<()> {
-    if end <= start {
-        return Some(());
+fn feed_suffix(path: &Path, start: u64, end: u64, hash: &mut u64) -> Option<()> {
+    feed_hash_range(path, start, end, hash).map(|_| ())
+}
+
+fn next_full_verify_offset(offset: u64) -> u64 {
+    if offset <= EXACT_PREFIX_VERIFY_LIMIT {
+        return offset;
     }
-    let mut file = File::open(path).ok()?;
-    if file.seek(SeekFrom::Start(start)).is_err() {
-        return None;
-    }
-    let mut buf = vec![0u8; 64 * 1024];
-    let mut remaining = end - start;
-    while remaining > 0 {
-        let want = buf.len().min(remaining as usize);
-        match file.read(&mut buf[..want]) {
-            Ok(0) | Err(_) => return None,
-            Ok(read) => {
-                hasher.write(&buf[..read]);
-                remaining -= read as u64;
-            }
-        }
-    }
-    Some(())
+    let growth = (offset / FULL_VERIFY_GROWTH_DIVISOR).max(MIN_FULL_VERIFY_GROWTH_BYTES);
+    offset.saturating_add(growth)
 }
 
 fn file_stamp(path: &Path) -> Result<FileStamp, SessionDetectorError> {
@@ -1551,6 +1653,38 @@ mod tests {
     }
 
     #[test]
+    fn large_append_prefix_validation_has_a_bounded_read_budget() {
+        let tmp = tempfile::tempdir().unwrap();
+        let session_dir = layout(tmp.path(), "demo-project");
+        let path = session_dir.join(format!("{PARENT}.jsonl"));
+        let filler = "x".repeat(1024);
+        let line = format!(r#"{{"type":"synthetic_padding","padding":"{filler}"}}"#);
+        let line_count = (EXACT_PREFIX_VERIFY_LIMIT as usize / line.len()) + 128;
+        let lines = vec![line; line_count];
+        let refs: Vec<&str> = lines.iter().map(String::as_str).collect();
+        write_jsonl(&path, &refs);
+
+        let mut source = CursorSessionSource::at_root(tmp.path().to_path_buf());
+        source.detect().unwrap();
+        let cached = source.cache.get(&path).unwrap();
+        assert!(cached.offset > EXACT_PREFIX_VERIFY_LIMIT);
+
+        let before = source.prefix_verification_bytes_for_test();
+        for index in 0..16 {
+            let mut file = fs::OpenOptions::new().append(true).open(&path).unwrap();
+            writeln!(file, r#"{{"type":"synthetic_append","index":{index}}}"#).unwrap();
+            drop(file);
+            source.detect().unwrap();
+        }
+        let verified = source.prefix_verification_bytes_for_test() - before;
+        let max_expected = 16 * PREFIX_GUARD_BYTES * 2;
+        assert!(
+            verified <= max_expected,
+            "large append validation read {verified} bytes, expected at most {max_expected}"
+        );
+    }
+
+    #[test]
     fn concurrent_torn_write_is_ignored_then_committed_once() {
         let tmp = tempfile::tempdir().unwrap();
         let session_dir = layout(tmp.path(), "demo-project");
@@ -1693,9 +1827,9 @@ mod tests {
     fn suffix_hash_failure_is_reported_instead_of_cached() {
         let tmp = tempfile::tempdir().unwrap();
         let path = tmp.path().join("missing-transcript.jsonl");
-        let mut hasher = DefaultHasher::new();
+        let mut hash = FNV_OFFSET_BASIS;
 
-        assert!(feed_suffix(&path, 0, 1, &mut hasher).is_none());
+        assert!(feed_suffix(&path, 0, 1, &mut hash).is_none());
     }
 
     #[test]

--- a/src-tauri/src/session/cursor.rs
+++ b/src-tauri/src/session/cursor.rs
@@ -3,6 +3,7 @@
 //! JSONL transcripts are the source of truth for discovery and liveness.
 //! `state.vscdb` is an optional read-only overlay for title, cwd, and model.
 
+use super::cache::FileVersion;
 use super::parser::MessageType;
 use super::source::{
     AgentKind, DetectedSession, DetectionDiagnostics, SessionDetectorError, SessionKind,
@@ -76,11 +77,7 @@ impl CursorTranscriptSummary {
     }
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-struct FileStamp {
-    len: u64,
-    modified_nanos: u128,
-}
+type FileStamp = FileVersion;
 
 #[derive(Debug, Clone)]
 struct CacheEntry {
@@ -123,6 +120,11 @@ impl CursorSessionSource {
         Self::at_roots(projects_root, None)
     }
 
+    #[cfg(test)]
+    pub(crate) fn parse_count_for_test(&self) -> u32 {
+        self.parse_count
+    }
+
     fn at_roots(projects_root: PathBuf, vscdb_path: Option<PathBuf>) -> Self {
         Self {
             projects_root,
@@ -131,6 +133,12 @@ impl CursorSessionSource {
             #[cfg(test)]
             parse_count: 0,
         }
+    }
+
+    pub(crate) fn contains_session_id(&self, session_id: &str) -> bool {
+        collect_transcript_refs(&self.projects_root)
+            .iter()
+            .any(|transcript| transcript.session_id == session_id)
     }
 
     #[cfg(test)]
@@ -148,10 +156,14 @@ impl CursorSessionSource {
 
         for transcript in &refs {
             existing_paths.insert(transcript.path.clone());
+            let age = file_age_secs(&transcript.path, wall_now);
+            if age > LINKED_PARENT_CEILING_SECS {
+                self.cache.remove(&transcript.path);
+                continue;
+            }
             let Ok(summary) = self.summary_for(&transcript.path, transcript) else {
                 continue;
             };
-            let age = file_age_secs(&transcript.path, wall_now);
             live.push((transcript.path.clone(), summary, age));
         }
 
@@ -177,7 +189,13 @@ impl CursorSessionSource {
             })
             .collect();
 
-        self.cache.retain(|path, _| existing_paths.contains(path));
+        let cacheable_paths: HashSet<PathBuf> = live
+            .iter()
+            .filter(|(_, _, age)| *age <= LINKED_PARENT_CEILING_SECS)
+            .map(|(path, _, _)| path.clone())
+            .collect();
+        self.cache
+            .retain(|path, _| existing_paths.contains(path) && cacheable_paths.contains(path));
 
         let mut sessions = Vec::new();
         for (_path, summary, age_secs) in live {
@@ -239,10 +257,32 @@ impl CursorSessionSource {
         path: &Path,
         transcript: &TranscriptRef,
     ) -> Result<CursorTranscriptSummary, SessionDetectorError> {
+        const MAX_READ_ATTEMPTS: usize = 3;
+
+        for _ in 0..MAX_READ_ATTEMPTS {
+            let (stamp, summary) = self.summary_for_once(path, transcript)?;
+            let after = file_stamp(path)?;
+            if stamp == after {
+                return Ok(summary);
+            }
+            self.cache.remove(path);
+        }
+
+        Err(SessionDetectorError::Parse(format!(
+            "Cursor transcript changed while reading: {}",
+            path.display()
+        )))
+    }
+
+    fn summary_for_once(
+        &mut self,
+        path: &Path,
+        transcript: &TranscriptRef,
+    ) -> Result<(FileStamp, CursorTranscriptSummary), SessionDetectorError> {
         let stamp = file_stamp(path)?;
         if let Some(cached) = self.cache.get(path) {
-            if cached.stamp == stamp {
-                return Ok(cached.summary.clone());
+            if cached.stamp == stamp && stamp.supports_unchanged_fast_path() {
+                return Ok((stamp, cached.summary.clone()));
             }
         }
         let (existing, start_offset, resumed_hasher) = match self.cache.get(path) {
@@ -267,10 +307,20 @@ impl CursorSessionSource {
         let prefix_hash = if let Some(mut hasher) = resumed_hasher {
             // Extend the verified prefix hash over the appended bytes instead
             // of re-hashing the whole range.
-            feed_suffix(path, start_offset, offset, &mut hasher);
+            feed_suffix(path, start_offset, offset, &mut hasher).ok_or_else(|| {
+                SessionDetectorError::Parse(format!(
+                    "Cursor transcript suffix changed while hashing: {}",
+                    path.display()
+                ))
+            })?;
             hasher.finish()
         } else {
-            hash_file_prefix(path, offset).unwrap_or(0)
+            hash_file_prefix(path, offset).ok_or_else(|| {
+                SessionDetectorError::Parse(format!(
+                    "Cursor transcript prefix could not be hashed: {}",
+                    path.display()
+                ))
+            })?
         };
         self.cache.insert(
             path.to_path_buf(),
@@ -281,7 +331,7 @@ impl CursorSessionSource {
                 summary: summary.clone(),
             },
         );
-        Ok(summary)
+        Ok((stamp, summary))
     }
 }
 
@@ -809,44 +859,35 @@ fn hash_file_prefix(path: &Path, len: u64) -> Option<u64> {
     Some(hasher.finish())
 }
 
-/// Feed the bytes of `path` in `[start, end)` into `hasher`, ignoring errors:
-/// a torn read just yields a weaker cache key, never a wrong summary.
-fn feed_suffix(path: &Path, start: u64, end: u64, hasher: &mut DefaultHasher) {
+/// Feed the bytes of `path` in `[start, end)` into `hasher`.
+///
+/// A failure is reported to the caller so an incomplete hash can never be
+/// persisted as if it represented the full cached prefix.
+fn feed_suffix(path: &Path, start: u64, end: u64, hasher: &mut DefaultHasher) -> Option<()> {
     if end <= start {
-        return;
+        return Some(());
     }
-    let Ok(mut file) = File::open(path) else {
-        return;
-    };
+    let mut file = File::open(path).ok()?;
     if file.seek(SeekFrom::Start(start)).is_err() {
-        return;
+        return None;
     }
     let mut buf = vec![0u8; 64 * 1024];
     let mut remaining = end - start;
     while remaining > 0 {
         let want = buf.len().min(remaining as usize);
         match file.read(&mut buf[..want]) {
-            Ok(0) | Err(_) => return,
+            Ok(0) | Err(_) => return None,
             Ok(read) => {
                 hasher.write(&buf[..read]);
                 remaining -= read as u64;
             }
         }
     }
+    Some(())
 }
 
 fn file_stamp(path: &Path) -> Result<FileStamp, SessionDetectorError> {
-    let metadata = fs::metadata(path)?;
-    let modified_nanos = metadata
-        .modified()
-        .ok()
-        .and_then(|time| time.duration_since(UNIX_EPOCH).ok())
-        .map(|duration| duration.as_nanos())
-        .unwrap_or(0);
-    Ok(FileStamp {
-        len: metadata.len(),
-        modified_nanos,
-    })
+    Ok(FileVersion::read(path)?)
 }
 
 fn file_age_secs(path: &Path, wall_now: SystemTime) -> u64 {
@@ -1301,6 +1342,36 @@ mod tests {
     }
 
     #[test]
+    fn cache_evicts_transcripts_past_visibility_ceiling() {
+        let tmp = tempfile::tempdir().unwrap();
+        let session_dir = layout(tmp.path(), "demo-project");
+        let path = session_dir.join(format!("{PARENT}.jsonl"));
+        write_jsonl(
+            &path,
+            &[
+                &user_line("old chat"),
+                r#"{"type":"turn_ended","status":"success"}"#,
+            ],
+        );
+
+        let mut source = CursorSessionSource::at_root(tmp.path().to_path_buf());
+        let (sessions, _) = source.detect().unwrap();
+        assert_eq!(sessions.len(), 1);
+        assert!(source.cache.contains_key(&path));
+
+        let stale = SystemTime::now() + Duration::from_secs(LINKED_PARENT_CEILING_SECS + 60);
+        let (sessions, _) = source.detect_at(stale).unwrap();
+        assert!(sessions.is_empty());
+        assert!(source.cache.is_empty());
+        let parse_count = source.parse_count;
+
+        let later = stale + Duration::from_secs(60);
+        let (sessions, _) = source.detect_at(later).unwrap();
+        assert!(sessions.is_empty());
+        assert_eq!(source.parse_count, parse_count);
+    }
+
+    #[test]
     fn decode_keeps_hyphenated_directory_names() {
         let tmp = tempfile::tempdir().unwrap();
         let real = tmp.path().join("my-app");
@@ -1403,6 +1474,141 @@ mod tests {
     }
 
     #[test]
+    fn deleted_and_renamed_transcripts_are_removed_from_cache() {
+        let tmp = tempfile::tempdir().unwrap();
+        let session_dir = layout(tmp.path(), "demo-project");
+        let path = session_dir.join(format!("{PARENT}.jsonl"));
+        write_jsonl(&path, &[&user_line("will disappear")]);
+
+        let mut source = CursorSessionSource::at_root(tmp.path().to_path_buf());
+        let (sessions, _) = source.detect().unwrap();
+        assert_eq!(sessions.len(), 1);
+        assert!(source.cache.contains_key(&path));
+
+        fs::remove_file(&path).unwrap();
+        let (sessions, _) = source.detect().unwrap();
+        assert!(sessions.is_empty());
+        assert!(!source.cache.contains_key(&path));
+
+        let renamed_dir = tmp
+            .path()
+            .join("demo-project")
+            .join("agent-transcripts")
+            .join(CHILD_DONE);
+        fs::rename(&session_dir, &renamed_dir).unwrap();
+        let renamed_path = renamed_dir.join(format!("{CHILD_DONE}.jsonl"));
+        write_jsonl(&renamed_path, &[&user_line("renamed session")]);
+
+        let (sessions, _) = source.detect().unwrap();
+        assert_eq!(sessions.len(), 1);
+        assert_eq!(sessions[0].session_id.as_deref(), Some(CHILD_DONE));
+        assert!(!source.cache.contains_key(&path));
+        assert!(source.cache.contains_key(&renamed_path));
+    }
+
+    #[test]
+    fn large_transcript_incremental_parse_matches_full_parse() {
+        let tmp = tempfile::tempdir().unwrap();
+        let session_dir = layout(tmp.path(), "demo-project");
+        let path = session_dir.join(format!("{PARENT}.jsonl"));
+        let mut lines = vec![user_line("large transcript")];
+        for index in 0..8_192 {
+            lines.push(assistant_line(&format!("synthetic message {index}")));
+        }
+        let line_refs: Vec<&str> = lines.iter().map(String::as_str).collect();
+        write_jsonl(&path, &line_refs);
+
+        let mut source = CursorSessionSource::at_root(tmp.path().to_path_buf());
+        let (first, _) = source.detect().unwrap();
+        let initial = first[0].cursor_summary.as_ref().unwrap().messages.len();
+        assert_eq!(initial, 8_193);
+
+        let appended = assistant_line("synthetic appended message");
+        let mut file = fs::OpenOptions::new().append(true).open(&path).unwrap();
+        writeln!(file, "{appended}").unwrap();
+        drop(file);
+
+        let (incremental, _) = source.detect().unwrap();
+        let mut fresh = CursorSessionSource::at_root(tmp.path().to_path_buf());
+        let (full, _) = fresh.detect().unwrap();
+        let incremental_messages = &incremental[0].cursor_summary.as_ref().unwrap().messages;
+        let full_messages = &full[0].cursor_summary.as_ref().unwrap().messages;
+        assert_eq!(incremental_messages.len(), full_messages.len());
+        for (incremental, full) in incremental_messages.iter().zip(full_messages) {
+            assert_eq!(incremental.role, full.role);
+            assert_eq!(incremental.message_type, full.message_type);
+            assert_eq!(incremental.content, full.content);
+        }
+        assert_eq!(
+            incremental[0]
+                .cursor_summary
+                .as_ref()
+                .unwrap()
+                .messages
+                .len(),
+            initial + 1
+        );
+    }
+
+    #[test]
+    fn concurrent_torn_write_is_ignored_then_committed_once() {
+        let tmp = tempfile::tempdir().unwrap();
+        let session_dir = layout(tmp.path(), "demo-project");
+        let path = session_dir.join(format!("{PARENT}.jsonl"));
+        write_jsonl(&path, &[&user_line("before concurrent write")]);
+
+        let mut source = CursorSessionSource::at_root(tmp.path().to_path_buf());
+        source.detect().unwrap();
+
+        let assistant = assistant_line("concurrent assistant");
+        let split = assistant.len() / 2;
+        let (partial_ready_tx, partial_ready_rx) = std::sync::mpsc::channel();
+        let (continue_tx, continue_rx) = std::sync::mpsc::channel();
+        let (complete_tx, complete_rx) = std::sync::mpsc::channel();
+        let writer_path = path.clone();
+        let writer = std::thread::spawn(move || {
+            let mut file = fs::OpenOptions::new()
+                .append(true)
+                .open(writer_path)
+                .unwrap();
+            file.write_all(&assistant.as_bytes()[..split]).unwrap();
+            file.flush().unwrap();
+            partial_ready_tx.send(()).unwrap();
+            continue_rx.recv().unwrap();
+            file.write_all(&assistant.as_bytes()[split..]).unwrap();
+            writeln!(file).unwrap();
+            file.flush().unwrap();
+            complete_tx.send(()).unwrap();
+        });
+
+        partial_ready_rx.recv().unwrap();
+        let (during_write, _) = source.detect().unwrap();
+        assert_eq!(
+            during_write[0]
+                .cursor_summary
+                .as_ref()
+                .unwrap()
+                .messages
+                .len(),
+            1
+        );
+        continue_tx.send(()).unwrap();
+        complete_rx.recv().unwrap();
+        writer.join().unwrap();
+
+        let (after_write, _) = source.detect().unwrap();
+        let messages = &after_write[0].cursor_summary.as_ref().unwrap().messages;
+        assert_eq!(messages.len(), 2);
+        assert_eq!(
+            messages
+                .iter()
+                .filter(|message| message.content == "concurrent assistant")
+                .count(),
+            1
+        );
+    }
+
+    #[test]
     fn turn_ended_only_file_stays_idle_not_connecting() {
         let tmp = tempfile::tempdir().unwrap();
         let session_dir = layout(tmp.path(), "demo-project");
@@ -1451,6 +1657,45 @@ mod tests {
                 .count(),
             1
         );
+    }
+
+    #[test]
+    fn same_length_rewrite_with_preserved_mtime_is_not_a_cache_hit() {
+        let tmp = tempfile::tempdir().unwrap();
+        let session_dir = layout(tmp.path(), "demo-project");
+        let path = session_dir.join(format!("{PARENT}.jsonl"));
+        let old = user_line("old prompt");
+        let fresh = user_line("new prompt");
+        assert_eq!(old.len(), fresh.len());
+        write_jsonl(&path, &[&old]);
+        let original_modified = fs::metadata(&path).unwrap().modified().unwrap();
+
+        let mut source = CursorSessionSource::at_root(tmp.path().to_path_buf());
+        let (first, _) = source.detect().unwrap();
+        assert_eq!(
+            first[0].cursor_summary.as_ref().unwrap().first_prompt(),
+            Some("old prompt")
+        );
+
+        write_jsonl(&path, &[&fresh]);
+        let file = fs::OpenOptions::new().write(true).open(&path).unwrap();
+        file.set_modified(original_modified).unwrap();
+        drop(file);
+
+        let (second, _) = source.detect().unwrap();
+        assert_eq!(
+            second[0].cursor_summary.as_ref().unwrap().first_prompt(),
+            Some("new prompt")
+        );
+    }
+
+    #[test]
+    fn suffix_hash_failure_is_reported_instead_of_cached() {
+        let tmp = tempfile::tempdir().unwrap();
+        let path = tmp.path().join("missing-transcript.jsonl");
+        let mut hasher = DefaultHasher::new();
+
+        assert!(feed_suffix(&path, 0, 1, &mut hasher).is_none());
     }
 
     #[test]

--- a/src-tauri/src/session/cursor.rs
+++ b/src-tauri/src/session/cursor.rs
@@ -245,14 +245,15 @@ impl CursorSessionSource {
                 return Ok(cached.summary.clone());
             }
         }
-        let (existing, start_offset) = match self.cache.get(path) {
-            Some(cached)
-                if stamp.len > cached.offset
-                    && hash_file_prefix(path, cached.offset) == Some(cached.prefix_hash) =>
-            {
-                (Some(cached.summary.clone()), cached.offset)
+        let (existing, start_offset, resumed_hasher) = match self.cache.get(path) {
+            Some(cached) if stamp.len > cached.offset => {
+                let resumed = verify_prefix(path, cached.offset, cached.prefix_hash);
+                match resumed {
+                    Some(hasher) => (Some(cached.summary.clone()), cached.offset, Some(hasher)),
+                    None => (None, 0, None),
+                }
             }
-            _ => (None, 0),
+            _ => (None, 0, None),
         };
         #[cfg(test)]
         {
@@ -263,7 +264,14 @@ impl CursorSessionSource {
         if summary.cwd.as_os_str().is_empty() {
             summary.cwd = decode_cursor_project_key(&transcript.project_key);
         }
-        let prefix_hash = hash_file_prefix(path, offset).unwrap_or(0);
+        let prefix_hash = if let Some(mut hasher) = resumed_hasher {
+            // Extend the verified prefix hash over the appended bytes instead
+            // of re-hashing the whole range.
+            feed_suffix(path, start_offset, offset, &mut hasher);
+            hasher.finish()
+        } else {
+            hash_file_prefix(path, offset).unwrap_or(0)
+        };
         self.cache.insert(
             path.to_path_buf(),
             CacheEntry {
@@ -762,15 +770,13 @@ fn looks_like_uuid(value: &str) -> bool {
         && bytes[23] == b'-'
 }
 
-/// Hash the first `len` bytes of `path`, or `None` if the file is shorter or
-/// unreadable. Used to distinguish a genuine append from a truncate-and-rewrite
-/// that happens to end up longer than the previously cached offset.
-fn hash_file_prefix(path: &Path, len: u64) -> Option<u64> {
+/// Feed exactly `len` bytes of `path` into `hasher`. Returns `None` if the
+/// file is shorter than `len`, unreadable, or ends prematurely.
+fn feed_prefix(path: &Path, len: u64, hasher: &mut DefaultHasher) -> Option<()> {
+    let mut file = File::open(path).ok()?;
     if fs::metadata(path).ok()?.len() < len {
         return None;
     }
-    let mut file = File::open(path).ok()?;
-    let mut hasher = DefaultHasher::new();
     let mut buf = vec![0u8; 64 * 1024];
     let mut remaining = len;
     while remaining > 0 {
@@ -782,7 +788,51 @@ fn hash_file_prefix(path: &Path, len: u64) -> Option<u64> {
         hasher.write(&buf[..read]);
         remaining -= read as u64;
     }
+    Some(())
+}
+
+/// Verify that the first `len` bytes of `path` hash to `expected_hash`.
+/// On success returns the hasher positioned after `len` bytes so callers can
+/// cheaply extend the hash over an appended suffix without re-reading.
+fn verify_prefix(path: &Path, len: u64, expected_hash: u64) -> Option<DefaultHasher> {
+    let mut hasher = DefaultHasher::new();
+    feed_prefix(path, len, &mut hasher)?;
+    (hasher.finish() == expected_hash).then_some(hasher)
+}
+
+/// Hash the first `len` bytes of `path`, or `None` if the file is shorter or
+/// unreadable. Used to distinguish a genuine append from a truncate-and-rewrite
+/// that happens to end up longer than the previously cached offset.
+fn hash_file_prefix(path: &Path, len: u64) -> Option<u64> {
+    let mut hasher = DefaultHasher::new();
+    feed_prefix(path, len, &mut hasher)?;
     Some(hasher.finish())
+}
+
+/// Feed the bytes of `path` in `[start, end)` into `hasher`, ignoring errors:
+/// a torn read just yields a weaker cache key, never a wrong summary.
+fn feed_suffix(path: &Path, start: u64, end: u64, hasher: &mut DefaultHasher) {
+    if end <= start {
+        return;
+    }
+    let Ok(mut file) = File::open(path) else {
+        return;
+    };
+    if file.seek(SeekFrom::Start(start)).is_err() {
+        return;
+    }
+    let mut buf = vec![0u8; 64 * 1024];
+    let mut remaining = end - start;
+    while remaining > 0 {
+        let want = buf.len().min(remaining as usize);
+        match file.read(&mut buf[..want]) {
+            Ok(0) | Err(_) => return,
+            Ok(read) => {
+                hasher.write(&buf[..read]);
+                remaining -= read as u64;
+            }
+        }
+    }
 }
 
 fn file_stamp(path: &Path) -> Result<FileStamp, SessionDetectorError> {
@@ -1448,6 +1498,52 @@ mod tests {
         assert_eq!(summary.first_prompt(), Some("fresh prompt"));
         assert_eq!(summary.lifecycle, expected.lifecycle);
         assert_eq!(summary.lifecycle, CursorLifecycle::Idle);
+    }
+
+    #[test]
+    fn partial_line_is_ignored_until_fully_written() {
+        let tmp = tempfile::tempdir().unwrap();
+        let session_dir = layout(tmp.path(), "demo-project");
+        let path = session_dir.join(format!("{PARENT}.jsonl"));
+        write_jsonl(&path, &[&user_line("hello")]);
+
+        let mut source = CursorSessionSource::at_root(tmp.path().to_path_buf());
+        let (first, _) = source.detect().unwrap();
+        assert_eq!(first[0].cursor_summary.as_ref().unwrap().messages.len(), 1);
+
+        // A torn write: bytes beyond the last complete line must not advance
+        // the cached offset nor produce a message.
+        let partial = assistant_line("half written");
+        fs::OpenOptions::new()
+            .append(true)
+            .open(&path)
+            .unwrap()
+            .write_all(partial[..partial.len() / 2].as_bytes())
+            .unwrap();
+
+        let (torn, _) = source.detect().unwrap();
+        assert_eq!(torn[0].cursor_summary.as_ref().unwrap().messages.len(), 1);
+
+        let (second, _) = source.detect().unwrap();
+        assert_eq!(second[0].cursor_summary.as_ref().unwrap().messages.len(), 1);
+
+        // Complete the line; it must appear exactly once.
+        let mut file = fs::OpenOptions::new().append(true).open(&path).unwrap();
+        file.write_all(partial[partial.len() / 2..].as_bytes())
+            .unwrap();
+        writeln!(file).unwrap();
+        drop(file);
+
+        let (third, _) = source.detect().unwrap();
+        let messages = &third[0].cursor_summary.as_ref().unwrap().messages;
+        assert_eq!(messages.len(), 2);
+        assert_eq!(
+            messages
+                .iter()
+                .filter(|message| message.content == "half written")
+                .count(),
+            1
+        );
     }
 
     #[test]

--- a/src-tauri/src/session/cursor.rs
+++ b/src-tauri/src/session/cursor.rs
@@ -317,7 +317,13 @@ impl CursorSessionSource {
                 return Ok((stamp, cached.summary.clone()));
             }
         }
-        let (existing, start_offset, resumed_hash) = match self.cache.get(path) {
+        let (
+            existing,
+            start_offset,
+            resumed_hash,
+            resumed_full_verification,
+            inherited_next_full_verify_offset,
+        ) = match self.cache.get(path) {
             Some(cached) if stamp.len > cached.offset => {
                 let full_verification = cached.offset <= EXACT_PREFIX_VERIFY_LIMIT
                     || stamp.len >= cached.next_full_verify_offset;
@@ -337,12 +343,14 @@ impl CursorSessionSource {
                             Some(cached.summary.clone()),
                             cached.offset,
                             Some(cached.prefix_hash),
+                            full_verification,
+                            Some(cached.next_full_verify_offset),
                         )
                     }
-                    None => (None, 0, None),
+                    None => (None, 0, None, false, None),
                 }
             }
-            _ => (None, 0, None),
+            _ => (None, 0, None, false, None),
         };
         #[cfg(test)]
         {
@@ -353,6 +361,7 @@ impl CursorSessionSource {
         if summary.cwd.as_os_str().is_empty() {
             summary.cwd = decode_cursor_project_key(&transcript.project_key);
         }
+        let full_prefix_validation = resumed_hash.is_none() || resumed_full_verification;
         let snapshot = if let Some(mut hash) = resumed_hash {
             // Extend the verified prefix hash over the appended bytes instead
             // of re-hashing the whole range. Large files use a bounded guard
@@ -382,6 +391,11 @@ impl CursorSessionSource {
                 ))
             })?
         };
+        let next_full_verify_offset = if full_prefix_validation {
+            next_full_verify_offset(offset)
+        } else {
+            inherited_next_full_verify_offset.unwrap_or_else(|| next_full_verify_offset(offset))
+        };
         self.cache.insert(
             path.to_path_buf(),
             CacheEntry {
@@ -389,7 +403,7 @@ impl CursorSessionSource {
                 offset,
                 prefix_hash: snapshot.hash,
                 prefix_guard: snapshot.guard,
-                next_full_verify_offset: next_full_verify_offset(offset),
+                next_full_verify_offset,
                 summary: summary.clone(),
             },
         );
@@ -1681,6 +1695,78 @@ mod tests {
         assert!(
             verified <= max_expected,
             "large append validation read {verified} bytes, expected at most {max_expected}"
+        );
+    }
+
+    #[test]
+    fn large_append_reaches_checkpoint_and_detects_middle_rewrite() {
+        let tmp = tempfile::tempdir().unwrap();
+        let session_dir = layout(tmp.path(), "demo-project");
+        let path = session_dir.join(format!("{PARENT}.jsonl"));
+        let padding = "x".repeat(16 * 1024);
+        let padding_line = format!(r#"{{"type":"synthetic_padding","padding":"{padding}"}}"#);
+        let middle_old = user_line("middle old");
+        let middle_new = user_line("middle new");
+        assert_eq!(middle_old.len(), middle_new.len());
+
+        let mut file = File::create(&path).unwrap();
+        writeln!(file, "{}", user_line("head")).unwrap();
+        for _ in 0..160 {
+            writeln!(file, "{padding_line}").unwrap();
+        }
+        let middle_offset = file.stream_position().unwrap();
+        writeln!(file, "{middle_old}").unwrap();
+        for _ in 0..160 {
+            writeln!(file, "{padding_line}").unwrap();
+        }
+        drop(file);
+
+        let mut source = CursorSessionSource::at_root(tmp.path().to_path_buf());
+        let (initial, _) = source.detect().unwrap();
+        let initial_summary = initial[0].cursor_summary.as_ref().unwrap();
+        assert!(initial_summary
+            .messages
+            .iter()
+            .any(|message| message.content == "middle old"));
+        let initial_checkpoint = source.cache.get(&path).unwrap().next_full_verify_offset;
+        assert!(source.cache.get(&path).unwrap().offset > EXACT_PREFIX_VERIFY_LIMIT);
+
+        for index in 0..8 {
+            let mut append = fs::OpenOptions::new().append(true).open(&path).unwrap();
+            writeln!(append, r#"{{"type":"synthetic_append","index":{index}}}"#).unwrap();
+            drop(append);
+            source.detect().unwrap();
+        }
+        assert_eq!(
+            source.cache.get(&path).unwrap().next_full_verify_offset,
+            initial_checkpoint,
+            "guard-only appends must not move the scheduled full checkpoint"
+        );
+
+        let mut rewrite = fs::OpenOptions::new().write(true).open(&path).unwrap();
+        rewrite.seek(SeekFrom::Start(middle_offset)).unwrap();
+        rewrite.write_all(middle_new.as_bytes()).unwrap();
+        drop(rewrite);
+
+        let mut detected_rewrite = false;
+        for _ in 8..96 {
+            let mut append = fs::OpenOptions::new().append(true).open(&path).unwrap();
+            writeln!(append, "{padding_line}").unwrap();
+            drop(append);
+            let (sessions, _) = source.detect().unwrap();
+            let summary = sessions[0].cursor_summary.as_ref().unwrap();
+            if summary
+                .messages
+                .iter()
+                .any(|message| message.content == "middle new")
+            {
+                detected_rewrite = true;
+                break;
+            }
+        }
+        assert!(
+            detected_rewrite,
+            "a middle rewrite must be detected when the fixed checkpoint is reached"
         );
     }
 

--- a/src-tauri/src/session/cursor.rs
+++ b/src-tauri/src/session/cursor.rs
@@ -10,9 +10,11 @@ use super::source::{
 };
 use serde::Deserialize;
 use serde_json::Value;
+use std::collections::hash_map::DefaultHasher;
 use std::collections::{HashMap, HashSet};
 use std::fs::{self, File};
-use std::io::{BufRead, BufReader, Seek, SeekFrom};
+use std::hash::Hasher;
+use std::io::{BufRead, BufReader, Read, Seek, SeekFrom};
 use std::path::{Path, PathBuf};
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
@@ -84,6 +86,10 @@ struct FileStamp {
 struct CacheEntry {
     stamp: FileStamp,
     offset: u64,
+    /// Hash of the transcript bytes in `[0, offset)`. A larger file alone does
+    /// not prove an append: truncate-and-rewrite can also grow past the old
+    /// offset, so the cached prefix must still match before reusing it.
+    prefix_hash: u64,
     summary: CursorTranscriptSummary,
 }
 
@@ -171,8 +177,7 @@ impl CursorSessionSource {
             })
             .collect();
 
-        self.cache
-            .retain(|path, _| existing_paths.contains(path));
+        self.cache.retain(|path, _| existing_paths.contains(path));
 
         let mut sessions = Vec::new();
         for (_path, summary, age_secs) in live {
@@ -241,7 +246,10 @@ impl CursorSessionSource {
             }
         }
         let (existing, start_offset) = match self.cache.get(path) {
-            Some(cached) if stamp.len > cached.offset => {
+            Some(cached)
+                if stamp.len > cached.offset
+                    && hash_file_prefix(path, cached.offset) == Some(cached.prefix_hash) =>
+            {
                 (Some(cached.summary.clone()), cached.offset)
             }
             _ => (None, 0),
@@ -255,11 +263,13 @@ impl CursorSessionSource {
         if summary.cwd.as_os_str().is_empty() {
             summary.cwd = decode_cursor_project_key(&transcript.project_key);
         }
+        let prefix_hash = hash_file_prefix(path, offset).unwrap_or(0);
         self.cache.insert(
             path.to_path_buf(),
             CacheEntry {
                 stamp,
                 offset,
+                prefix_hash,
                 summary: summary.clone(),
             },
         );
@@ -309,8 +319,8 @@ pub fn find_cursor_conversation_under(
         .map(|meta| meta.len())
         .unwrap_or(0);
     on_progress(0, total);
-    let mut summary =
-        parse_transcript(&transcript.path, &transcript, false).map_err(|error| error.to_string())?;
+    let mut summary = parse_transcript(&transcript.path, &transcript, false)
+        .map_err(|error| error.to_string())?;
     on_progress(total, total);
     if !include_tools {
         summary
@@ -597,7 +607,11 @@ fn parse_transcript_range(
     Ok((summary, offset))
 }
 
-fn apply_transcript_line(summary: &mut CursorTranscriptSummary, value: &Value, compact: bool) -> bool {
+fn apply_transcript_line(
+    summary: &mut CursorTranscriptSummary,
+    value: &Value,
+    compact: bool,
+) -> bool {
     if value.get("type").and_then(Value::as_str) == Some("turn_ended") {
         summary.lifecycle = CursorLifecycle::Idle;
         return true;
@@ -637,10 +651,7 @@ fn apply_transcript_line(summary: &mut CursorTranscriptSummary, value: &Value, c
                 if block.get("type").and_then(Value::as_str) != Some("tool_use") {
                     continue;
                 }
-                let name = block
-                    .get("name")
-                    .and_then(Value::as_str)
-                    .unwrap_or("tool");
+                let name = block.get("name").and_then(Value::as_str).unwrap_or("tool");
                 let input = block.get("input").cloned().unwrap_or(Value::Null);
                 if name == "Task" && summary.agent_kind == AgentKind::Subagent {
                     if let Some(subagent_type) = input.get("subagent_type").and_then(Value::as_str)
@@ -751,6 +762,29 @@ fn looks_like_uuid(value: &str) -> bool {
         && bytes[23] == b'-'
 }
 
+/// Hash the first `len` bytes of `path`, or `None` if the file is shorter or
+/// unreadable. Used to distinguish a genuine append from a truncate-and-rewrite
+/// that happens to end up longer than the previously cached offset.
+fn hash_file_prefix(path: &Path, len: u64) -> Option<u64> {
+    if fs::metadata(path).ok()?.len() < len {
+        return None;
+    }
+    let mut file = File::open(path).ok()?;
+    let mut hasher = DefaultHasher::new();
+    let mut buf = vec![0u8; 64 * 1024];
+    let mut remaining = len;
+    while remaining > 0 {
+        let want = buf.len().min(remaining as usize);
+        let read = file.read(&mut buf[..want]).ok()?;
+        if read == 0 {
+            return None;
+        }
+        hasher.write(&buf[..read]);
+        remaining -= read as u64;
+    }
+    Some(hasher.finish())
+}
+
 fn file_stamp(path: &Path) -> Result<FileStamp, SessionDetectorError> {
     let metadata = fs::metadata(path)?;
     let modified_nanos = metadata
@@ -799,7 +833,10 @@ struct ComposerOverlay {
     generating: bool,
 }
 
-fn apply_composer_overlay(summary: &mut CursorTranscriptSummary, overlay: Option<&ComposerOverlay>) {
+fn apply_composer_overlay(
+    summary: &mut CursorTranscriptSummary,
+    overlay: Option<&ComposerOverlay>,
+) {
     let Some(overlay) = overlay else {
         return;
     };
@@ -827,14 +864,17 @@ fn load_composer_map(vscdb_path: Option<&Path>) -> HashMap<String, ComposerOverl
     read_composer_overlays(path).unwrap_or_default()
 }
 
-fn read_composer_overlays(path: &Path) -> Result<HashMap<String, ComposerOverlay>, rusqlite::Error> {
+fn read_composer_overlays(
+    path: &Path,
+) -> Result<HashMap<String, ComposerOverlay>, rusqlite::Error> {
     let uri = format!("file:{}?mode=ro", path.display());
     let conn = rusqlite::Connection::open_with_flags(
         &uri,
         rusqlite::OpenFlags::SQLITE_OPEN_READ_ONLY | rusqlite::OpenFlags::SQLITE_OPEN_URI,
     )?;
     let _ = conn.busy_timeout(Duration::from_millis(50));
-    let mut stmt = conn.prepare("SELECT key, value FROM cursorDiskKV WHERE key LIKE 'composerData:%'")?;
+    let mut stmt =
+        conn.prepare("SELECT key, value FROM cursorDiskKV WHERE key LIKE 'composerData:%'")?;
     let rows = stmt.query_map([], |row| {
         let key: String = row.get(0)?;
         let value: String = row.get(1)?;
@@ -994,7 +1034,10 @@ mod tests {
             &session_dir.join(format!("{PARENT}.jsonl")),
             &[
                 &user_line("parent prompt"),
-                &tool_line("Task", r#"{"subagent_type":"explore","description":"scan"}"#),
+                &tool_line(
+                    "Task",
+                    r#"{"subagent_type":"explore","description":"scan"}"#,
+                ),
                 r#"{"type":"turn_ended","status":"success"}"#,
             ],
         );
@@ -1082,8 +1125,8 @@ mod tests {
                 &assistant_line("done"),
             ],
         );
-        let with_tools = find_cursor_conversation_under(tmp.path(), PARENT, true, &mut |_, _| {})
-            .unwrap();
+        let with_tools =
+            find_cursor_conversation_under(tmp.path(), PARENT, true, &mut |_, _| {}).unwrap();
         let without_tools =
             find_cursor_conversation_under(tmp.path(), PARENT, false, &mut |_, _| {}).unwrap();
         assert!(with_tools
@@ -1161,8 +1204,7 @@ mod tests {
         .unwrap();
         drop(conn);
 
-        let mut source =
-            CursorSessionSource::at_root_with_vscdb(tmp.path().to_path_buf(), db_path);
+        let mut source = CursorSessionSource::at_root_with_vscdb(tmp.path().to_path_buf(), db_path);
         let (sessions, _) = source.detect().unwrap();
         assert_eq!(sessions.len(), 1);
         assert_eq!(
@@ -1240,7 +1282,10 @@ mod tests {
             DetectionDiagnostics::default(),
         )
         .unwrap();
-        assert_eq!(enriched[0].status, crate::session::SessionStatus::Connecting);
+        assert_eq!(
+            enriched[0].status,
+            crate::session::SessionStatus::Connecting
+        );
     }
 
     #[test]
@@ -1263,7 +1308,10 @@ mod tests {
         assert_eq!(entries[0].session_id, PARENT);
         assert_eq!(entries[0].provider, "cursor");
         assert_eq!(entries[0].display, "root prompt");
-        assert!(entries[0].timestamp > 0, "history should sort by last write, not birth");
+        assert!(
+            entries[0].timestamp > 0,
+            "history should sort by last write, not birth"
+        );
     }
 
     #[test]
@@ -1280,7 +1328,10 @@ mod tests {
         );
         let parsed = source.parse_count;
         let _ = source.detect().unwrap();
-        assert_eq!(source.parse_count, parsed, "unchanged file must be a cache hit");
+        assert_eq!(
+            source.parse_count, parsed,
+            "unchanged file must be a cache hit"
+        );
 
         let mut file = fs::OpenOptions::new().append(true).open(&path).unwrap();
         writeln!(file, r#"{{"type":"turn_ended","status":"success"}}"#).unwrap();
@@ -1319,7 +1370,10 @@ mod tests {
             DetectionDiagnostics::default(),
         )
         .unwrap();
-        assert_eq!(enriched[0].status, crate::session::SessionStatus::WaitingForInput);
+        assert_eq!(
+            enriched[0].status,
+            crate::session::SessionStatus::WaitingForInput
+        );
     }
 
     #[test]
@@ -1350,6 +1404,53 @@ mod tests {
     }
 
     #[test]
+    fn truncated_then_rewritten_longer_matches_full_parse() {
+        let tmp = tempfile::tempdir().unwrap();
+        let session_dir = layout(tmp.path(), "demo-project");
+        let path = session_dir.join(format!("{PARENT}.jsonl"));
+        write_jsonl(
+            &path,
+            &[&user_line("old prompt"), &assistant_line("old answer")],
+        );
+
+        let mut source = CursorSessionSource::at_root(tmp.path().to_path_buf());
+        let (first, _) = source.detect().unwrap();
+        assert_eq!(
+            first[0].cursor_summary.as_ref().unwrap().first_prompt(),
+            Some("old prompt")
+        );
+        let cached_offset = source.cache.get(&path).unwrap().offset;
+
+        // Truncate and rewrite with content that is LONGER than the cached offset.
+        write_jsonl(
+            &path,
+            &[
+                &user_line("fresh prompt"),
+                &assistant_line("fresh answer"),
+                r#"{"type":"turn_ended","status":"success"}"#,
+            ],
+        );
+        let new_len = fs::metadata(&path).unwrap().len();
+        assert!(new_len > cached_offset, "fixture must exceed cached offset");
+
+        let (second, _) = source.detect().unwrap();
+        let summary = second[0].cursor_summary.as_ref().unwrap();
+
+        // Ground truth: a fresh source doing a full parse of the same file.
+        let mut fresh = CursorSessionSource::at_root(tmp.path().to_path_buf());
+        let (expected_sessions, _) = fresh.detect().unwrap();
+        let expected = expected_sessions[0].cursor_summary.as_ref().unwrap();
+
+        assert_eq!(
+            summary.messages, expected.messages,
+            "no stale messages may survive a truncate+rewrite"
+        );
+        assert_eq!(summary.first_prompt(), Some("fresh prompt"));
+        assert_eq!(summary.lifecycle, expected.lifecycle);
+        assert_eq!(summary.lifecycle, CursorLifecycle::Idle);
+    }
+
+    #[test]
     fn parent_task_tool_does_not_become_root_agent_role() {
         let tmp = tempfile::tempdir().unwrap();
         let session_dir = layout(tmp.path(), "demo-project");
@@ -1357,7 +1458,10 @@ mod tests {
             &session_dir.join(format!("{PARENT}.jsonl")),
             &[
                 &user_line("parent prompt"),
-                &tool_line("Task", r#"{"subagent_type":"explore","description":"scan"}"#),
+                &tool_line(
+                    "Task",
+                    r#"{"subagent_type":"explore","description":"scan"}"#,
+                ),
                 r#"{"type":"turn_ended","status":"success"}"#,
             ],
         );

--- a/src-tauri/src/session/detector.rs
+++ b/src-tauri/src/session/detector.rs
@@ -35,7 +35,9 @@ impl LegacySessionSource {
     }
 
     /// Detects all active Claude Code sessions
-    pub fn detect_sessions(&mut self) -> Result<(Vec<DetectedSession>, DetectionDiagnostics), SessionDetectorError> {
+    pub fn detect_sessions(
+        &mut self,
+    ) -> Result<(Vec<DetectedSession>, DetectionDiagnostics), SessionDetectorError> {
         // Refresh process information (only what we need: name, cwd, start_time)
         self.system.refresh_processes_specifics(
             ProcessesToUpdate::All,
@@ -276,7 +278,8 @@ impl LegacySessionSource {
             } else {
                 crate::debug_log::log_warn(&format!(
                     "PID={}: no matching session found for cwd={}",
-                    proc.pid, proc_cwd.display()
+                    proc.pid,
+                    proc_cwd.display()
                 ));
             }
         }

--- a/src-tauri/src/session/detector_cli.rs
+++ b/src-tauri/src/session/detector_cli.rs
@@ -91,6 +91,7 @@ impl CliSessionSource {
             can_stop: true,
             can_rename: true,
             codex_summary: None,
+            cursor_summary: None,
         }
     }
 }

--- a/src-tauri/src/session/detector_cli.rs
+++ b/src-tauri/src/session/detector_cli.rs
@@ -146,8 +146,8 @@ impl SessionSource for CliSessionSource {
             )));
         }
 
-        let agents: Vec<CliAgent> = serde_json::from_slice(&buf)
-            .map_err(|e| SessionDetectorError::Parse(e.to_string()))?;
+        let agents: Vec<CliAgent> =
+            serde_json::from_slice(&buf).map_err(|e| SessionDetectorError::Parse(e.to_string()))?;
 
         // Filter out non-CLI entrypoints (e.g. sdk-ts from Zed/IDE integrations).
         // `claude agents --json` lists every live agent including SDK-driven ones,
@@ -180,7 +180,10 @@ fn is_cli_entrypoint(pid: u32) -> bool {
 }
 
 fn is_cli_entrypoint_under(home: &Path, pid: u32) -> bool {
-    let path = home.join(".claude").join("sessions").join(format!("{pid}.json"));
+    let path = home
+        .join(".claude")
+        .join("sessions")
+        .join(format!("{pid}.json"));
     let raw = match std::fs::read_to_string(&path) {
         Ok(s) => s,
         Err(_) => return true,
@@ -351,7 +354,10 @@ mod tests {
         let home = tmp.path();
         let cwd = PathBuf::from("/Users/test/proj");
         let session_id = "sess-scan";
-        let wrong_dir = home.join(".claude").join("projects").join("totally-different-dir");
+        let wrong_dir = home
+            .join(".claude")
+            .join("projects")
+            .join("totally-different-dir");
         std::fs::create_dir_all(&wrong_dir).unwrap();
         std::fs::write(wrong_dir.join(format!("{session_id}.jsonl")), b"").unwrap();
 

--- a/src-tauri/src/session/enrichment.rs
+++ b/src-tauri/src/session/enrichment.rs
@@ -120,8 +120,7 @@ pub fn merge_cli_activity(
 
 /// Detect sessions and enrich them with status and conversation data.
 /// Uses the configured backend (CLI or Legacy) via the factory.
-pub fn detect_and_enrich_sessions(
-) -> Result<(Vec<Session>, DetectionDiagnostics), String> {
+pub fn detect_and_enrich_sessions() -> Result<(Vec<Session>, DetectionDiagnostics), String> {
     let mut source = crate::session::create_session_source();
     let claude_result = source.detect();
     let codex_result = crate::session::codex::CodexSessionSource::new()
@@ -275,12 +274,11 @@ pub fn enrich_detected_sessions(
             }
             None => {
                 // Session not in index or index doesn't exist - use fallback values
-                let session_file_path =
-                    detected.project_path.join(format!("{}.jsonl", session_id));
+                let session_file_path = detected.project_path.join(format!("{}.jsonl", session_id));
 
                 // Try to get first prompt from JSONL file
-                let first_prompt = get_first_prompt_from_jsonl(&session_file_path)
-                    .unwrap_or_else(|| {
+                let first_prompt =
+                    get_first_prompt_from_jsonl(&session_file_path).unwrap_or_else(|| {
                         if detected.started_at_ms.is_some() {
                             "(No conversation yet)".to_string()
                         } else {
@@ -303,8 +301,7 @@ pub fn enrich_detected_sessions(
                     })
                     .or_else(|| {
                         detected.started_at_ms.and_then(|ms| {
-                            DateTime::<Utc>::from_timestamp_millis(ms)
-                                .map(|dt| dt.to_rfc3339())
+                            DateTime::<Utc>::from_timestamp_millis(ms).map(|dt| dt.to_rfc3339())
                         })
                     })
                     .unwrap_or_default();
@@ -368,8 +365,7 @@ pub fn enrich_detected_sessions(
         // Get custom title: Claude Code native /rename takes priority over c9watch's own.
         // Uses a static cache keyed by (path, mtime) to avoid re-scanning the JSONL every cycle.
         let native_title = get_cached_native_title(&session_file_path);
-        let custom_title =
-            native_title.or_else(|| custom_titles.get(&session_id).cloned());
+        let custom_title = native_title.or_else(|| custom_titles.get(&session_id).cloned());
 
         sessions.push(Session {
             id: session_id,
@@ -445,9 +441,7 @@ pub fn get_first_prompt_from_jsonl_raw(path: &Path) -> Option<String> {
                         } else if let Some(arr) = content.as_array() {
                             for item in arr {
                                 if item.get("type").and_then(|t| t.as_str()) == Some("text") {
-                                    if let Some(text) =
-                                        item.get("text").and_then(|t| t.as_str())
-                                    {
+                                    if let Some(text) = item.get("text").and_then(|t| t.as_str()) {
                                         return Some(text.to_string());
                                     }
                                 }
@@ -474,9 +468,7 @@ pub fn truncate_string(s: &str, max_chars: usize) -> String {
 }
 
 /// Extract the latest message content from session entries
-pub fn get_latest_message_from_entries(
-    entries: &[crate::session::parser::SessionEntry],
-) -> String {
+pub fn get_latest_message_from_entries(entries: &[crate::session::parser::SessionEntry]) -> String {
     if entries.is_empty() {
         return String::new();
     }
@@ -613,22 +605,27 @@ mod merge_tests {
 
     #[test]
     fn merge_preserves_needs_attention_when_busy() {
-        let merged =
-            merge_cli_activity(SessionStatus::NeedsAttention, Some(CliActivity::Busy), false);
+        let merged = merge_cli_activity(
+            SessionStatus::NeedsAttention,
+            Some(CliActivity::Busy),
+            false,
+        );
         assert_eq!(merged, SessionStatus::NeedsAttention);
     }
 
     #[test]
     fn merge_preserves_needs_attention_when_idle() {
-        let merged =
-            merge_cli_activity(SessionStatus::NeedsAttention, Some(CliActivity::Idle), false);
+        let merged = merge_cli_activity(
+            SessionStatus::NeedsAttention,
+            Some(CliActivity::Idle),
+            false,
+        );
         assert_eq!(merged, SessionStatus::NeedsAttention);
     }
 
     #[test]
     fn merge_preserves_connecting() {
-        let merged =
-            merge_cli_activity(SessionStatus::Connecting, Some(CliActivity::Busy), false);
+        let merged = merge_cli_activity(SessionStatus::Connecting, Some(CliActivity::Busy), false);
         assert_eq!(merged, SessionStatus::Connecting);
     }
 
@@ -644,15 +641,13 @@ mod merge_tests {
 
     #[test]
     fn merge_idle_downgrades_working_without_pending_tool() {
-        let merged =
-            merge_cli_activity(SessionStatus::Working, Some(CliActivity::Idle), false);
+        let merged = merge_cli_activity(SessionStatus::Working, Some(CliActivity::Idle), false);
         assert_eq!(merged, SessionStatus::WaitingForInput);
     }
 
     #[test]
     fn merge_idle_keeps_working_when_pending_tool() {
-        let merged =
-            merge_cli_activity(SessionStatus::Working, Some(CliActivity::Idle), true);
+        let merged = merge_cli_activity(SessionStatus::Working, Some(CliActivity::Idle), true);
         assert_eq!(merged, SessionStatus::Working);
     }
 
@@ -707,7 +702,11 @@ mod placeholder_tests {
         let s = &sessions[0];
         assert!(!s.modified.is_empty(), "modified must not be empty");
         let parsed = DateTime::parse_from_rfc3339(&s.modified);
-        assert!(parsed.is_ok(), "modified must parse as RFC3339, got: {}", s.modified);
+        assert!(
+            parsed.is_ok(),
+            "modified must parse as RFC3339, got: {}",
+            s.modified
+        );
         assert_eq!(s.started_at_ms, Some(1_700_000_000_000));
     }
 
@@ -725,6 +724,9 @@ mod placeholder_tests {
         );
         let (sessions, _) =
             enrich_detected_sessions(vec![detected], DetectionDiagnostics::default()).unwrap();
-        assert!(sessions.is_empty(), "legacy empty-JSONL session must be skipped");
+        assert!(
+            sessions.is_empty(),
+            "legacy empty-JSONL session must be skipped"
+        );
     }
 }

--- a/src-tauri/src/session/enrichment.rs
+++ b/src-tauri/src/session/enrichment.rs
@@ -1,8 +1,10 @@
+use crate::session::cache::FileVersion;
 use crate::session::codex::CodexLifecycle;
 use crate::session::cursor::CursorLifecycle;
+use crate::session::owners::global_provider_source_owners;
 use crate::session::source::{
-    AgentKind, CliActivity, DetectedSession, DetectionDiagnostics, SessionProvider, SessionSource,
-    SessionSurface,
+    AgentKind, CliActivity, DetectedSession, DetectionDiagnostics, SessionIdentity,
+    SessionProvider, SessionSource, SessionSurface,
 };
 use crate::session::{
     determine_status, get_pending_tool_input, get_pending_tool_name, parse_last_n_entries,
@@ -21,6 +23,8 @@ use std::sync::{LazyLock, Mutex};
 #[serde(rename_all = "camelCase")]
 pub struct Session {
     pub id: String,
+    /// Provider-scoped identity used by frontend selection and backend maps.
+    pub session_key: String,
     pub pid: u32,
     pub session_name: String,
     pub custom_title: Option<String>,
@@ -69,28 +73,60 @@ pub struct Session {
 }
 
 /// Cache for native custom titles, keyed by file path.
-/// Stores (mtime_as_nanos, cached_title) to avoid re-scanning JSONL files every poll cycle.
-static NATIVE_TITLE_CACHE: LazyLock<Mutex<HashMap<std::path::PathBuf, (u64, Option<String>)>>> =
-    LazyLock::new(|| Mutex::new(HashMap::new()));
+/// The stamp includes size and, on Unix, change time and inode.  Mtime alone
+/// can be coarse or unchanged for an in-place rewrite, which would otherwise
+/// let a stale title survive in the history view.
+type NativeTitleStamp = FileVersion;
 
-/// Look up the native custom title for a session JSONL, using a mtime-based cache.
+/// Stores the file stamp and cached title to avoid re-scanning JSONL files
+/// every poll cycle while still falling back safely on weak metadata systems.
+static NATIVE_TITLE_CACHE: LazyLock<
+    Mutex<HashMap<std::path::PathBuf, (NativeTitleStamp, Option<String>)>>,
+> = LazyLock::new(|| Mutex::new(HashMap::new()));
+
+fn native_title_stamp(path: &Path) -> Option<NativeTitleStamp> {
+    FileVersion::read(path).ok()
+}
+
+fn claude_custom_name(
+    provider: SessionProvider,
+    names: &crate::session::CustomNames,
+    session_id: &str,
+) -> Option<String> {
+    (provider == SessionProvider::ClaudeCode)
+        .then(|| names.get(session_id).cloned())
+        .flatten()
+}
+
+fn claude_custom_title(
+    provider: SessionProvider,
+    titles: &crate::session::CustomTitles,
+    session_id: &str,
+) -> Option<String> {
+    (provider == SessionProvider::ClaudeCode)
+        .then(|| titles.get(session_id).cloned())
+        .flatten()
+}
+
+/// Look up the native custom title for a session JSONL, using a strong file
+/// stamp when the platform provides one and a safe re-scan otherwise.
 pub(crate) fn get_cached_native_title(path: &Path) -> Option<String> {
-    let mtime = std::fs::metadata(path)
-        .and_then(|m| m.modified())
-        .ok()?
-        .duration_since(std::time::UNIX_EPOCH)
-        .unwrap_or_default()
-        .as_nanos() as u64;
+    let Some(stamp) = native_title_stamp(path) else {
+        if let Ok(mut cache) = NATIVE_TITLE_CACHE.lock() {
+            cache.remove(path);
+        }
+        return None;
+    };
 
     if let Ok(mut cache) = NATIVE_TITLE_CACHE.lock() {
-        if let Some((cached_mtime, cached_title)) = cache.get(path) {
-            if *cached_mtime == mtime {
+        if let Some((cached_stamp, cached_title)) = cache.get(path) {
+            if *cached_stamp == stamp && stamp.supports_unchanged_fast_path() {
                 return cached_title.clone();
             }
         }
         // Cache miss or stale — re-scan
         let title = crate::session::parser::get_native_custom_title_from_file(path);
-        cache.insert(path.to_path_buf(), (mtime, title.clone()));
+        cache.insert(path.to_path_buf(), (stamp, title.clone()));
         title
     } else {
         // Mutex poisoned — fallback to direct read
@@ -124,12 +160,9 @@ pub fn merge_cli_activity(
 pub fn detect_and_enrich_sessions() -> Result<(Vec<Session>, DetectionDiagnostics), String> {
     let mut source = crate::session::create_session_source();
     let claude_result = source.detect();
-    let codex_result = crate::session::codex::CodexSessionSource::new()
-        .ok()
-        .and_then(|mut codex| codex.detect().ok());
-    let cursor_result = crate::session::cursor::CursorSessionSource::new()
-        .ok()
-        .and_then(|mut cursor| cursor.detect().ok());
+    let owners = global_provider_source_owners();
+    let codex_result = owners.detect_codex();
+    let cursor_result = owners.detect_cursor();
     match claude_result {
         Ok((mut detected, diagnostics)) => {
             if let Some((mut codex_sessions, _)) = codex_result {
@@ -180,22 +213,23 @@ pub fn enrich_detected_sessions(
     let custom_names = crate::session::CustomNames::load();
     let custom_titles = crate::session::CustomTitles::load();
     let mut sessions = Vec::new();
-    let mut seen_ids: HashSet<String> = HashSet::new();
+    let mut seen_ids: HashSet<SessionIdentity> = HashSet::new();
 
     for detected in detected_sessions {
         // Get session ID - if not found, skip this session
-        let session_id = match &detected.session_id {
-            Some(id) => id.clone(),
+        let identity = match detected.identity() {
+            Some(identity) => identity,
             None => {
                 continue;
             }
         };
+        let session_id = identity.session_id.clone();
 
-        // Skip duplicate session IDs (same session can appear in multiple project dirs)
-        if seen_ids.contains(&session_id) {
+        // Skip duplicate provider-scoped identities (the same session can
+        // appear in multiple project dirs without collapsing other providers).
+        if !seen_ids.insert(identity) {
             continue;
         }
-        seen_ids.insert(session_id.clone());
 
         if let Some(summary) = detected.codex_summary.as_ref() {
             let first_prompt = summary
@@ -206,9 +240,7 @@ pub fn enrich_detected_sessions(
                 .latest_message()
                 .map(|message| truncate_string(message, 200))
                 .unwrap_or_default();
-            let session_name = custom_names
-                .get(&session_id)
-                .cloned()
+            let session_name = claude_custom_name(detected.provider, &custom_names, &session_id)
                 .or_else(|| detected.agent_nickname.clone())
                 .unwrap_or_else(|| detected.project_name.clone());
             let modified = if summary.last_timestamp.is_empty() {
@@ -222,9 +254,10 @@ pub fn enrich_detected_sessions(
             };
             sessions.push(Session {
                 id: session_id.clone(),
+                session_key: SessionIdentity::new(detected.provider, session_id.clone()).key(),
                 pid: detected.pid,
                 session_name,
-                custom_title: custom_titles.get(&session_id).cloned(),
+                custom_title: claude_custom_title(detected.provider, &custom_titles, &session_id),
                 project_path: detected.cwd.to_string_lossy().to_string(),
                 git_branch: None,
                 first_prompt,
@@ -267,9 +300,7 @@ pub fn enrich_detected_sessions(
                 .latest_message()
                 .map(|message| truncate_string(message, 200))
                 .unwrap_or_default();
-            let session_name = custom_names
-                .get(&session_id)
-                .cloned()
+            let session_name = claude_custom_name(detected.provider, &custom_names, &session_id)
                 .or_else(|| detected.agent_nickname.clone())
                 .unwrap_or_else(|| detected.project_name.clone());
             let modified = if summary.last_timestamp.is_empty() {
@@ -292,11 +323,10 @@ pub fn enrich_detected_sessions(
             };
             sessions.push(Session {
                 id: session_id.clone(),
+                session_key: SessionIdentity::new(detected.provider, session_id.clone()).key(),
                 pid: detected.pid,
                 session_name,
-                custom_title: custom_titles
-                    .get(&session_id)
-                    .cloned()
+                custom_title: claude_custom_title(detected.provider, &custom_titles, &session_id)
                     .or_else(|| detected.official_name.clone()),
                 project_path: detected.cwd.to_string_lossy().to_string(),
                 git_branch: None,
@@ -443,18 +473,18 @@ pub fn enrich_detected_sessions(
         }
 
         // Use custom name if available, otherwise use detected project name
-        let session_name = custom_names
-            .get(&session_id)
-            .cloned()
+        let session_name = claude_custom_name(detected.provider, &custom_names, &session_id)
             .unwrap_or(detected.project_name);
 
         // Get custom title: Claude Code native /rename takes priority over c9watch's own.
-        // Uses a static cache keyed by (path, mtime) to avoid re-scanning the JSONL every cycle.
+        // Uses a static cache keyed by path plus a strong file stamp when available.
         let native_title = get_cached_native_title(&session_file_path);
-        let custom_title = native_title.or_else(|| custom_titles.get(&session_id).cloned());
+        let custom_title = native_title
+            .or_else(|| claude_custom_title(detected.provider, &custom_titles, &session_id));
 
         sessions.push(Session {
-            id: session_id,
+            id: session_id.clone(),
+            session_key: SessionIdentity::new(detected.provider, session_id.clone()).key(),
             pid: detected.pid,
             session_name,
             custom_title,
@@ -750,6 +780,7 @@ mod merge_tests {
 mod placeholder_tests {
     use super::*;
     use crate::session::source::{DetectedSession, DetectionDiagnostics, SessionKind};
+    use std::io::Write;
     use std::path::PathBuf;
 
     #[test]
@@ -815,5 +846,75 @@ mod placeholder_tests {
             sessions.is_empty(),
             "legacy empty-JSONL session must be skipped"
         );
+    }
+
+    #[test]
+    fn provider_scoped_identity_keeps_same_id_from_codex_and_cursor() {
+        let tmp = tempfile::tempdir().unwrap();
+        let same_id = "same-provider-id";
+
+        let mut codex = DetectedSession::with_legacy_defaults(
+            0,
+            PathBuf::from("/tmp/codex"),
+            tmp.path().join("codex"),
+            Some(same_id.to_string()),
+            "codex".to_string(),
+        );
+        codex.provider = SessionProvider::Codex;
+        codex.surface = SessionSurface::App;
+        let mut codex_summary = crate::session::codex::CodexRolloutSummary::default();
+        codex_summary.thread_id = same_id.to_string();
+        codex.codex_summary = Some(codex_summary);
+
+        let mut cursor = DetectedSession::with_legacy_defaults(
+            0,
+            PathBuf::from("/tmp/cursor"),
+            tmp.path().join("cursor"),
+            Some(same_id.to_string()),
+            "cursor".to_string(),
+        );
+        cursor.provider = SessionProvider::Cursor;
+        cursor.surface = SessionSurface::Cursor;
+        let mut cursor_summary = crate::session::cursor::CursorTranscriptSummary::default();
+        cursor_summary.session_id = same_id.to_string();
+        cursor.cursor_summary = Some(cursor_summary);
+
+        let (sessions, _) =
+            enrich_detected_sessions(vec![codex, cursor], DetectionDiagnostics::default()).unwrap();
+
+        assert_eq!(sessions.len(), 2);
+        assert_eq!(sessions[0].session_key, "codex:same-provider-id");
+        assert_eq!(sessions[1].session_key, "cursor:same-provider-id");
+    }
+
+    #[test]
+    fn native_title_cache_invalidates_on_transcript_change_and_delete() {
+        let tmp = tempfile::tempdir().unwrap();
+        let path = tmp.path().join("synthetic-claude.jsonl");
+        let mut file = std::fs::File::create(&path).unwrap();
+        writeln!(
+            file,
+            r#"{{"type":"custom-title","customTitle":"first","sessionId":"synthetic"}}"#
+        )
+        .unwrap();
+        drop(file);
+
+        assert_eq!(get_cached_native_title(&path).as_deref(), Some("first"));
+        assert_eq!(get_cached_native_title(&path).as_deref(), Some("first"));
+
+        let mut file = std::fs::OpenOptions::new()
+            .append(true)
+            .open(&path)
+            .unwrap();
+        writeln!(
+            file,
+            r#"{{"type":"custom-title","customTitle":"second","sessionId":"synthetic"}}"#
+        )
+        .unwrap();
+        drop(file);
+
+        assert_eq!(get_cached_native_title(&path).as_deref(), Some("second"));
+        std::fs::remove_file(&path).unwrap();
+        assert_eq!(get_cached_native_title(&path), None);
     }
 }

--- a/src-tauri/src/session/enrichment.rs
+++ b/src-tauri/src/session/enrichment.rs
@@ -28,6 +28,12 @@ pub struct Session {
     pub pid: u32,
     pub session_name: String,
     pub custom_title: Option<String>,
+    /// Codex's current UI thread name from ~/.codex/session_index.jsonl.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub codex_title: Option<String>,
+    /// Cursor's current UI composer name from state.vscdb.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub cursor_title: Option<String>,
     pub project_path: String,
     pub git_branch: Option<String>,
     pub first_prompt: String,
@@ -243,6 +249,7 @@ pub fn enrich_detected_sessions(
             let session_name = claude_custom_name(detected.provider, &custom_names, &session_id)
                 .or_else(|| detected.agent_nickname.clone())
                 .unwrap_or_else(|| detected.project_name.clone());
+            let codex_title = crate::session::codex::get_cached_codex_thread_title(&session_id);
             let modified = if summary.last_timestamp.is_empty() {
                 detected
                     .started_at_ms
@@ -258,6 +265,8 @@ pub fn enrich_detected_sessions(
                 pid: detected.pid,
                 session_name,
                 custom_title: claude_custom_title(detected.provider, &custom_titles, &session_id),
+                codex_title,
+                cursor_title: None,
                 project_path: detected.cwd.to_string_lossy().to_string(),
                 git_branch: None,
                 first_prompt,
@@ -328,6 +337,8 @@ pub fn enrich_detected_sessions(
                 session_name,
                 custom_title: claude_custom_title(detected.provider, &custom_titles, &session_id)
                     .or_else(|| detected.official_name.clone()),
+                codex_title: None,
+                cursor_title: summary.cursor_title.clone(),
                 project_path: detected.cwd.to_string_lossy().to_string(),
                 git_branch: None,
                 first_prompt,
@@ -488,6 +499,8 @@ pub fn enrich_detected_sessions(
             pid: detected.pid,
             session_name,
             custom_title,
+            codex_title: None,
+            cursor_title: None,
             project_path: detected.cwd.to_string_lossy().to_string(),
             git_branch,
             first_prompt,

--- a/src-tauri/src/session/enrichment.rs
+++ b/src-tauri/src/session/enrichment.rs
@@ -1,4 +1,5 @@
 use crate::session::codex::CodexLifecycle;
+use crate::session::cursor::CursorLifecycle;
 use crate::session::source::{
     AgentKind, CliActivity, DetectedSession, DetectionDiagnostics, SessionProvider, SessionSource,
     SessionSurface,
@@ -126,18 +127,34 @@ pub fn detect_and_enrich_sessions() -> Result<(Vec<Session>, DetectionDiagnostic
     let codex_result = crate::session::codex::CodexSessionSource::new()
         .ok()
         .and_then(|mut codex| codex.detect().ok());
+    let cursor_result = crate::session::cursor::CursorSessionSource::new()
+        .ok()
+        .and_then(|mut cursor| cursor.detect().ok());
     match claude_result {
         Ok((mut detected, diagnostics)) => {
             if let Some((mut codex_sessions, _)) = codex_result {
                 detected.append(&mut codex_sessions);
             }
+            if let Some((mut cursor_sessions, _)) = cursor_result {
+                detected.append(&mut cursor_sessions);
+            }
             enrich_detected_sessions(detected, diagnostics)
         }
         Err(error) => {
-            if let Some((codex_sessions, diagnostics)) = codex_result {
-                if !codex_sessions.is_empty() {
-                    return enrich_detected_sessions(codex_sessions, diagnostics);
+            let mut fallback = Vec::new();
+            let mut diagnostics = DetectionDiagnostics::default();
+            if let Some((sessions, extra)) = codex_result {
+                fallback.extend(sessions);
+                diagnostics = extra;
+            }
+            if let Some((sessions, extra)) = cursor_result {
+                fallback.extend(sessions);
+                if diagnostics.claude_processes_found == 0 {
+                    diagnostics = extra;
                 }
+            }
+            if !fallback.is_empty() {
+                return enrich_detected_sessions(fallback, diagnostics);
             }
             Err(format!("Failed to detect sessions: {error}"))
         }
@@ -219,6 +236,75 @@ pub fn enrich_detected_sessions(
                 } else {
                     SessionStatus::WaitingForInput
                 },
+                latest_message,
+                pending_tool_name: None,
+                pending_tool_input: None,
+                worker_of: None,
+                official_name: detected.official_name.clone(),
+                started_at_ms: detected.started_at_ms,
+                provider: detected.provider,
+                surface: detected.surface,
+                agent_kind: detected.agent_kind,
+                parent_thread_id: detected.parent_thread_id.clone(),
+                root_session_id: detected.root_session_id.clone(),
+                agent_path: detected.agent_path.clone(),
+                agent_nickname: detected.agent_nickname.clone(),
+                agent_role: detected.agent_role.clone(),
+                internal_kind: detected.internal_kind.clone(),
+                can_open: detected.can_open,
+                can_stop: detected.can_stop,
+                can_rename: detected.can_rename,
+            });
+            continue;
+        }
+
+        if let Some(summary) = detected.cursor_summary.as_ref() {
+            let first_prompt = summary
+                .first_prompt()
+                .map(|prompt| truncate_string(prompt, 100))
+                .unwrap_or_else(|| "(No conversation yet)".to_string());
+            let latest_message = summary
+                .latest_message()
+                .map(|message| truncate_string(message, 200))
+                .unwrap_or_default();
+            let session_name = custom_names
+                .get(&session_id)
+                .cloned()
+                .or_else(|| detected.agent_nickname.clone())
+                .unwrap_or_else(|| detected.project_name.clone());
+            let modified = if summary.last_timestamp.is_empty() {
+                detected
+                    .started_at_ms
+                    .and_then(DateTime::<Utc>::from_timestamp_millis)
+                    .map(|timestamp| timestamp.to_rfc3339())
+                    .unwrap_or_default()
+            } else {
+                summary.last_timestamp.clone()
+            };
+            let status = if summary.lifecycle == CursorLifecycle::Working {
+                if summary.empty {
+                    SessionStatus::Connecting
+                } else {
+                    SessionStatus::Working
+                }
+            } else {
+                SessionStatus::WaitingForInput
+            };
+            sessions.push(Session {
+                id: session_id.clone(),
+                pid: detected.pid,
+                session_name,
+                custom_title: custom_titles
+                    .get(&session_id)
+                    .cloned()
+                    .or_else(|| detected.official_name.clone()),
+                project_path: detected.cwd.to_string_lossy().to_string(),
+                git_branch: None,
+                first_prompt,
+                summary: None,
+                message_count: summary.messages.len() as u32,
+                modified,
+                status,
                 latest_message,
                 pending_tool_name: None,
                 pending_tool_input: None,
@@ -695,6 +781,7 @@ mod placeholder_tests {
             can_stop: true,
             can_rename: true,
             codex_summary: None,
+            cursor_summary: None,
         };
         let (sessions, _) =
             enrich_detected_sessions(vec![detected], DetectionDiagnostics::default()).unwrap();

--- a/src-tauri/src/session/history.rs
+++ b/src-tauri/src/session/history.rs
@@ -26,6 +26,12 @@ pub struct HistoryEntry {
     pub project: String,
     pub project_name: String,
     pub custom_title: Option<String>,
+    /// Codex's current UI thread name from ~/.codex/session_index.jsonl.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub codex_title: Option<String>,
+    /// Cursor's current UI composer name from state.vscdb.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub cursor_title: Option<String>,
     #[serde(default = "default_provider")]
     pub provider: String,
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -96,6 +102,8 @@ pub fn parse_history_jsonl(content: &str) -> Vec<HistoryEntry> {
                 project: accum.first.project,
                 project_name,
                 custom_title: None,
+                codex_title: None,
+                cursor_title: None,
                 provider: default_provider(),
                 surface: None,
                 agent_kind: None,
@@ -137,6 +145,7 @@ fn codex_history_entries(home_dir: &std::path::Path) -> Vec<HistoryEntry> {
                 .and_then(|name| name.to_str())
                 .unwrap_or("unknown")
                 .to_string();
+            let codex_title = super::codex::get_cached_codex_thread_title(&snapshot.thread_id);
             HistoryEntry {
                 session_id: snapshot.thread_id,
                 display: snapshot.display,
@@ -144,6 +153,8 @@ fn codex_history_entries(home_dir: &std::path::Path) -> Vec<HistoryEntry> {
                 project: snapshot.cwd,
                 project_name,
                 custom_title: None,
+                codex_title,
+                cursor_title: None,
                 provider: "codex".to_string(),
                 surface: Some(snapshot.surface),
                 agent_kind: Some(snapshot.agent_kind),
@@ -666,6 +677,8 @@ mod tests {
                 project: project.into(),
                 project_name: "myproj".into(),
                 custom_title: None,
+                codex_title: None,
+                cursor_title: None,
                 provider: default_provider(),
                 surface: None,
                 agent_kind: None,
@@ -677,6 +690,8 @@ mod tests {
                 project: project.into(),
                 project_name: "myproj".into(),
                 custom_title: None,
+                codex_title: None,
+                cursor_title: None,
                 provider: default_provider(),
                 surface: None,
                 agent_kind: None,
@@ -698,6 +713,8 @@ mod tests {
             project: "/p/gone".into(),
             project_name: "gone".into(),
             custom_title: None,
+            codex_title: None,
+            cursor_title: None,
             provider: default_provider(),
             surface: None,
             agent_kind: None,

--- a/src-tauri/src/session/history.rs
+++ b/src-tauri/src/session/history.rs
@@ -127,7 +127,7 @@ pub fn get_history() -> Result<Vec<HistoryEntry>, String> {
 }
 
 fn codex_history_entries(home_dir: &std::path::Path) -> Vec<HistoryEntry> {
-    super::codex_archive::load_default_snapshots(home_dir)
+    super::codex_archive::load_default_listing(home_dir)
         .into_iter()
         .filter(|snapshot| !snapshot.is_internal())
         .map(|snapshot| {

--- a/src-tauri/src/session/history.rs
+++ b/src-tauri/src/session/history.rs
@@ -122,6 +122,7 @@ pub fn get_history() -> Result<Vec<HistoryEntry>, String> {
     };
 
     entries.extend(codex_history_entries(&home_dir));
+    entries.extend(crate::session::cursor::cursor_history_entries(&home_dir));
     entries.sort_by(|left, right| right.timestamp.cmp(&left.timestamp));
     Ok(entries)
 }
@@ -520,6 +521,14 @@ pub(crate) fn deep_search_under(
             .into_inner()
             .map_err(|error| format!("Codex search mutex poisoned: {error}"))?,
     );
+    result.extend(crate::session::cursor::search_cursor_transcripts(
+        &home_dir,
+        query_norm.as_str(),
+        case_sensitive,
+        whole_word,
+        phrase_match,
+        extract_snippet,
+    ));
     result.sort_by(|left, right| {
         left.provider
             .cmp(&right.provider)

--- a/src-tauri/src/session/mod.rs
+++ b/src-tauri/src/session/mod.rs
@@ -34,7 +34,7 @@ pub mod cost;
 pub use cost::{get_cost_data, CostData};
 
 pub(crate) fn codex_session_ids(home: &std::path::Path, prefix: &str) -> Vec<String> {
-    codex_archive::load_default_snapshots(home)
+    codex_archive::load_default_listing(home)
         .into_iter()
         .filter(|snapshot| snapshot.thread_id.starts_with(prefix))
         .map(|snapshot| snapshot.thread_id)

--- a/src-tauri/src/session/mod.rs
+++ b/src-tauri/src/session/mod.rs
@@ -1,5 +1,5 @@
-pub mod custom_names;
 pub mod codex;
+pub mod custom_names;
 pub mod detector;
 pub mod parser;
 pub mod permissions;
@@ -11,16 +11,16 @@ pub use detector::LegacySessionSource;
 pub mod detector_cli;
 pub use detector_cli::CliSessionSource;
 pub mod state;
-pub use state::DetectorState;
-pub use source::{
-    AgentKind, CliActivity, DetectedSession, DetectionDiagnostics, SessionKind, SessionProvider,
-    SessionSource, SessionSurface,
-};
 pub use parser::{
     extract_messages, parse_all_entries, parse_last_n_entries, parse_sessions_index, ImageBlock,
     MessageContent, MessageType, SessionEntry, SessionIndexEntry, SessionsIndex,
 };
 pub use permissions::PermissionChecker;
+pub use source::{
+    AgentKind, CliActivity, DetectedSession, DetectionDiagnostics, SessionKind, SessionProvider,
+    SessionSource, SessionSurface,
+};
+pub use state::DetectorState;
 pub use status::{
     determine_status, determine_status_with_context, get_pending_tool_input, get_pending_tool_name,
     SessionStatus,
@@ -29,8 +29,8 @@ pub use status::{
 pub mod history;
 pub use history::{deep_search, get_history, DeepSearchHit, HistoryEntry};
 
-pub mod cost;
 mod codex_archive;
+pub mod cost;
 pub use cost::{get_cost_data, CostData};
 
 pub(crate) fn codex_session_ids(home: &std::path::Path, prefix: &str) -> Vec<String> {
@@ -55,8 +55,8 @@ pub use conversation::{get_conversation_data, Conversation, ConversationMessage}
 
 pub mod subagents;
 pub use subagents::{
-    active_subagents_for_path, all_subagents_by_session, get_subagent_transcript,
-    SubagentInfo, SubagentStatus, SubagentTranscript,
+    active_subagents_for_path, all_subagents_by_session, get_subagent_transcript, SubagentInfo,
+    SubagentStatus, SubagentTranscript,
 };
 
 use std::process::Command;
@@ -238,7 +238,10 @@ mod factory_tests {
 
     #[test]
     fn parse_semver_handles_extra_text() {
-        assert_eq!(parse_semver("Claude Code 2.2.0 — build abc"), Some((2, 2, 0)));
+        assert_eq!(
+            parse_semver("Claude Code 2.2.0 — build abc"),
+            Some((2, 2, 0))
+        );
     }
 
     #[test]

--- a/src-tauri/src/session/mod.rs
+++ b/src-tauri/src/session/mod.rs
@@ -1,4 +1,5 @@
 pub mod codex;
+pub mod cursor;
 pub mod custom_names;
 pub mod detector;
 pub mod parser;
@@ -39,6 +40,10 @@ pub(crate) fn codex_session_ids(home: &std::path::Path, prefix: &str) -> Vec<Str
         .filter(|snapshot| snapshot.thread_id.starts_with(prefix))
         .map(|snapshot| snapshot.thread_id)
         .collect()
+}
+
+pub(crate) fn cursor_session_ids(home: &std::path::Path, prefix: &str) -> Vec<String> {
+    cursor::list_session_ids(home, prefix)
 }
 
 pub mod memory;

--- a/src-tauri/src/session/mod.rs
+++ b/src-tauri/src/session/mod.rs
@@ -1,3 +1,4 @@
+mod cache;
 pub mod codex;
 pub mod cursor;
 pub mod custom_names;
@@ -18,9 +19,37 @@ pub use parser::{
 };
 pub use permissions::PermissionChecker;
 pub use source::{
-    AgentKind, CliActivity, DetectedSession, DetectionDiagnostics, SessionKind, SessionProvider,
-    SessionSource, SessionSurface,
+    AgentKind, CliActivity, DetectedSession, DetectionDiagnostics, SessionIdentity, SessionKind,
+    SessionProvider, SessionSource, SessionSurface,
 };
+
+/// Rename currently mutates Claude Code's native custom-title records.
+/// Provider-aware callers must not accidentally route a Codex/Cursor ID into
+/// that Claude-only write path. `None` remains a legacy Claude request, while
+/// `validate_rename_request` adds the collision guard before any write.
+pub(crate) fn validate_rename_provider(provider: Option<SessionProvider>) -> Result<(), String> {
+    match provider {
+        Some(SessionProvider::ClaudeCode) => Ok(()),
+        None => Ok(()),
+        Some(provider) => Err(format!(
+            "renaming is only supported for Claude Code sessions; got {provider:?}"
+        )),
+    }
+}
+
+pub(crate) fn validate_rename_request(
+    provider: Option<SessionProvider>,
+    session_id: &str,
+    owners: &ProviderSourceOwners,
+) -> Result<(), String> {
+    validate_rename_provider(provider)?;
+    if provider.is_none() && owners.has_non_claude_session(session_id) {
+        return Err(format!(
+            "renaming session {session_id} requires an explicit provider because the ID collides across providers"
+        ));
+    }
+    Ok(())
+}
 pub use state::DetectorState;
 pub use status::{
     determine_status, determine_status_with_context, get_pending_tool_input, get_pending_tool_name,
@@ -48,6 +77,9 @@ pub(crate) fn cursor_session_ids(home: &std::path::Path, prefix: &str) -> Vec<St
 
 pub mod memory;
 pub use memory::{get_memory_files, MemoryFile, ProjectMemory};
+
+mod owners;
+pub(crate) use owners::{global_provider_source_owners, ProviderSourceOwners};
 
 pub mod enrichment;
 pub use enrichment::{detect_and_enrich_sessions, Session};
@@ -230,6 +262,42 @@ pub fn create_session_source() -> Box<dyn SessionSource> {
 #[cfg(test)]
 mod factory_tests {
     use super::*;
+
+    #[test]
+    fn rename_provider_validation_is_claude_only() {
+        assert!(validate_rename_provider(None).is_ok());
+        assert!(validate_rename_provider(Some(SessionProvider::ClaudeCode)).is_ok());
+        assert!(validate_rename_provider(Some(SessionProvider::Codex)).is_err());
+        assert!(validate_rename_provider(Some(SessionProvider::Cursor)).is_err());
+    }
+
+    #[test]
+    fn legacy_rename_is_rejected_for_a_cross_provider_collision() {
+        const SESSION_ID: &str = "cccccccc-cccc-cccc-cccc-cccccccccccc";
+        let temp = tempfile::tempdir().unwrap();
+        let transcript_dir = temp
+            .path()
+            .join("synthetic-project")
+            .join("agent-transcripts")
+            .join(SESSION_ID);
+        std::fs::create_dir_all(&transcript_dir).unwrap();
+        std::fs::write(
+            transcript_dir.join(format!("{SESSION_ID}.jsonl")),
+            r#"{"role":"user","message":{"content":[{"type":"text","text":"collision fixture"}]}}
+"#,
+        )
+        .unwrap();
+
+        let cursor =
+            crate::session::cursor::CursorSessionSource::at_root(temp.path().to_path_buf());
+        assert!(cursor.contains_session_id(SESSION_ID));
+        let owners = ProviderSourceOwners::from_test_sources(None, Some(cursor));
+
+        assert!(validate_rename_request(None, SESSION_ID, &owners).is_err());
+        assert!(
+            validate_rename_request(Some(SessionProvider::ClaudeCode), SESSION_ID, &owners).is_ok()
+        );
+    }
 
     #[test]
     fn parse_semver_extracts_triple_from_cc_output() {

--- a/src-tauri/src/session/owners.rs
+++ b/src-tauri/src/session/owners.rs
@@ -1,0 +1,260 @@
+//! Process-wide owners for provider-specific transcript sources.
+//!
+//! A source contains incremental parsing state, so creating one per caller
+//! silently turns every poll/request into a cold parse.  The GUI detector and
+//! the CLI/Web enrichment path therefore share these owners.  Provider
+//! discovery and parsing remain separate; only the lifecycle of the mutable
+//! source is shared.
+
+use super::codex::CodexSessionSource;
+use super::cursor::CursorSessionSource;
+use super::source::{DetectedSession, DetectionDiagnostics, SessionSource};
+use std::sync::{Arc, LazyLock, Mutex};
+
+pub(crate) type SharedCodexSource = Arc<Mutex<Option<CodexSessionSource>>>;
+pub(crate) type SharedCursorSource = Arc<Mutex<Option<CursorSessionSource>>>;
+
+#[derive(Clone)]
+pub(crate) struct ProviderSourceOwners {
+    pub(crate) codex: SharedCodexSource,
+    pub(crate) cursor: SharedCursorSource,
+    initialize_defaults: bool,
+}
+
+impl ProviderSourceOwners {
+    fn new() -> Self {
+        Self {
+            codex: Arc::new(Mutex::new(None)),
+            cursor: Arc::new(Mutex::new(None)),
+            initialize_defaults: true,
+        }
+    }
+
+    pub(crate) fn detect_codex(&self) -> Option<(Vec<DetectedSession>, DetectionDiagnostics)> {
+        let mut guard = recover_lock(&self.codex);
+        if guard.is_none() {
+            if !self.initialize_defaults {
+                return None;
+            }
+            *guard = CodexSessionSource::new().ok();
+        }
+        guard.as_mut()?.detect().ok()
+    }
+
+    pub(crate) fn detect_cursor(&self) -> Option<(Vec<DetectedSession>, DetectionDiagnostics)> {
+        let mut guard = recover_lock(&self.cursor);
+        if guard.is_none() {
+            if !self.initialize_defaults {
+                return None;
+            }
+            *guard = CursorSessionSource::new().ok();
+        }
+        guard.as_mut()?.detect().ok()
+    }
+
+    pub(crate) fn has_non_claude_session(&self, session_id: &str) -> bool {
+        let codex = {
+            let mut guard = recover_lock(&self.codex);
+            if guard.is_none() && self.initialize_defaults {
+                *guard = CodexSessionSource::new().ok();
+            }
+            guard
+                .as_ref()
+                .is_some_and(|source| source.contains_session_id(session_id))
+        };
+        if codex {
+            return true;
+        }
+
+        let mut guard = recover_lock(&self.cursor);
+        if guard.is_none() && self.initialize_defaults {
+            *guard = CursorSessionSource::new().ok();
+        }
+        guard
+            .as_ref()
+            .is_some_and(|source| source.contains_session_id(session_id))
+    }
+
+    #[cfg(test)]
+    pub(crate) fn from_test_sources(
+        codex: Option<CodexSessionSource>,
+        cursor: Option<CursorSessionSource>,
+    ) -> Self {
+        Self {
+            codex: Arc::new(Mutex::new(codex)),
+            cursor: Arc::new(Mutex::new(cursor)),
+            initialize_defaults: false,
+        }
+    }
+}
+
+static GLOBAL_PROVIDER_SOURCE_OWNERS: LazyLock<ProviderSourceOwners> =
+    LazyLock::new(ProviderSourceOwners::new);
+
+pub(crate) fn global_provider_source_owners() -> ProviderSourceOwners {
+    GLOBAL_PROVIDER_SOURCE_OWNERS.clone()
+}
+
+fn recover_lock<T>(mutex: &Mutex<T>) -> std::sync::MutexGuard<'_, T> {
+    match mutex.lock() {
+        Ok(guard) => guard,
+        Err(poisoned) => poisoned.into_inner(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::Arc;
+
+    #[test]
+    fn cloned_owners_share_each_provider_source() {
+        let owners = ProviderSourceOwners::new();
+        let clone = owners.clone();
+
+        assert!(Arc::ptr_eq(&owners.codex, &clone.codex));
+        assert!(Arc::ptr_eq(&owners.cursor, &clone.cursor));
+    }
+
+    #[test]
+    fn global_owner_clones_share_each_provider_source() {
+        let detector_owner = global_provider_source_owners();
+        let enrichment_owner = global_provider_source_owners();
+
+        assert!(Arc::ptr_eq(&detector_owner.codex, &enrichment_owner.codex));
+        assert!(Arc::ptr_eq(
+            &detector_owner.cursor,
+            &enrichment_owner.cursor
+        ));
+    }
+
+    #[test]
+    fn independent_test_owners_do_not_share_state() {
+        let left = ProviderSourceOwners::new();
+        let right = ProviderSourceOwners::new();
+
+        assert!(!Arc::ptr_eq(&left.codex, &right.codex));
+        assert!(!Arc::ptr_eq(&left.cursor, &right.cursor));
+    }
+
+    #[test]
+    fn test_owners_without_sources_do_not_initialize_production_roots() {
+        let owners = ProviderSourceOwners::from_test_sources(None, None);
+
+        assert!(owners.detect_codex().is_none());
+        assert!(owners.detect_cursor().is_none());
+        assert!(owners.codex.lock().unwrap().is_none());
+        assert!(owners.cursor.lock().unwrap().is_none());
+    }
+
+    #[test]
+    fn shared_cursor_owner_detects_a_synthetic_fixture() {
+        const SESSION_ID: &str = "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa";
+        let temp = tempfile::tempdir().unwrap();
+        let transcript_dir = temp
+            .path()
+            .join("demo-project")
+            .join("agent-transcripts")
+            .join(SESSION_ID);
+        std::fs::create_dir_all(&transcript_dir).unwrap();
+        std::fs::write(
+            transcript_dir.join(format!("{SESSION_ID}.jsonl")),
+            r#"{"role":"user","message":{"content":[{"type":"text","text":"<user_query>shared owner fixture</user_query>"}]}}
+"#,
+        )
+        .unwrap();
+
+        let owners = ProviderSourceOwners::from_test_sources(
+            None,
+            Some(CursorSessionSource::at_root(temp.path().to_path_buf())),
+        );
+        let first = owners.detect_cursor().unwrap().0;
+        let parses_after_first = owners
+            .cursor
+            .lock()
+            .unwrap()
+            .as_ref()
+            .unwrap()
+            .parse_count_for_test();
+        let second = owners.clone().detect_cursor().unwrap().0;
+        let parses_after_second = owners
+            .cursor
+            .lock()
+            .unwrap()
+            .as_ref()
+            .unwrap()
+            .parse_count_for_test();
+
+        assert_eq!(first.len(), 1);
+        assert_eq!(second.len(), 1);
+        assert_eq!(parses_after_first, parses_after_second);
+        assert_eq!(first[0].session_id, Some(SESSION_ID.to_string()));
+        assert_eq!(second[0].session_id, Some(SESSION_ID.to_string()));
+        assert!(owners.has_non_claude_session(SESSION_ID));
+        assert!(!owners.has_non_claude_session("missing-cursor-session"));
+    }
+
+    #[test]
+    fn shared_codex_owner_detects_a_synthetic_fixture() {
+        const SESSION_ID: &str = "bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb";
+        let temp = tempfile::tempdir().unwrap();
+        let now = chrono::Local::now();
+        let day = temp.path().join(now.format("%Y/%m/%d").to_string());
+        std::fs::create_dir_all(&day).unwrap();
+        let path = day.join(format!("rollout-synthetic-{SESSION_ID}.jsonl"));
+        let event = |event_type: &str, payload: serde_json::Value| {
+            serde_json::json!({
+                "timestamp": now.to_rfc3339(),
+                "type": event_type,
+                "payload": payload,
+            })
+            .to_string()
+        };
+        std::fs::write(
+            &path,
+            format!(
+                "{}\n{}\n",
+                event(
+                    "session_meta",
+                    serde_json::json!({
+                        "id": SESSION_ID,
+                        "cwd": "/tmp/synthetic-codex",
+                        "source": "cli",
+                        "originator": "codex-tui"
+                    })
+                ),
+                event("event_msg", serde_json::json!({"type": "task_started"}))
+            ),
+        )
+        .unwrap();
+
+        let owners = ProviderSourceOwners::from_test_sources(
+            Some(CodexSessionSource::at_root(temp.path().to_path_buf())),
+            None,
+        );
+        let first = owners.detect_codex().unwrap().0;
+        let parses_after_first = owners
+            .codex
+            .lock()
+            .unwrap()
+            .as_ref()
+            .unwrap()
+            .parse_count_for_test();
+        let second = owners.clone().detect_codex().unwrap().0;
+        let parses_after_second = owners
+            .codex
+            .lock()
+            .unwrap()
+            .as_ref()
+            .unwrap()
+            .parse_count_for_test();
+
+        assert_eq!(first.len(), 1);
+        assert_eq!(second.len(), 1);
+        assert_eq!(parses_after_first, parses_after_second);
+        assert_eq!(first[0].session_id, Some(SESSION_ID.to_string()));
+        assert_eq!(second[0].session_id, Some(SESSION_ID.to_string()));
+        assert!(owners.has_non_claude_session(SESSION_ID));
+        assert!(!owners.has_non_claude_session("missing-codex-session"));
+    }
+}

--- a/src-tauri/src/session/parser.rs
+++ b/src-tauri/src/session/parser.rs
@@ -316,16 +316,38 @@ pub fn parse_last_n_entries<P: AsRef<Path>>(
 
 /// Parse all entries from a session JSONL file
 pub fn parse_all_entries<P: AsRef<Path>>(path: P) -> Result<Vec<SessionEntry>, String> {
+    parse_all_entries_with_progress(path, &mut |_, _| {})
+}
+
+/// Like [`parse_all_entries`], but reports `(bytes_read, bytes_total)` while scanning.
+pub fn parse_all_entries_with_progress<P: AsRef<Path>>(
+    path: P,
+    on_progress: &mut dyn FnMut(u64, u64),
+) -> Result<Vec<SessionEntry>, String> {
     let file =
         File::open(path.as_ref()).map_err(|e| format!("Failed to open JSONL file: {}", e))?;
-
-    let reader = BufReader::new(file);
-    let lines: Vec<String> = reader
-        .lines()
-        .map_while(Result::ok)
-        .filter(|line| !line.trim().is_empty())
-        .collect();
-
+    let total = file.metadata().map(|m| m.len()).unwrap_or(0);
+    let mut reader = BufReader::new(file);
+    let mut lines = Vec::new();
+    let mut buf = String::new();
+    let mut read = 0u64;
+    on_progress(0, total);
+    loop {
+        buf.clear();
+        let n = reader
+            .read_line(&mut buf)
+            .map_err(|e| format!("Failed to read JSONL file: {}", e))?;
+        if n == 0 {
+            break;
+        }
+        read += n as u64;
+        on_progress(read, total);
+        let without_newline = buf.trim_end_matches(['\n', '\r']);
+        if !without_newline.trim().is_empty() {
+            lines.push(without_newline.to_string());
+        }
+    }
+    on_progress(total, total);
     Ok(parse_jsonl_entries(lines))
 }
 

--- a/src-tauri/src/session/parser.rs
+++ b/src-tauri/src/session/parser.rs
@@ -1,6 +1,6 @@
 use serde::{Deserialize, Serialize};
 use std::fs::File;
-use std::io::{BufRead, BufReader, Seek, SeekFrom};
+use std::io::{BufRead, BufReader, Read, Seek, SeekFrom};
 use std::path::{Path, PathBuf};
 
 /// Represents the sessions-index.json file structure
@@ -278,19 +278,45 @@ pub fn read_last_n_lines<P: AsRef<Path>>(path: P, n: usize) -> Result<Vec<String
         return Ok(lines[start..].to_vec());
     }
 
-    // For larger files, read from the end
-    // Estimate: average line is ~1KB, so read last n*1KB + buffer
-    let chunk_size = (n * 1024 * 2).min(file_size as usize);
+    // For larger files, read backwards in chunks until we have one complete
+    // line more than requested. A fixed byte window can begin in the middle of
+    // a valid, large JSONL record and silently drop the newest entry.
+    const REVERSE_CHUNK_BYTES: u64 = 8 * 1024;
     let mut file = file;
+    let mut position = file_size;
+    let mut chunks = Vec::new();
+    let mut newline_count = 0usize;
+    let required_newlines = n.saturating_add(1);
 
-    file.seek(SeekFrom::End(-(chunk_size as i64)))
-        .map_err(|e| format!("Failed to seek in file: {}", e))?;
+    while position > 0 {
+        let read_len = position.min(REVERSE_CHUNK_BYTES) as usize;
+        position -= read_len as u64;
+        file.seek(SeekFrom::Start(position))
+            .map_err(|e| format!("Failed to seek in file: {}", e))?;
 
-    let reader = BufReader::new(file);
-    let lines: Vec<String> = reader
+        let mut chunk = vec![0u8; read_len];
+        file.read_exact(&mut chunk)
+            .map_err(|e| format!("Failed to read JSONL chunk: {}", e))?;
+        newline_count =
+            newline_count.saturating_add(chunk.iter().filter(|byte| **byte == b'\n').count());
+        chunks.push(chunk);
+
+        if newline_count >= required_newlines {
+            break;
+        }
+    }
+
+    let total_bytes: usize = chunks.iter().map(Vec::len).sum();
+    let mut bytes = Vec::with_capacity(total_bytes);
+    for chunk in chunks.into_iter().rev() {
+        bytes.extend_from_slice(&chunk);
+    }
+
+    let content = String::from_utf8_lossy(&bytes);
+    let lines: Vec<String> = content
         .lines()
-        .map_while(Result::ok)
         .filter(|line| !line.trim().is_empty())
+        .map(ToOwned::to_owned)
         .collect();
 
     let start = if lines.len() > n { lines.len() - n } else { 0 };
@@ -624,6 +650,7 @@ pub fn get_native_custom_title_from_file(path: &std::path::Path) -> Option<Strin
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::io::Write;
 
     #[test]
     fn test_parse_user_message() {
@@ -648,6 +675,46 @@ mod tests {
         } else {
             panic!("Failed to parse user message");
         }
+    }
+
+    #[test]
+    fn read_last_n_lines_expands_for_a_large_complete_jsonl_record() {
+        let temp = tempfile::tempdir().unwrap();
+        let path = temp.path().join("large-record.jsonl");
+        let mut file = File::create(&path).unwrap();
+
+        for index in 0..20 {
+            let small_record = serde_json::json!({
+                "type": "user",
+                "uuid": format!("small-{index}"),
+                "timestamp": "2026-01-08T15:23:03.096Z",
+                "sessionId": "large",
+                "message": {"role": "user", "content": "small"}
+            });
+            writeln!(file, "{}", serde_json::to_string(&small_record).unwrap()).unwrap();
+        }
+
+        let long_content = "x".repeat(50 * 1024);
+        let long_record = serde_json::json!({
+            "type": "assistant",
+            "uuid": "large-assistant",
+            "timestamp": "2026-01-08T15:23:04.096Z",
+            "sessionId": "large",
+            "message": {
+                "model": "claude-sonnet",
+                "id": "large-message",
+                "role": "assistant",
+                "content": [{"type": "text", "text": long_content}]
+            }
+        });
+        writeln!(file, "{}", serde_json::to_string(&long_record).unwrap()).unwrap();
+
+        let entries = parse_last_n_entries(&path, 20).unwrap();
+        assert_eq!(entries.len(), 20);
+        assert!(matches!(
+            entries.last(),
+            Some(SessionEntry::Assistant { .. })
+        ));
     }
 
     #[test]

--- a/src-tauri/src/session/parser.rs
+++ b/src-tauri/src/session/parser.rs
@@ -158,9 +158,7 @@ impl<'de> Deserialize<'de> for UserMessage {
                                     .and_then(|v| v.as_str())
                                     .unwrap_or("image/png")
                                     .to_string();
-                                if let Some(data) =
-                                    source.get("data").and_then(|v| v.as_str())
-                                {
+                                if let Some(data) = source.get("data").and_then(|v| v.as_str()) {
                                     images.push(ImageBlock {
                                         media_type,
                                         data: data.to_string(),
@@ -412,7 +410,9 @@ fn format_system_tags(tags: &[(String, String)]) -> String {
     use std::fmt::Write;
 
     // Check if this is a slash command entry
-    let has_command_tags = tags.iter().any(|(name, _)| COMMAND_TAGS.contains(&name.as_str()));
+    let has_command_tags = tags
+        .iter()
+        .any(|(name, _)| COMMAND_TAGS.contains(&name.as_str()));
 
     if has_command_tags {
         // Format as: /command-name args
@@ -1055,7 +1055,9 @@ mod tests {
 
     #[test]
     fn test_is_system_message_caveat() {
-        assert!(is_system_content("<local-command-caveat>Caveat: ...</local-command-caveat>"));
+        assert!(is_system_content(
+            "<local-command-caveat>Caveat: ...</local-command-caveat>"
+        ));
     }
 
     #[test]
@@ -1082,7 +1084,9 @@ mod tests {
     #[test]
     fn test_is_system_message_bash() {
         assert!(is_system_content("<bash-input>git status</bash-input>"));
-        assert!(is_system_content("<bash-stdout>On branch main</bash-stdout>"));
+        assert!(is_system_content(
+            "<bash-stdout>On branch main</bash-stdout>"
+        ));
     }
 
     #[test]

--- a/src-tauri/src/session/sanitize.rs
+++ b/src-tauri/src/session/sanitize.rs
@@ -71,7 +71,10 @@ mod tests {
     #[test]
     fn test_preserves_normal_text() {
         let input = "Just a normal message with no tags";
-        assert_eq!(strip_system_tags(input), "Just a normal message with no tags");
+        assert_eq!(
+            strip_system_tags(input),
+            "Just a normal message with no tags"
+        );
     }
 
     #[test]

--- a/src-tauri/src/session/source.rs
+++ b/src-tauri/src/session/source.rs
@@ -165,15 +165,30 @@ mod tests {
 
     #[test]
     fn session_kind_serializes_as_lowercase() {
-        assert_eq!(serde_json::to_string(&SessionKind::Interactive).unwrap(), "\"interactive\"");
-        assert_eq!(serde_json::to_string(&SessionKind::Background).unwrap(), "\"background\"");
-        assert_eq!(serde_json::to_string(&SessionKind::Unknown).unwrap(), "\"unknown\"");
+        assert_eq!(
+            serde_json::to_string(&SessionKind::Interactive).unwrap(),
+            "\"interactive\""
+        );
+        assert_eq!(
+            serde_json::to_string(&SessionKind::Background).unwrap(),
+            "\"background\""
+        );
+        assert_eq!(
+            serde_json::to_string(&SessionKind::Unknown).unwrap(),
+            "\"unknown\""
+        );
     }
 
     #[test]
     fn cli_activity_serializes_as_lowercase() {
-        assert_eq!(serde_json::to_string(&CliActivity::Busy).unwrap(), "\"busy\"");
-        assert_eq!(serde_json::to_string(&CliActivity::Idle).unwrap(), "\"idle\"");
+        assert_eq!(
+            serde_json::to_string(&CliActivity::Busy).unwrap(),
+            "\"busy\""
+        );
+        assert_eq!(
+            serde_json::to_string(&CliActivity::Idle).unwrap(),
+            "\"idle\""
+        );
     }
 
     #[test]
@@ -197,9 +212,21 @@ mod tests {
 
     #[test]
     fn provider_surface_and_agent_kind_use_frontend_contract_values() {
-        assert_eq!(serde_json::to_string(&SessionProvider::ClaudeCode).unwrap(), "\"claudeCode\"");
-        assert_eq!(serde_json::to_string(&SessionProvider::Codex).unwrap(), "\"codex\"");
-        assert_eq!(serde_json::to_string(&SessionSurface::Integration).unwrap(), "\"integration\"");
-        assert_eq!(serde_json::to_string(&AgentKind::Subagent).unwrap(), "\"subagent\"");
+        assert_eq!(
+            serde_json::to_string(&SessionProvider::ClaudeCode).unwrap(),
+            "\"claudeCode\""
+        );
+        assert_eq!(
+            serde_json::to_string(&SessionProvider::Codex).unwrap(),
+            "\"codex\""
+        );
+        assert_eq!(
+            serde_json::to_string(&SessionSurface::Integration).unwrap(),
+            "\"integration\""
+        );
+        assert_eq!(
+            serde_json::to_string(&AgentKind::Subagent).unwrap(),
+            "\"subagent\""
+        );
     }
 }

--- a/src-tauri/src/session/source.rs
+++ b/src-tauri/src/session/source.rs
@@ -36,7 +36,7 @@ pub enum CliActivity {
     Idle,
 }
 
-#[derive(Debug, Clone, Copy, Serialize, Deserialize, Default, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, Default, PartialEq, Eq, Hash)]
 #[serde(rename_all = "camelCase")]
 pub enum SessionProvider {
     #[default]
@@ -45,7 +45,7 @@ pub enum SessionProvider {
     Cursor,
 }
 
-#[derive(Debug, Clone, Copy, Serialize, Deserialize, Default, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, Default, PartialEq, Eq, Hash)]
 #[serde(rename_all = "camelCase")]
 pub enum SessionSurface {
     #[default]
@@ -65,6 +65,41 @@ pub enum AgentKind {
     Root,
     Subagent,
     Internal,
+}
+
+/// Stable identity for a detected session.
+///
+/// A provider owns the namespace of its session IDs. Keeping the provider in
+/// the key prevents a Claude, Codex, and Cursor session with the same opaque
+/// ID from sharing deduplication, status, or overlay state.
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct SessionIdentity {
+    pub provider: SessionProvider,
+    pub session_id: String,
+}
+
+impl SessionIdentity {
+    pub fn new(provider: SessionProvider, session_id: impl Into<String>) -> Self {
+        Self {
+            provider,
+            session_id: session_id.into(),
+        }
+    }
+
+    /// Opaque UI/storage key. The provider prefix is explicit so callers do
+    /// not have to infer a namespace from a raw session ID.
+    pub fn key(&self) -> String {
+        format!("{}:{}", provider_key(self.provider), self.session_id)
+    }
+}
+
+fn provider_key(provider: SessionProvider) -> &'static str {
+    match provider {
+        SessionProvider::ClaudeCode => "claudeCode",
+        SessionProvider::Codex => "codex",
+        SessionProvider::Cursor => "cursor",
+    }
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, Default, PartialEq)]
@@ -122,6 +157,16 @@ fn default_true() -> bool {
 }
 
 impl DetectedSession {
+    pub fn identity(&self) -> Option<SessionIdentity> {
+        self.session_id
+            .as_ref()
+            .map(|id| SessionIdentity::new(self.provider, id.clone()))
+    }
+
+    pub fn identity_key(&self) -> Option<String> {
+        self.identity().map(|identity| identity.key())
+    }
+
     /// Legacy backend doesn't fill the new (Phase 2) fields. Helper enforces the defaults.
     pub fn with_legacy_defaults(
         pid: u32,
@@ -242,5 +287,19 @@ mod tests {
             serde_json::to_string(&AgentKind::Subagent).unwrap(),
             "\"subagent\""
         );
+    }
+
+    #[test]
+    fn session_identity_namespaces_provider_ids() {
+        let id = "same-session-id";
+        let claude = SessionIdentity::new(SessionProvider::ClaudeCode, id);
+        let codex = SessionIdentity::new(SessionProvider::Codex, id);
+        let cursor = SessionIdentity::new(SessionProvider::Cursor, id);
+
+        assert_ne!(claude, codex);
+        assert_ne!(codex, cursor);
+        assert_eq!(claude.key(), "claudeCode:same-session-id");
+        assert_eq!(codex.key(), "codex:same-session-id");
+        assert_eq!(cursor.key(), "cursor:same-session-id");
     }
 }

--- a/src-tauri/src/session/source.rs
+++ b/src-tauri/src/session/source.rs
@@ -3,6 +3,7 @@ use std::path::PathBuf;
 use thiserror::Error;
 
 use super::codex::CodexRolloutSummary;
+use super::cursor::CursorTranscriptSummary;
 
 #[derive(Error, Debug)]
 pub enum SessionDetectorError {
@@ -41,6 +42,7 @@ pub enum SessionProvider {
     #[default]
     ClaudeCode,
     Codex,
+    Cursor,
 }
 
 #[derive(Debug, Clone, Copy, Serialize, Deserialize, Default, PartialEq, Eq)]
@@ -52,6 +54,7 @@ pub enum SessionSurface {
     Cli,
     Exec,
     Integration,
+    Cursor,
     Unknown,
 }
 
@@ -110,6 +113,8 @@ pub struct DetectedSession {
     pub can_rename: bool,
     #[serde(skip)]
     pub codex_summary: Option<CodexRolloutSummary>,
+    #[serde(skip)]
+    pub cursor_summary: Option<CursorTranscriptSummary>,
 }
 
 fn default_true() -> bool {
@@ -148,6 +153,7 @@ impl DetectedSession {
             can_stop: true,
             can_rename: true,
             codex_summary: None,
+            cursor_summary: None,
         }
     }
 }
@@ -219,6 +225,14 @@ mod tests {
         assert_eq!(
             serde_json::to_string(&SessionProvider::Codex).unwrap(),
             "\"codex\""
+        );
+        assert_eq!(
+            serde_json::to_string(&SessionProvider::Cursor).unwrap(),
+            "\"cursor\""
+        );
+        assert_eq!(
+            serde_json::to_string(&SessionSurface::Cursor).unwrap(),
+            "\"cursor\""
         );
         assert_eq!(
             serde_json::to_string(&SessionSurface::Integration).unwrap(),

--- a/src-tauri/src/session/state.rs
+++ b/src-tauri/src/session/state.rs
@@ -1,5 +1,6 @@
 // src-tauri/src/session/state.rs
 use super::codex::CodexSessionSource;
+use super::cursor::CursorSessionSource;
 use super::source::{DetectedSession, DetectionDiagnostics, SessionDetectorError, SessionSource};
 use super::{create_session_source, mode_from_env, BackendMode};
 use crate::session::detector::LegacySessionSource;
@@ -14,6 +15,7 @@ pub struct DetectorState {
     telemetry_counter: Arc<AtomicU32>,
     mode: BackendMode,
     codex_source: Option<CodexSessionSource>,
+    cursor_source: Option<CursorSessionSource>,
 }
 
 impl DetectorState {
@@ -24,6 +26,7 @@ impl DetectorState {
             telemetry_counter: Arc::new(AtomicU32::new(0)),
             mode: mode_from_env(),
             codex_source: CodexSessionSource::new().ok(),
+            cursor_source: CursorSessionSource::new().ok(),
         }
     }
 
@@ -32,11 +35,15 @@ impl DetectorState {
     ) -> Result<(Vec<DetectedSession>, DetectionDiagnostics), SessionDetectorError> {
         let claude_result = self.source.detect();
         let codex_result = self.codex_source.as_mut().map(SessionSource::detect);
+        let cursor_result = self.cursor_source.as_mut().map(SessionSource::detect);
         match claude_result {
             Ok((mut sessions, diagnostics)) => {
                 self.consecutive_failures = 0;
-                if let Some(Ok((mut codex_sessions, _))) = codex_result {
-                    sessions.append(&mut codex_sessions);
+                if let Some(Ok((mut extra, _))) = codex_result {
+                    sessions.append(&mut extra);
+                }
+                if let Some(Ok((mut extra, _))) = cursor_result {
+                    sessions.append(&mut extra);
                 }
                 Ok((sessions, diagnostics))
             }
@@ -45,10 +52,20 @@ impl DetectorState {
                 if self.should_downgrade() {
                     self.downgrade_to_legacy();
                 }
-                if let Some(Ok((codex_sessions, diagnostics))) = codex_result {
-                    if !codex_sessions.is_empty() {
-                        return Ok((codex_sessions, diagnostics));
+                let mut fallback = Vec::new();
+                let mut diagnostics = DetectionDiagnostics::default();
+                if let Some(Ok((sessions, extra))) = codex_result {
+                    fallback.extend(sessions);
+                    diagnostics = extra;
+                }
+                if let Some(Ok((sessions, extra))) = cursor_result {
+                    fallback.extend(sessions);
+                    if diagnostics.claude_processes_found == 0 {
+                        diagnostics = extra;
                     }
+                }
+                if !fallback.is_empty() {
+                    return Ok((fallback, diagnostics));
                 }
                 Err(e)
             }
@@ -99,6 +116,7 @@ impl DetectorState {
             telemetry_counter: Arc::new(AtomicU32::new(0)),
             mode,
             codex_source: None,
+            cursor_source: None,
         }
     }
 

--- a/src-tauri/src/session/state.rs
+++ b/src-tauri/src/session/state.rs
@@ -1,6 +1,5 @@
 // src-tauri/src/session/state.rs
-use super::codex::CodexSessionSource;
-use super::cursor::CursorSessionSource;
+use super::owners::{global_provider_source_owners, ProviderSourceOwners};
 use super::source::{DetectedSession, DetectionDiagnostics, SessionDetectorError, SessionSource};
 use super::{create_session_source, mode_from_env, BackendMode};
 use crate::session::detector::LegacySessionSource;
@@ -14,8 +13,7 @@ pub struct DetectorState {
     consecutive_failures: u32,
     telemetry_counter: Arc<AtomicU32>,
     mode: BackendMode,
-    codex_source: Option<CodexSessionSource>,
-    cursor_source: Option<CursorSessionSource>,
+    provider_sources: ProviderSourceOwners,
 }
 
 impl DetectorState {
@@ -25,8 +23,7 @@ impl DetectorState {
             consecutive_failures: 0,
             telemetry_counter: Arc::new(AtomicU32::new(0)),
             mode: mode_from_env(),
-            codex_source: CodexSessionSource::new().ok(),
-            cursor_source: CursorSessionSource::new().ok(),
+            provider_sources: global_provider_source_owners(),
         }
     }
 
@@ -34,15 +31,15 @@ impl DetectorState {
         &mut self,
     ) -> Result<(Vec<DetectedSession>, DetectionDiagnostics), SessionDetectorError> {
         let claude_result = self.source.detect();
-        let codex_result = self.codex_source.as_mut().map(SessionSource::detect);
-        let cursor_result = self.cursor_source.as_mut().map(SessionSource::detect);
+        let codex_result = self.provider_sources.detect_codex();
+        let cursor_result = self.provider_sources.detect_cursor();
         match claude_result {
             Ok((mut sessions, diagnostics)) => {
                 self.consecutive_failures = 0;
-                if let Some(Ok((mut extra, _))) = codex_result {
+                if let Some((mut extra, _)) = codex_result {
                     sessions.append(&mut extra);
                 }
-                if let Some(Ok((mut extra, _))) = cursor_result {
+                if let Some((mut extra, _)) = cursor_result {
                     sessions.append(&mut extra);
                 }
                 Ok((sessions, diagnostics))
@@ -54,11 +51,11 @@ impl DetectorState {
                 }
                 let mut fallback = Vec::new();
                 let mut diagnostics = DetectionDiagnostics::default();
-                if let Some(Ok((sessions, extra))) = codex_result {
+                if let Some((sessions, extra)) = codex_result {
                     fallback.extend(sessions);
                     diagnostics = extra;
                 }
-                if let Some(Ok((sessions, extra))) = cursor_result {
+                if let Some((sessions, extra)) = cursor_result {
                     fallback.extend(sessions);
                     if diagnostics.claude_processes_found == 0 {
                         diagnostics = extra;
@@ -115,8 +112,7 @@ impl DetectorState {
             consecutive_failures: 0,
             telemetry_counter: Arc::new(AtomicU32::new(0)),
             mode,
-            codex_source: None,
-            cursor_source: None,
+            provider_sources: ProviderSourceOwners::from_test_sources(None, None),
         }
     }
 

--- a/src-tauri/src/session/state.rs
+++ b/src-tauri/src/session/state.rs
@@ -1,8 +1,6 @@
 // src-tauri/src/session/state.rs
 use super::codex::CodexSessionSource;
-use super::source::{
-    DetectedSession, DetectionDiagnostics, SessionDetectorError, SessionSource,
-};
+use super::source::{DetectedSession, DetectionDiagnostics, SessionDetectorError, SessionSource};
 use super::{create_session_source, mode_from_env, BackendMode};
 use crate::session::detector::LegacySessionSource;
 use std::sync::atomic::{AtomicU32, Ordering};
@@ -124,12 +122,17 @@ mod tests {
 
     impl FakeSource {
         fn new(name: &'static str, fails: u32) -> Self {
-            Self { name, fail_next: Cell::new(fails) }
+            Self {
+                name,
+                fail_next: Cell::new(fails),
+            }
         }
     }
 
     impl SessionSource for FakeSource {
-        fn detect(&mut self) -> Result<(Vec<DetectedSession>, DetectionDiagnostics), SessionDetectorError> {
+        fn detect(
+            &mut self,
+        ) -> Result<(Vec<DetectedSession>, DetectionDiagnostics), SessionDetectorError> {
             let n = self.fail_next.get();
             if n > 0 {
                 self.fail_next.set(n - 1);
@@ -137,7 +140,9 @@ mod tests {
             }
             Ok((Vec::new(), DetectionDiagnostics::default()))
         }
-        fn backend_name(&self) -> &'static str { self.name }
+        fn backend_name(&self) -> &'static str {
+            self.name
+        }
     }
 
     #[test]
@@ -167,7 +172,8 @@ mod tests {
 
     #[test]
     fn force_cli_mode_never_downgrades() {
-        let mut s = DetectorState::for_test(Box::new(FakeSource::new("cli", 20)), BackendMode::ForceCli);
+        let mut s =
+            DetectorState::for_test(Box::new(FakeSource::new("cli", 20)), BackendMode::ForceCli);
         for _ in 0..20 {
             let _ = s.detect();
         }
@@ -176,7 +182,8 @@ mod tests {
 
     #[test]
     fn legacy_backend_failures_do_not_swap() {
-        let mut s = DetectorState::for_test(Box::new(FakeSource::new("legacy", 10)), BackendMode::Auto);
+        let mut s =
+            DetectorState::for_test(Box::new(FakeSource::new("legacy", 10)), BackendMode::Auto);
         for _ in 0..10 {
             let _ = s.detect();
         }
@@ -186,17 +193,24 @@ mod tests {
     #[test]
     fn counter_resets_on_success_between_failures() {
         let mut s = DetectorState::for_test(Box::new(FakeSource::new("cli", 3)), BackendMode::Auto);
-        for _ in 0..3 { let _ = s.detect(); }
+        for _ in 0..3 {
+            let _ = s.detect();
+        }
         let _ = s.detect();
         assert_eq!(s.consecutive_failures, 0);
         s.replace_source(Box::new(FakeSource::new("cli", 3)));
-        for _ in 0..3 { let _ = s.detect(); }
+        for _ in 0..3 {
+            let _ = s.detect();
+        }
         assert_eq!(s.backend_name(), "cli");
     }
 
     #[test]
     fn recheck_no_swap_in_force_modes() {
-        let mut s = DetectorState::for_test(Box::new(FakeSource::new("cli", 0)), BackendMode::ForceLegacy);
+        let mut s = DetectorState::for_test(
+            Box::new(FakeSource::new("cli", 0)),
+            BackendMode::ForceLegacy,
+        );
         s.recheck_and_maybe_swap();
         assert_eq!(s.backend_name(), "cli");
     }

--- a/src-tauri/src/session/status.rs
+++ b/src-tauri/src/session/status.rs
@@ -214,17 +214,13 @@ fn is_assistant_asking_question(message: &AssistantMessage) -> bool {
 
     // Pattern 2: Last text block ends with '?' and stop_reason is end_turn
     if message.stop_reason.as_deref() == Some("end_turn") {
-        let last_text = message
-            .content
-            .iter()
-            .rev()
-            .find_map(|c| {
-                if let MessageContent::Text { text } = c {
-                    Some(text.as_str())
-                } else {
-                    None
-                }
-            });
+        let last_text = message.content.iter().rev().find_map(|c| {
+            if let MessageContent::Text { text } = c {
+                Some(text.as_str())
+            } else {
+                None
+            }
+        });
 
         if let Some(text) = last_text {
             let trimmed = text.trim();
@@ -1199,7 +1195,10 @@ mod tests {
                 usage: None,
             },
         }];
-        assert_eq!(get_pending_tool_name(&entries), Some("Question".to_string()));
+        assert_eq!(
+            get_pending_tool_name(&entries),
+            Some("Question".to_string())
+        );
     }
 
     #[test]

--- a/src-tauri/src/session/subagents.rs
+++ b/src-tauri/src/session/subagents.rs
@@ -658,8 +658,8 @@ pub fn get_subagent_transcript(
     None
 }
 
-/// Build a map of parent_session_id -> subagents for all sessions found under
-/// `~/.claude/projects/`. Caller filters/joins as needed.
+/// Build a map of provider-scoped parent identity -> subagents for all Claude
+/// sessions found under `~/.claude/projects/`. Caller filters/joins as needed.
 pub fn all_subagents_by_session() -> HashMap<String, Vec<SubagentInfo>> {
     let mut out: HashMap<String, Vec<SubagentInfo>> = HashMap::new();
     let Some(home) = dirs::home_dir() else {
@@ -687,7 +687,7 @@ pub fn all_subagents_by_session() -> HashMap<String, Vec<SubagentInfo>> {
             };
             let subs = active_subagents_for_path(stem, &path);
             if !subs.is_empty() {
-                out.insert(stem.to_string(), subs);
+                out.insert(format!("claudeCode:{stem}"), subs);
             }
         }
     }

--- a/src-tauri/src/session/subagents.rs
+++ b/src-tauri/src/session/subagents.rs
@@ -145,7 +145,9 @@ fn collect_user_tool_result_ids<P: AsRef<Path>>(path: P) -> HashMap<String, Stri
         if line.trim().is_empty() {
             continue;
         }
-        let Ok(value) = serde_json::from_str::<Value>(&line) else { continue };
+        let Ok(value) = serde_json::from_str::<Value>(&line) else {
+            continue;
+        };
         let entry_type = value.get("type").and_then(Value::as_str).unwrap_or("");
         if entry_type != "user" {
             continue;
@@ -164,9 +166,7 @@ fn collect_user_tool_result_ids<P: AsRef<Path>>(path: P) -> HashMap<String, Stri
         };
         for block in content {
             if block.get("type").and_then(Value::as_str) == Some("tool_result") {
-                if let Some(tool_use_id) =
-                    block.get("tool_use_id").and_then(Value::as_str)
-                {
+                if let Some(tool_use_id) = block.get("tool_use_id").and_then(Value::as_str) {
                     completed
                         .entry(tool_use_id.to_string())
                         .or_insert_with(|| timestamp.clone());
@@ -264,7 +264,9 @@ fn extract_transcript_from_file<P: AsRef<Path>>(
         if line.trim().is_empty() || !line.contains(subagent_id) {
             continue;
         }
-        let Ok(value) = serde_json::from_str::<Value>(line) else { continue };
+        let Ok(value) = serde_json::from_str::<Value>(line) else {
+            continue;
+        };
         let entry_type = value.get("type").and_then(Value::as_str).unwrap_or("");
         let timestamp = value
             .get("timestamp")
@@ -403,7 +405,9 @@ fn extract_transcript_from_file<P: AsRef<Path>>(
             if line.trim().is_empty() || !line.contains(aid) {
                 continue;
             }
-            let Ok(value) = serde_json::from_str::<Value>(line) else { continue };
+            let Ok(value) = serde_json::from_str::<Value>(line) else {
+                continue;
+            };
             let entry_type = value.get("type").and_then(Value::as_str).unwrap_or("");
             let timestamp = value
                 .get("timestamp")
@@ -447,9 +451,7 @@ fn extract_transcript_from_file<P: AsRef<Path>>(
                     }
                 }
                 async_result = match async_result {
-                    Some((prev_ts, prev_text)) if prev_ts > timestamp => {
-                        Some((prev_ts, prev_text))
-                    }
+                    Some((prev_ts, prev_text)) if prev_ts > timestamp => Some((prev_ts, prev_text)),
                     _ => Some((timestamp.clone(), result_body)),
                 };
                 continue;
@@ -466,8 +468,7 @@ fn extract_transcript_from_file<P: AsRef<Path>>(
                 .map(|blocks| {
                     blocks.iter().any(|b| {
                         b.get("type").and_then(Value::as_str) == Some("tool_result")
-                            && b.get("tool_use_id").and_then(Value::as_str)
-                                == Some(subagent_id)
+                            && b.get("tool_use_id").and_then(Value::as_str) == Some(subagent_id)
                     })
                 })
                 .unwrap_or(false);
@@ -501,9 +502,7 @@ fn extract_transcript_from_file<P: AsRef<Path>>(
                 }
             }
             async_result = match async_result {
-                Some((prev_ts, prev_text)) if prev_ts > timestamp => {
-                    Some((prev_ts, prev_text))
-                }
+                Some((prev_ts, prev_text)) if prev_ts > timestamp => Some((prev_ts, prev_text)),
                 _ => Some((timestamp.clone(), result_text)),
             };
         }
@@ -547,9 +546,8 @@ fn parse_agent_id_from_stub(text: &str) -> Option<String> {
         while let Some(rel) = text[search_from..].find(key) {
             let idx = search_from + rel + key.len();
             // Advance past any quote/colon/space/equals chars.
-            let rest = text[idx..].trim_start_matches(|c: char| {
-                matches!(c, ':' | '=' | ' ' | '\t' | '"' | '\'')
-            });
+            let rest = text[idx..]
+                .trim_start_matches(|c: char| matches!(c, ':' | '=' | ' ' | '\t' | '"' | '\''));
             let candidate: String = rest
                 .chars()
                 .take_while(|c| c.is_ascii_hexdigit() || *c == '-' || *c == '_')
@@ -567,7 +565,9 @@ fn parse_agent_id_from_stub(text: &str) -> Option<String> {
 /// Concatenate user-message text content. Handles both plain string form
 /// (`content: "..."`) and structured block form (`content: [{type:text, text:"..."}]`).
 fn extract_user_message_text(content: Option<&Value>) -> String {
-    let Some(content) = content else { return String::new() };
+    let Some(content) = content else {
+        return String::new();
+    };
     if let Some(s) = content.as_str() {
         return s.to_string();
     }
@@ -618,12 +618,9 @@ fn collect_text_blocks(blocks: &[Value]) -> String {
 }
 
 fn extract_usage_stats(usage_str: &str) -> (Option<u64>, Option<u64>, Option<u64>) {
-    let total_tokens = extract_tag(usage_str, "total_tokens")
-        .and_then(|s| s.parse::<u64>().ok());
-    let tool_uses = extract_tag(usage_str, "tool_uses")
-        .and_then(|s| s.parse::<u64>().ok());
-    let duration_ms = extract_tag(usage_str, "duration_ms")
-        .and_then(|s| s.parse::<u64>().ok());
+    let total_tokens = extract_tag(usage_str, "total_tokens").and_then(|s| s.parse::<u64>().ok());
+    let tool_uses = extract_tag(usage_str, "tool_uses").and_then(|s| s.parse::<u64>().ok());
+    let duration_ms = extract_tag(usage_str, "duration_ms").and_then(|s| s.parse::<u64>().ok());
     (total_tokens, tool_uses, duration_ms)
 }
 
@@ -641,13 +638,17 @@ pub fn get_subagent_transcript(
         if !project_path.is_dir() {
             continue;
         }
-        let Ok(file_iter) = fs::read_dir(&project_path) else { continue };
+        let Ok(file_iter) = fs::read_dir(&project_path) else {
+            continue;
+        };
         for file_entry in file_iter.flatten() {
             let path = file_entry.path();
             if path.extension().and_then(|s| s.to_str()) != Some("jsonl") {
                 continue;
             }
-            let Some(stem) = path.file_stem().and_then(|s| s.to_str()) else { continue };
+            let Some(stem) = path.file_stem().and_then(|s| s.to_str()) else {
+                continue;
+            };
             if stem != parent_session_id {
                 continue;
             }
@@ -673,13 +674,17 @@ pub fn all_subagents_by_session() -> HashMap<String, Vec<SubagentInfo>> {
         if !project_path.is_dir() {
             continue;
         }
-        let Ok(file_iter) = fs::read_dir(&project_path) else { continue };
+        let Ok(file_iter) = fs::read_dir(&project_path) else {
+            continue;
+        };
         for file_entry in file_iter.flatten() {
             let path = file_entry.path();
             if path.extension().and_then(|s| s.to_str()) != Some("jsonl") {
                 continue;
             }
-            let Some(stem) = path.file_stem().and_then(|s| s.to_str()) else { continue };
+            let Some(stem) = path.file_stem().and_then(|s| s.to_str()) else {
+                continue;
+            };
             let subs = active_subagents_for_path(stem, &path);
             if !subs.is_empty() {
                 out.insert(stem.to_string(), subs);
@@ -727,7 +732,10 @@ mod tests {
         let subs = active_subagents_for_path("s1", f.path());
         assert_eq!(subs.len(), 1);
         assert_eq!(subs[0].status, SubagentStatus::Completed);
-        assert_eq!(subs[0].completed_at.as_deref(), Some("2026-01-01T00:01:00Z"));
+        assert_eq!(
+            subs[0].completed_at.as_deref(),
+            Some("2026-01-01T00:01:00Z")
+        );
     }
 
     #[test]
@@ -755,8 +763,7 @@ mod tests {
         let f = write_jsonl(&[line, user]);
         let subs = active_subagents_for_path("s1", f.path());
         assert_eq!(subs.len(), 2);
-        let by_id: HashMap<&str, &SubagentInfo> =
-            subs.iter().map(|s| (s.id.as_str(), s)).collect();
+        let by_id: HashMap<&str, &SubagentInfo> = subs.iter().map(|s| (s.id.as_str(), s)).collect();
         assert_eq!(by_id["a1"].status, SubagentStatus::Completed);
         assert_eq!(by_id["a2"].status, SubagentStatus::Running);
     }
@@ -906,10 +913,7 @@ mod tests {
 
     #[test]
     fn extract_tag_helper() {
-        assert_eq!(
-            extract_tag("<a>foo</a>", "a"),
-            Some("foo".to_string())
-        );
+        assert_eq!(extract_tag("<a>foo</a>", "a"), Some("foo".to_string()));
         assert_eq!(
             extract_tag("x<result>multi\nline\nbody</result>y", "result"),
             Some("multi\nline\nbody".to_string())

--- a/src-tauri/src/web_server.rs
+++ b/src-tauri/src/web_server.rs
@@ -26,6 +26,7 @@ pub struct WsState {
     pub auth_token: String,
     pub sessions_tx: broadcast::Sender<String>,
     pub notifications_tx: broadcast::Sender<String>,
+    pub progress_tx: broadcast::Sender<String>,
 }
 
 // ── Protocol types ──────────────────────────────────────────────────
@@ -41,6 +42,8 @@ enum ClientMsg {
     GetConversation {
         #[serde(rename = "sessionId")]
         session_id: String,
+        #[serde(default, rename = "includeTools")]
+        include_tools: bool,
     },
 
     #[serde(rename = "stopSession")]
@@ -86,6 +89,9 @@ enum ServerMsg {
 
     #[serde(rename = "notification")]
     Notification { data: serde_json::Value },
+
+    #[serde(rename = "conversationProgress")]
+    ConversationProgress { data: serde_json::Value },
 
     #[serde(rename = "memoryFiles")]
     MemoryFiles { data: serde_json::Value },
@@ -193,6 +199,9 @@ async fn handle_socket(mut socket: WebSocket, state: Arc<WsState>) {
     crate::debug_log::log_info("[ws-server] Client connected");
     let mut sessions_rx = state.sessions_tx.subscribe();
     let mut notifications_rx = state.notifications_tx.subscribe();
+    let mut progress_rx = state.progress_tx.subscribe();
+
+    let mut inflight: Option<tokio::task::JoinHandle<ServerMsg>> = None;
 
     loop {
         tokio::select! {
@@ -201,15 +210,40 @@ async fn handle_socket(mut socket: WebSocket, state: Arc<WsState>) {
                 match msg {
                     Some(Ok(Message::Text(text))) => {
                         let text_str: &str = &text;
-                        let response = match serde_json::from_str::<ClientMsg>(text_str) {
-                            Ok(client_msg) => handle_message(client_msg).await,
-                            Err(e) => ServerMsg::Error {
-                                message: format!("Invalid message: {}", e),
-                            },
-                        };
-                        let json = serde_json::to_string(&response).unwrap_or_default();
-                        if socket.send(Message::Text(json)).await.is_err() {
-                            break;
+                        match serde_json::from_str::<ClientMsg>(text_str) {
+                            Ok(ClientMsg::GetConversation {
+                                session_id,
+                                include_tools,
+                            }) => {
+                                if let Some(previous) = inflight.take() {
+                                    previous.abort();
+                                }
+                                let progress_tx = state.progress_tx.clone();
+                                inflight = Some(tokio::spawn(async move {
+                                    load_conversation_response(
+                                        session_id,
+                                        include_tools,
+                                        progress_tx,
+                                    )
+                                    .await
+                                }));
+                            }
+                            Ok(client_msg) => {
+                                let response = handle_message(client_msg).await;
+                                let json = serde_json::to_string(&response).unwrap_or_default();
+                                if socket.send(Message::Text(json)).await.is_err() {
+                                    break;
+                                }
+                            }
+                            Err(e) => {
+                                let response = ServerMsg::Error {
+                                    message: format!("Invalid message: {}", e),
+                                };
+                                let json = serde_json::to_string(&response).unwrap_or_default();
+                                if socket.send(Message::Text(json)).await.is_err() {
+                                    break;
+                                }
+                            }
                         }
                     }
                     Some(Ok(Message::Ping(data))) => {
@@ -219,6 +253,25 @@ async fn handle_socket(mut socket: WebSocket, state: Arc<WsState>) {
                     }
                     Some(Ok(Message::Close(_))) | None => break,
                     _ => {}
+                }
+            }
+            result = async {
+                match inflight.as_mut() {
+                    Some(handle) => Some(handle.await),
+                    None => std::future::pending().await,
+                }
+            } => {
+                inflight = None;
+                let response = match result {
+                    Some(Ok(response)) => response,
+                    Some(Err(error)) => ServerMsg::Error {
+                        message: format!("Failed to load conversation: {error}"),
+                    },
+                    None => continue,
+                };
+                let json = serde_json::to_string(&response).unwrap_or_default();
+                if socket.send(Message::Text(json)).await.is_err() {
+                    break;
                 }
             }
             // Push session updates from polling loop
@@ -241,6 +294,15 @@ async fn handle_socket(mut socket: WebSocket, state: Arc<WsState>) {
                     break;
                 }
             }
+            Ok(progress_json) = progress_rx.recv() => {
+                let msg = ServerMsg::ConversationProgress {
+                    data: serde_json::from_str(&progress_json).unwrap_or_default(),
+                };
+                let json = serde_json::to_string(&msg).unwrap_or_default();
+                if socket.send(Message::Text(json)).await.is_err() {
+                    break;
+                }
+            }
         }
     }
 
@@ -248,6 +310,38 @@ async fn handle_socket(mut socket: WebSocket, state: Arc<WsState>) {
 }
 
 // ── Message dispatch ────────────────────────────────────────────────
+
+async fn load_conversation_response(
+    session_id: String,
+    include_tools: bool,
+    progress_tx: broadcast::Sender<String>,
+) -> ServerMsg {
+    let emit_id = session_id.clone();
+    match tokio::task::spawn_blocking(move || {
+        crate::get_conversation_data_with_progress(
+            &session_id,
+            include_tools,
+            &mut |bytes_read, bytes_total| {
+                let payload = serde_json::json!({
+                    "sessionId": emit_id,
+                    "bytesRead": bytes_read,
+                    "bytesTotal": bytes_total,
+                });
+                let _ = progress_tx.send(payload.to_string());
+            },
+        )
+    })
+    .await
+    {
+        Ok(Ok(conv)) => ServerMsg::Conversation {
+            data: serde_json::to_value(&conv).unwrap_or_default(),
+        },
+        Ok(Err(e)) => ServerMsg::Error { message: e },
+        Err(e) => ServerMsg::Error {
+            message: format!("Failed to load conversation: {e}"),
+        },
+    }
+}
 
 async fn handle_message(msg: ClientMsg) -> ServerMsg {
     match msg {
@@ -258,13 +352,15 @@ async fn handle_message(msg: ClientMsg) -> ServerMsg {
             Err(e) => ServerMsg::Error { message: e },
         },
 
-        ClientMsg::GetConversation { session_id } => {
-            match crate::get_conversation_data(&session_id) {
-                Ok(conv) => ServerMsg::Conversation {
-                    data: serde_json::to_value(&conv).unwrap_or_default(),
-                },
-                Err(e) => ServerMsg::Error { message: e },
-            }
+        ClientMsg::GetConversation {
+            session_id,
+            include_tools,
+        } => {
+            load_conversation_response(session_id, include_tools, {
+                let (tx, _) = broadcast::channel(1);
+                tx
+            })
+            .await
         }
 
         ClientMsg::StopSession { pid } => match crate::actions::stop_session(pid) {

--- a/src-tauri/src/web_server.rs
+++ b/src-tauri/src/web_server.rs
@@ -41,6 +41,8 @@ enum ClientMsg {
     GetConversation {
         #[serde(rename = "sessionId")]
         session_id: String,
+        #[serde(default)]
+        provider: Option<crate::session::SessionProvider>,
     },
 
     #[serde(rename = "stopSession")]
@@ -59,6 +61,8 @@ enum ClientMsg {
         session_id: String,
         #[serde(rename = "newName")]
         new_name: String,
+        #[serde(default)]
+        provider: Option<crate::session::SessionProvider>,
     },
 
     #[serde(rename = "getMemoryFiles")]
@@ -250,6 +254,13 @@ async fn handle_socket(mut socket: WebSocket, state: Arc<WsState>) {
 // ── Message dispatch ────────────────────────────────────────────────
 
 async fn handle_message(msg: ClientMsg) -> ServerMsg {
+    handle_message_with_owners(msg, crate::session::global_provider_source_owners()).await
+}
+
+async fn handle_message_with_owners(
+    msg: ClientMsg,
+    owners: crate::session::ProviderSourceOwners,
+) -> ServerMsg {
     match msg {
         ClientMsg::GetSessions => match crate::polling::detect_and_enrich_sessions() {
             Ok(sessions) => ServerMsg::Sessions {
@@ -258,14 +269,15 @@ async fn handle_message(msg: ClientMsg) -> ServerMsg {
             Err(e) => ServerMsg::Error { message: e },
         },
 
-        ClientMsg::GetConversation { session_id } => {
-            match crate::get_conversation_data(&session_id) {
-                Ok(conv) => ServerMsg::Conversation {
-                    data: serde_json::to_value(&conv).unwrap_or_default(),
-                },
-                Err(e) => ServerMsg::Error { message: e },
-            }
-        }
+        ClientMsg::GetConversation {
+            session_id,
+            provider,
+        } => match crate::get_conversation_data_for_provider(&session_id, provider) {
+            Ok(conv) => ServerMsg::Conversation {
+                data: serde_json::to_value(&conv).unwrap_or_default(),
+            },
+            Err(e) => ServerMsg::Error { message: e },
+        },
 
         ClientMsg::StopSession { pid } => match crate::actions::stop_session(pid) {
             Ok(()) => ServerMsg::Ok,
@@ -282,13 +294,16 @@ async fn handle_message(msg: ClientMsg) -> ServerMsg {
         ClientMsg::RenameSession {
             session_id,
             new_name,
+            provider,
         } => {
-            // Write to Claude Code's native JSONL format
-            crate::write_native_custom_title(&session_id, &new_name);
-            // Also write to c9watch's own custom titles (fallback)
-            let mut custom_titles = crate::session::CustomTitles::load();
-            custom_titles.set(session_id, new_name);
-            match custom_titles.save() {
+            match crate::run_validated_rename(provider, &session_id, &owners, || {
+                // Write to Claude Code's native JSONL format
+                crate::write_native_custom_title(&session_id, &new_name);
+                // Also write to c9watch's own custom titles (fallback)
+                let mut custom_titles = crate::session::CustomTitles::load();
+                custom_titles.set(session_id.clone(), new_name.clone());
+                custom_titles.save()
+            }) {
                 Ok(()) => ServerMsg::Ok,
                 Err(e) => ServerMsg::Error { message: e },
             }
@@ -300,5 +315,117 @@ async fn handle_message(msg: ClientMsg) -> ServerMsg {
             },
             Err(e) => ServerMsg::Error { message: e },
         },
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const SESSION_ID: &str = "eeeeeeee-eeee-eeee-eeee-eeeeeeeeeeee";
+
+    fn synthetic_cursor_owner(temp: &tempfile::TempDir) -> crate::session::ProviderSourceOwners {
+        let transcript_dir = temp
+            .path()
+            .join("synthetic-project")
+            .join("agent-transcripts")
+            .join(SESSION_ID);
+        std::fs::create_dir_all(&transcript_dir).unwrap();
+        std::fs::write(
+            transcript_dir.join(format!("{SESSION_ID}.jsonl")),
+            b"{\"role\":\"user\",\"message\":{\"content\":[]}}\n",
+        )
+        .unwrap();
+
+        crate::session::ProviderSourceOwners::from_test_sources(
+            None,
+            Some(crate::session::cursor::CursorSessionSource::at_root(
+                temp.path().to_path_buf(),
+            )),
+        )
+    }
+
+    fn synthetic_codex_owner(temp: &tempfile::TempDir) -> crate::session::ProviderSourceOwners {
+        let rollout_dir = temp.path().join("2026").join("08").join("24");
+        std::fs::create_dir_all(&rollout_dir).unwrap();
+        std::fs::write(
+            rollout_dir.join(format!("rollout-synthetic-{SESSION_ID}.jsonl")),
+            b"{}\n",
+        )
+        .unwrap();
+
+        crate::session::ProviderSourceOwners::from_test_sources(
+            Some(crate::session::codex::CodexSessionSource::at_root(
+                temp.path().to_path_buf(),
+            )),
+            None,
+        )
+    }
+
+    #[test]
+    fn rename_message_keeps_provider_namespace_for_validation() {
+        let message: ClientMsg = serde_json::from_value(serde_json::json!({
+            "type": "renameSession",
+            "sessionId": "same-id",
+            "newName": "synthetic",
+            "provider": "cursor"
+        }))
+        .unwrap();
+
+        match message {
+            ClientMsg::RenameSession { provider, .. } => {
+                assert_eq!(provider, Some(crate::session::SessionProvider::Cursor));
+                assert!(crate::session::validate_rename_provider(provider).is_err());
+            }
+            _ => panic!("expected rename message"),
+        }
+    }
+
+    #[test]
+    fn legacy_rename_message_keeps_compatibility_shape() {
+        let message: ClientMsg = serde_json::from_value(serde_json::json!({
+            "type": "renameSession",
+            "sessionId": "legacy-id",
+            "newName": "synthetic"
+        }))
+        .unwrap();
+
+        match message {
+            ClientMsg::RenameSession { provider, .. } => {
+                assert!(provider.is_none());
+                assert!(crate::session::validate_rename_provider(provider).is_ok());
+            }
+            _ => panic!("expected rename message"),
+        }
+    }
+
+    #[tokio::test]
+    async fn websocket_rename_collision_rejects_before_custom_title_write() {
+        let cursor_temp = tempfile::tempdir().unwrap();
+        let codex_temp = tempfile::tempdir().unwrap();
+        let owners = [
+            synthetic_cursor_owner(&cursor_temp),
+            synthetic_codex_owner(&codex_temp),
+        ];
+
+        for owners in owners {
+            let response = handle_message_with_owners(
+                ClientMsg::RenameSession {
+                    session_id: SESSION_ID.to_string(),
+                    new_name: "synthetic collision".to_string(),
+                    provider: None,
+                },
+                owners,
+            )
+            .await;
+
+            match response {
+                ServerMsg::Error { message } => {
+                    assert!(message.contains("requires an explicit provider"));
+                }
+                ServerMsg::Ok => panic!("collision must not reach title writes"),
+                other => panic!("unexpected WebSocket response: {other:?}"),
+            }
+        }
     }
 }

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "c9watch",
-  "version": "0.9.0",
+  "version": "0.10.0",
   "identifier": "com.minchenlee.c9watch",
   "build": {
     "beforeDevCommand": "npm run dev",

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "c9watch",
-  "version": "0.8.1",
+  "version": "0.9.0",
   "identifier": "com.minchenlee.c9watch",
   "build": {
     "beforeDevCommand": "npm run dev",

--- a/src-tauri/tests/bg_round_trip.rs
+++ b/src-tauri/tests/bg_round_trip.rs
@@ -29,12 +29,21 @@ struct StopGuard {
     disarmed: bool,
 }
 impl StopGuard {
-    fn new(short: String) -> Self { Self { short, disarmed: false } }
-    fn disarm(&mut self) { self.disarmed = true; }
+    fn new(short: String) -> Self {
+        Self {
+            short,
+            disarmed: false,
+        }
+    }
+    fn disarm(&mut self) {
+        self.disarmed = true;
+    }
 }
 impl Drop for StopGuard {
     fn drop(&mut self) {
-        if self.disarmed { return; }
+        if self.disarmed {
+            return;
+        }
         eprintln!("[guard] cleaning up {}", self.short);
         let _ = Command::new("claude").arg("stop").arg(&self.short).status();
         let _ = Command::new("claude").arg("rm").arg(&self.short).status();
@@ -76,41 +85,58 @@ async fn bg_round_trip_inner() -> Result<()> {
 
     let mut guard = StopGuard::new(short.clone());
 
-    let stream = UnixStream::connect(&socket).await
+    let stream = UnixStream::connect(&socket)
+        .await
         .with_context(|| format!("step 3: connect to {}", socket))?;
     let (rd, mut wr) = stream.into_split();
     let mut reader = BufReader::new(rd).lines();
     println!("[connect] unix stream open");
 
     write_line(&mut wr, &json!({"proto":1,"op":"subscribe","short":short}))
-        .await.context("step 4: write subscribe")?;
+        .await
+        .context("step 4: write subscribe")?;
     println!("[subscribe] sent");
 
-    drain_initial_snapshot(&mut reader).await.context("step 4a: drain snapshot")?;
+    drain_initial_snapshot(&mut reader)
+        .await
+        .context("step 4a: drain snapshot")?;
 
     // Turn 1: the prompt we passed at spawn. Subscribing here catches the
     // mid-flight active→idle state patch reliably (verified manually).
-    let d1 = wait_for_idle(&mut reader, &short, "turn-1").await
+    let d1 = wait_for_idle(&mut reader, &short, "turn-1")
+        .await
         .context("step 5: wait for turn-1 idle")?;
     println!("[turn-1 detail] {:?}", d1);
 
     // Turn 2: send via the `reply` verb. Field is `text` (not message/prompt).
-    write_line(&mut wr, &json!({
-        "proto":1, "op":"reply", "short":short,
-        "text":"now say DONE in all caps and nothing else"
-    })).await.context("step 6: write turn-2 reply")?;
+    write_line(
+        &mut wr,
+        &json!({
+            "proto":1, "op":"reply", "short":short,
+            "text":"now say DONE in all caps and nothing else"
+        }),
+    )
+    .await
+    .context("step 6: write turn-2 reply")?;
     println!("[send] turn-2 reply sent");
 
-    let d2 = wait_for_idle(&mut reader, &short, "turn-2").await
+    let d2 = wait_for_idle(&mut reader, &short, "turn-2")
+        .await
         .context("step 7: wait for turn-2 idle")?;
     println!("[turn-2 detail] {:?}", d2);
 
-    let stop = Command::new("claude").arg("stop").arg(&short).status()
+    let stop = Command::new("claude")
+        .arg("stop")
+        .arg(&short)
+        .status()
         .context("step 8a: `claude stop`")?;
     println!("[stop] exit={}", stop.code().unwrap_or(-1));
     assert_eq!(stop.code().unwrap_or(-1), 0, "claude stop failed");
 
-    let rm = Command::new("claude").arg("rm").arg(&short).status()
+    let rm = Command::new("claude")
+        .arg("rm")
+        .arg(&short)
+        .status()
         .context("step 8b: `claude rm`")?;
     println!("[rm] exit={}", rm.code().unwrap_or(-1));
     assert_eq!(rm.code().unwrap_or(-1), 0, "claude rm failed");
@@ -124,7 +150,9 @@ async fn bg_round_trip_inner() -> Result<()> {
 }
 
 async fn write_line<W>(w: &mut W, v: &Value) -> Result<()>
-where W: tokio::io::AsyncWrite + Unpin {
+where
+    W: tokio::io::AsyncWrite + Unpin,
+{
     w.write_all(format!("{}\n", v).as_bytes()).await?;
     Ok(())
 }
@@ -138,12 +166,19 @@ fn resolve_socket() -> Result<String> {
         .flatten()
     {
         let p = e.path().join("control.sock");
-        if p.exists() { hits.push(p.to_string_lossy().into_owned()); }
+        if p.exists() {
+            hits.push(p.to_string_lossy().into_owned());
+        }
     }
     match hits.len() {
         0 => bail!("no control.sock under {} (CC >= 2.1.145 required)", parent),
         1 => Ok(hits.remove(0)),
-        n => bail!("expected 1 host-id subdir under {}, found {}: {:?}", parent, n, hits),
+        n => bail!(
+            "expected 1 host-id subdir under {}, found {}: {:?}",
+            parent,
+            n,
+            hits
+        ),
     }
 }
 
@@ -157,11 +192,16 @@ fn spawn_bg(name: &str) -> Result<(String, String)> {
         let out = Command::new("claude")
             .args(["--bg", "--name", name, "--model", model, prompt])
             .current_dir("/tmp")
-            .stdout(Stdio::piped()).stderr(Stdio::piped())
-            .output().with_context(|| format!("spawn claude --bg --model {}", model))?;
+            .stdout(Stdio::piped())
+            .stderr(Stdio::piped())
+            .output()
+            .with_context(|| format!("spawn claude --bg --model {}", model))?;
         if !out.status.success() {
-            eprintln!("[spawn] model={} rejected: {}", model,
-                String::from_utf8_lossy(&out.stderr).trim());
+            eprintln!(
+                "[spawn] model={} rejected: {}",
+                model,
+                String::from_utf8_lossy(&out.stderr).trim()
+            );
             continue;
         }
         let stdout = String::from_utf8_lossy(&out.stdout);
@@ -175,16 +215,20 @@ fn spawn_bg(name: &str) -> Result<(String, String)> {
 fn parse_short(stdout: &str) -> Result<String> {
     // "backgrounded · <8hex> [· name]" or with "(idle ...)" suffix.
     let re = Regex::new(r"backgrounded\s*[·•]\s*([0-9a-f]{8})").unwrap();
-    stdout.lines()
+    stdout
+        .lines()
         .find_map(|l| re.captures(l).map(|c| c[1].to_string()))
         .ok_or_else(|| anyhow!("no `backgrounded · <short>` line found"))
 }
 
 async fn drain_initial_snapshot<R>(reader: &mut tokio::io::Lines<BufReader<R>>) -> Result<()>
-where R: tokio::io::AsyncRead + Unpin {
+where
+    R: tokio::io::AsyncRead + Unpin,
+{
     let deadline = Instant::now() + Duration::from_secs(5);
     loop {
-        let rem = deadline.checked_duration_since(Instant::now())
+        let rem = deadline
+            .checked_duration_since(Instant::now())
             .ok_or_else(|| anyhow!("snapshot not received within 5s"))?;
         let line = match timeout(rem, reader.next_line()).await {
             Ok(Ok(Some(l))) => l,
@@ -192,10 +236,19 @@ where R: tokio::io::AsyncRead + Unpin {
             Ok(Err(e)) => bail!("read error: {}", e),
             Err(_) => bail!("snapshot not received within 5s"),
         };
-        let v: Value = match serde_json::from_str(&line) { Ok(v) => v, Err(_) => continue };
+        let v: Value = match serde_json::from_str(&line) {
+            Ok(v) => v,
+            Err(_) => continue,
+        };
         if v.get("type").and_then(|x| x.as_str()) == Some("snapshot") {
-            let tempo = v.pointer("/record/tempo").and_then(|x| x.as_str()).unwrap_or("?");
-            let state = v.pointer("/record/state").and_then(|x| x.as_str()).unwrap_or("?");
+            let tempo = v
+                .pointer("/record/tempo")
+                .and_then(|x| x.as_str())
+                .unwrap_or("?");
+            let state = v
+                .pointer("/record/state")
+                .and_then(|x| x.as_str())
+                .unwrap_or("?");
             println!("[event] initial snapshot tempo={} state={}", tempo, state);
             return Ok(());
         }
@@ -208,9 +261,12 @@ where R: tokio::io::AsyncRead + Unpin {
 /// 3. `claude agents --json` poll: busy→idle transition (out-of-band)
 async fn wait_for_idle<R>(
     reader: &mut tokio::io::Lines<BufReader<R>>,
-    short: &str, label: &str,
+    short: &str,
+    label: &str,
 ) -> Result<Option<String>>
-where R: tokio::io::AsyncRead + Unpin {
+where
+    R: tokio::io::AsyncRead + Unpin,
+{
     tokio::select! {
         r = stream_or_state(reader, label) => r,
         r = poll_idle(short, label) => r,
@@ -219,21 +275,32 @@ where R: tokio::io::AsyncRead + Unpin {
 
 /// Drives the reader: returns on settled state patch OR stream-quiet.
 async fn stream_or_state<R>(
-    reader: &mut tokio::io::Lines<BufReader<R>>, label: &str,
+    reader: &mut tokio::io::Lines<BufReader<R>>,
+    label: &str,
 ) -> Result<Option<String>>
-where R: tokio::io::AsyncRead + Unpin {
+where
+    R: tokio::io::AsyncRead + Unpin,
+{
     let mut saw_stream = false;
     let mut frames = 0u32;
     let deadline = Instant::now() + SETTLE_TIMEOUT;
     loop {
-        if Instant::now() >= deadline { bail!("{}: stream_or_state timeout", label); }
+        if Instant::now() >= deadline {
+            bail!("{}: stream_or_state timeout", label);
+        }
         match timeout(QUIET_WINDOW, reader.next_line()).await {
             Ok(Ok(Some(line))) => {
-                let v: Value = match serde_json::from_str(&line) { Ok(v) => v, Err(_) => continue };
+                let v: Value = match serde_json::from_str(&line) {
+                    Ok(v) => v,
+                    Err(_) => continue,
+                };
                 match v.get("type").and_then(|x| x.as_str()) {
                     Some("stream") => {
-                        if !saw_stream { println!("[stream] {} first frame seen", label); }
-                        saw_stream = true; frames += 1;
+                        if !saw_stream {
+                            println!("[stream] {} first frame seen", label);
+                        }
+                        saw_stream = true;
+                        frames += 1;
                     }
                     Some("state") => {
                         let p = v.get("patch").cloned().unwrap_or(Value::Null);
@@ -242,8 +309,14 @@ where R: tokio::io::AsyncRead + Unpin {
                         if matches!(st, Some("done") | Some("blocked"))
                             || matches!(te, Some("idle") | Some("blocked"))
                         {
-                            let d = p.get("detail").and_then(|x| x.as_str()).map(|s| s.to_string());
-                            println!("[{} complete via state] state={:?} tempo={:?}", label, st, te);
+                            let d = p
+                                .get("detail")
+                                .and_then(|x| x.as_str())
+                                .map(|s| s.to_string());
+                            println!(
+                                "[{} complete via state] state={:?} tempo={:?}",
+                                label, st, te
+                            );
                             return Ok(d);
                         }
                     }
@@ -254,8 +327,10 @@ where R: tokio::io::AsyncRead + Unpin {
             Ok(Err(e)) => bail!("{}: read error: {}", label, e),
             Err(_) => {
                 if saw_stream {
-                    println!("[{} complete via stream-quiet] frames={} silence={:?}",
-                        label, frames, QUIET_WINDOW);
+                    println!(
+                        "[{} complete via stream-quiet] frames={} silence={:?}",
+                        label, frames, QUIET_WINDOW
+                    );
                     return Ok(None);
                 }
             }
@@ -274,7 +349,10 @@ async fn poll_idle(short: &str, label: &str) -> Result<Option<String>> {
         }
         let status = current_status(short)?;
         let disp = status.clone().unwrap_or_else(|| "<absent>".into());
-        if disp != last { println!("[poll] {} status={}", label, disp); last = disp.clone(); }
+        if disp != last {
+            println!("[poll] {} status={}", label, disp);
+            last = disp.clone();
+        }
         match status.as_deref() {
             Some("busy") | Some("running") | Some("active") => saw_busy = true,
             Some("idle") | Some("blocked") | Some("done") if saw_busy => {
@@ -289,15 +367,31 @@ async fn poll_idle(short: &str, label: &str) -> Result<Option<String>> {
 
 /// Returns `status` field of the agents entry whose sessionId starts with `short`.
 fn current_status(short: &str) -> Result<Option<String>> {
-    let out = Command::new("claude").args(["agents", "--json"]).output()
+    let out = Command::new("claude")
+        .args(["agents", "--json"])
+        .output()
         .context("run `claude agents --json`")?;
     if !out.status.success() {
-        bail!("claude agents --json failed: {}", String::from_utf8_lossy(&out.stderr));
+        bail!(
+            "claude agents --json failed: {}",
+            String::from_utf8_lossy(&out.stderr)
+        );
     }
-    let arr: Value = serde_json::from_str(&String::from_utf8_lossy(&out.stdout))
-        .context("parse agents json")?;
-    Ok(arr.as_array().and_then(|a| a.iter().find(|e| {
-        e.get("sessionId").and_then(|x| x.as_str())
-            .map(|s| s.starts_with(short)).unwrap_or(false)
-    })).and_then(|e| e.get("status").and_then(|x| x.as_str()).map(|s| s.to_string())))
+    let arr: Value =
+        serde_json::from_str(&String::from_utf8_lossy(&out.stdout)).context("parse agents json")?;
+    Ok(arr
+        .as_array()
+        .and_then(|a| {
+            a.iter().find(|e| {
+                e.get("sessionId")
+                    .and_then(|x| x.as_str())
+                    .map(|s| s.starts_with(short))
+                    .unwrap_or(false)
+            })
+        })
+        .and_then(|e| {
+            e.get("status")
+                .and_then(|x| x.as_str())
+                .map(|s| s.to_string())
+        }))
 }

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -25,15 +25,21 @@ export async function getSessions(): Promise<Session[]> {
 /**
  * Get the full conversation history for a specific session
  */
-export async function getConversation(sessionId: string): Promise<Conversation> {
+export async function getConversation(
+	sessionId: string,
+	includeTools = false
+): Promise<Conversation> {
 	if (get(isDemoMode)) {
 		return demoConversations[sessionId] ?? { sessionId, messages: [] };
 	}
 
 	if (useWebSocket()) {
-		return await wsClient.request<Conversation>('getConversation', { sessionId });
+		return await wsClient.request<Conversation>('getConversation', {
+			sessionId,
+			includeTools
+		});
 	}
-	return await invoke<Conversation>('get_conversation', { sessionId });
+	return await invoke<Conversation>('get_conversation', { sessionId, includeTools });
 }
 
 /**

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -5,7 +5,7 @@
 
 import { invoke } from '@tauri-apps/api/core';
 import { get } from 'svelte/store';
-import type { Session, Conversation, HistoryEntry, DeepSearchHit, CostData, ProjectMemory, LogEntry } from './types';
+import type { Session, Conversation, HistoryEntry, DeepSearchHit, CostData, ProjectMemory, LogEntry, SessionProvider } from './types';
 import { isDemoMode } from './demo/mode';
 import { getDemoSessions, getDemoHistoryEntries, getDemoCostData, demoConversations } from './demo/data';
 import { wsClient, useWebSocket } from './ws';
@@ -25,15 +25,15 @@ export async function getSessions(): Promise<Session[]> {
 /**
  * Get the full conversation history for a specific session
  */
-export async function getConversation(sessionId: string): Promise<Conversation> {
+export async function getConversation(sessionId: string, provider?: SessionProvider): Promise<Conversation> {
 	if (get(isDemoMode)) {
 		return demoConversations[sessionId] ?? { sessionId, messages: [] };
 	}
 
 	if (useWebSocket()) {
-		return await wsClient.request<Conversation>('getConversation', { sessionId });
+		return await wsClient.request<Conversation>('getConversation', { sessionId, provider });
 	}
-	return await invoke<Conversation>('get_conversation', { sessionId });
+	return await invoke<Conversation>('get_conversation', { sessionId, provider });
 }
 
 /**
@@ -65,14 +65,18 @@ export async function openSession(pid: number, projectPath: string): Promise<voi
 /**
  * Rename a session title
  */
-export async function renameSession(sessionId: string, newName: string): Promise<void> {
+export async function renameSession(
+	sessionId: string,
+	newName: string,
+	provider?: SessionProvider,
+): Promise<void> {
 	if (get(isDemoMode)) return;
 
 	if (useWebSocket()) {
-		await wsClient.request('renameSession', { sessionId, newName });
+		await wsClient.request('renameSession', { sessionId, newName, provider });
 		return;
 	}
-	await invoke<void>('rename_session', { sessionId, newName });
+	await invoke<void>('rename_session', { sessionId, newName, provider });
 }
 
 /**

--- a/src/lib/components/ConversationLoadBar.svelte
+++ b/src/lib/components/ConversationLoadBar.svelte
@@ -1,0 +1,58 @@
+<script lang="ts">
+	import { conversationLoad, conversationLoadPercent } from '$lib/stores/conversation-loader';
+
+	interface Props {
+		sessionId: string;
+	}
+
+	let { sessionId }: Props = $props();
+
+	let active = $derived($conversationLoad?.sessionId === sessionId);
+	let percent = $derived(conversationLoadPercent($conversationLoad));
+</script>
+
+{#if active}
+	<div
+		class="load-track"
+		role="progressbar"
+		aria-valuemin={0}
+		aria-valuemax={100}
+		aria-valuenow={percent ?? undefined}
+		aria-label="Loading conversation"
+	>
+		<div
+			class="load-fill"
+			class:indeterminate={percent == null}
+			style={percent == null ? undefined : `width: ${percent}%`}
+		></div>
+	</div>
+{/if}
+
+<style>
+	.load-track {
+		height: 2px;
+		background: var(--border-muted);
+		overflow: hidden;
+		flex-shrink: 0;
+	}
+
+	.load-fill {
+		height: 100%;
+		background: var(--status-working);
+		transition: width 80ms linear;
+	}
+
+	.load-fill.indeterminate {
+		width: 30%;
+		animation: load-slide 1s linear infinite;
+	}
+
+	@keyframes load-slide {
+		from {
+			transform: translateX(-100%);
+		}
+		to {
+			transform: translateX(350%);
+		}
+	}
+</style>

--- a/src/lib/components/CostTracker.svelte
+++ b/src/lib/components/CostTracker.svelte
@@ -8,7 +8,7 @@
 	import { formatCost, formatTokens, modelDisplayName } from '$lib/cost-utils';
 	import { flyIn, fadeIn } from '$lib/transitions';
 	import { providerFilter } from '$lib/stores/provider-filter';
-	import { matchesProvider, providerFilterLabel } from '$lib/provider';
+	import { matchesProvider, providerFilterLabel, providerOf } from '$lib/provider';
 	import ProviderBadge from './ProviderBadge.svelte';
 	import { isCostAvailable, selectChartDays, summarizeCostSessions } from '$lib/cost-semantics';
 
@@ -34,7 +34,7 @@
 
 	function providerUsageValue(sessions: SessionCostRecord[], provider: SessionProvider): number {
 		return sessions
-			.filter((session) => (session.provider === 'codex' ? 'codex' : 'claudeCode') === provider)
+			.filter((session) => providerOf(session) === provider)
 			.reduce((sum, session) => {
 				if (mode === 'tokens') return sum + (session.totalTokens || 0);
 				return sum + (isCostAvailable(session) ? session.cost : 0);
@@ -66,7 +66,7 @@
 	function mergeSessionRows(sessions: SessionCostRecord[]): CostSessionRow[] {
 		const rows = new Map<string, CostSessionRow>();
 		for (const [index, session] of sessions.entries()) {
-			const provider = session.provider === 'codex' ? 'codex' : 'claudeCode';
+			const provider = providerOf(session);
 			const key = session.sessionId
 				? `${provider}:${session.sessionId}`
 				: `${provider}:${session.date}:${session.timestamp}:${session.model}:${index}`;
@@ -462,7 +462,7 @@
 
 		const modelMap = new Map<string, { model: string; provider: import('$lib/types').SessionProvider; cost: number; tokens: number; unpricedTokens: number }>();
 		for (const s of sessions) {
-			const provider = s.provider === 'codex' ? 'codex' : 'claudeCode';
+			const provider = providerOf(s);
 			const key = `${provider}:${s.model}`;
 			const cur = modelMap.get(key) || { model: s.model, provider, cost: 0, tokens: 0, unpricedTokens: 0 };
 			if (isCostAvailable(s)) cur.cost += s.cost;

--- a/src/lib/components/CostTracker.svelte
+++ b/src/lib/components/CostTracker.svelte
@@ -8,7 +8,7 @@
 	import { formatCost, formatTokens, modelDisplayName } from '$lib/cost-utils';
 	import { flyIn, fadeIn } from '$lib/transitions';
 	import { providerFilter } from '$lib/stores/provider-filter';
-	import { matchesProvider, providerFilterLabel, providerOf } from '$lib/provider';
+	import { matchesProvider, providerFilterLabel, providerOf, providerSessionKey } from '$lib/provider';
 	import ProviderBadge from './ProviderBadge.svelte';
 	import { isCostAvailable, selectChartDays, summarizeCostSessions } from '$lib/cost-semantics';
 
@@ -41,19 +41,36 @@
 			}, 0);
 	}
 
-	function claudeUsageShare(sessions: SessionCostRecord[]): number {
-		const claude = providerUsageValue(sessions, 'claudeCode');
-		const codex = providerUsageValue(sessions, 'codex');
-		return claude + codex > 0 ? (claude / (claude + codex)) * 100 : 100;
+	function providerUsageGradient(sessions: SessionCostRecord[]): string {
+		const providers: Array<{ color: string; value: number }> = [
+			{ color: 'var(--accent-amber)', value: providerUsageValue(sessions, 'claudeCode') },
+			{ color: 'var(--accent-blue)', value: providerUsageValue(sessions, 'codex') },
+			{ color: 'var(--accent-purple)', value: providerUsageValue(sessions, 'cursor') }
+		];
+		const total = providers.reduce((sum, provider) => sum + provider.value, 0);
+		let offset = 0;
+		const stops = providers.map(({ color, value }) => {
+			const start = total > 0 ? (offset / total) * 100 : 0;
+			offset += value;
+			const end = total > 0 ? (offset / total) * 100 : 100;
+			return `${color} ${start}% ${end}%`;
+		});
+		return `linear-gradient(to top, ${stops.join(', ')})`;
 	}
 
 	function providerBreakdownLabel(sessions: SessionCostRecord[]): string {
-		const claude = providerUsageValue(sessions, 'claudeCode');
-		const codex = providerUsageValue(sessions, 'codex');
-		const total = claude + codex;
+		const providers: Array<{ label: string; provider: SessionProvider }> = [
+			{ label: 'Claude Code', provider: 'claudeCode' },
+			{ label: 'Codex', provider: 'codex' },
+			{ label: 'Cursor', provider: 'cursor' }
+		];
+		const values = providers.map(({ provider }) => providerUsageValue(sessions, provider));
+		const total = values.reduce((sum, value) => sum + value, 0);
 		const format = mode === 'tokens' ? formatTokens : formatCost;
 		const percentage = (value: number) => total > 0 ? `${((value / total) * 100).toFixed(0)}%` : '0%';
-		return `Claude Code ${format(claude)} (${percentage(claude)}), Codex ${format(codex)} (${percentage(codex)})`;
+		return providers
+			.map(({ label }, index) => `${label} ${format(values[index])} (${percentage(values[index])})`)
+			.join(', ');
 	}
 
 	function formatAggregate(cost: number, tokens: number, unpricedTokens: number): string {
@@ -68,7 +85,7 @@
 		for (const [index, session] of sessions.entries()) {
 			const provider = providerOf(session);
 			const key = session.sessionId
-				? `${provider}:${session.sessionId}`
+				? providerSessionKey(provider, session.sessionId)
 				: `${provider}:${session.date}:${session.timestamp}:${session.model}:${index}`;
 			const unpricedTokens = isCostAvailable(session) ? 0 : session.totalTokens;
 			const model = session.model || 'unknown';
@@ -142,6 +159,7 @@
 		if (normalized.startsWith('gpt-5.4')) return 'var(--accent-red)';
 		if (normalized.startsWith('gpt-5.3-codex')) return '#a3e635';
 
+		if (provider === 'cursor') return 'var(--accent-purple)';
 		if (provider === 'codex' || normalized.startsWith('gpt-')) {
 			let hash = 0;
 			for (let i = 0; i < normalized.length; i++) {
@@ -179,6 +197,7 @@
 	});
 	let mode = $derived($costMode);
 	let hasCodexUsage = $derived(costData?.dailyCosts.some((day) => day.sessions.some((session) => session.provider === 'codex')) ?? false);
+	let hasCursorUsage = $derived(costData?.dailyCosts.some((day) => day.sessions.some((session) => session.provider === 'cursor')) ?? false);
 	let collapsedProjects = $state<Set<string>>(new Set());
 	let modelTrackWidth = $state(0);
 	let projectTrackWidth = $state(0);
@@ -300,7 +319,7 @@
 		};
 		conversation = null;
 		try {
-			conversation = await getConversation(session.sessionId);
+			conversation = await getConversation(session.sessionId, session.provider);
 		} catch (e) {
 			console.error('Failed to load conversation:', e);
 		} finally {
@@ -582,13 +601,22 @@
 	/** Build a project bar with provider-specific blocks, then fill the remainder. */
 	function buildProviderBarBlocks(fillPct: number, totalCols: number, sessions: SessionCostRecord[]): Array<{ type: string }> {
 		const filled = Math.round((fillPct / 100) * totalCols);
-		const claude = providerUsageValue(sessions, 'claudeCode');
-		const codex = providerUsageValue(sessions, 'codex');
-		const total = claude + codex;
-		const claudeBlocks = total > 0 ? Math.round((claude / total) * filled) : 0;
+		const providers = [
+			{ type: 'claude', value: providerUsageValue(sessions, 'claudeCode') },
+			{ type: 'codex', value: providerUsageValue(sessions, 'codex') },
+			{ type: 'cursor', value: providerUsageValue(sessions, 'cursor') }
+		];
+		const total = providers.reduce((sum, provider) => sum + provider.value, 0);
 		const arr: Array<{ type: string }> = [];
-		for (let i = 0; i < claudeBlocks; i++) arr.push({ type: 'claude' });
-		for (let i = claudeBlocks; i < filled; i++) arr.push({ type: 'codex' });
+		for (let i = 0; i < filled && total > 0; i++) {
+			const midpoint = ((i + 0.5) / filled) * total;
+			let cumulative = 0;
+			const provider = providers.find(({ value }) => {
+				cumulative += value;
+				return midpoint <= cumulative;
+			}) ?? providers[providers.length - 1];
+			arr.push({ type: provider.type });
+		}
 		while (arr.length < totalCols) arr.push({ type: 'empty' });
 		return arr;
 	}
@@ -704,6 +732,7 @@
 			<div class="provider-usage-legend" aria-label="Cost chart provider colors">
 				<span class="provider-usage-legend-item"><span class="provider-usage-swatch claude" aria-hidden="true"></span>CLAUDE CODE</span>
 				<span class="provider-usage-legend-item"><span class="provider-usage-swatch codex" aria-hidden="true"></span>CODEX</span>
+				{#if hasCursorUsage}<span class="provider-usage-legend-item"><span class="provider-usage-swatch cursor" aria-hidden="true"></span>CURSOR</span>{/if}
 			</div>
 			{#if filteredProjectCosts.length === 0}
 				<div class="state-msg">No {providerFilterLabel($providerFilter)} usage data available.</div>
@@ -744,7 +773,7 @@
 				<div class="vchart-area">
 					{#each chronoBuckets as bucket (bucket.key)}
 						{@const barValue = mode === 'usd' ? bucket.cost : bucket.tokens}
-						{@const claudeShare = claudeUsageShare(bucket.sessions)}
+						{@const providerGradient = providerUsageGradient(bucket.sessions)}
 						<div
 							class="vchart-col"
 							onmouseenter={() => hoveredBucket = bucket.key}
@@ -763,7 +792,7 @@
 								<div
 									class="vchart-bar"
 									class:vchart-bar-empty={barValue === 0}
-									style="height: {bucketScaleMax > 0 ? (barValue / bucketScaleMax) * 100 : 0}%; --claude-share: {claudeShare}%"
+								style="height: {bucketScaleMax > 0 ? (barValue / bucketScaleMax) * 100 : 0}%; --provider-gradient: {providerGradient}"
 								></div>
 							</div>
 							<span class="vchart-label">
@@ -826,7 +855,7 @@
 							<!-- svelte-ignore a11y_click_events_have_key_events -->
 							<!-- svelte-ignore a11y_no_static_element_interactions -->
 							{@const sorted = sortSessions(proj.displaySessions)}
-							{#each expandedProjects.has(proj.project) ? sorted : sorted.slice(0, 5) as session ((session.provider ?? 'claudeCode') + '-' + session.sessionId + '-' + session.timestamp)}
+							{#each expandedProjects.has(proj.project) ? sorted : sorted.slice(0, 5) as session (providerSessionKey(session.provider, session.sessionId) + '-' + session.timestamp)}
 								<!-- svelte-ignore a11y_click_events_have_key_events -->
 								<!-- svelte-ignore a11y_no_static_element_interactions -->
 								<div class="session-detail" class:codex-session={session.provider === 'codex'} onclick={() => handleSessionClick(session)}>
@@ -987,6 +1016,15 @@
 		color: var(--accent-blue);
 		background: var(--accent-blue);
 	}
+
+	.provider-usage-swatch.cursor {
+		color: var(--accent-purple);
+		background: var(--accent-purple);
+	}
+
+	.rect.claude { background: var(--accent-amber); }
+	.rect.codex { background: var(--accent-blue); }
+	.rect.cursor { background: var(--accent-purple); }
 
 	.cost-section {
 		display: flex;
@@ -1247,11 +1285,7 @@
 				rgba(0, 0, 0, 0.2) 3px,
 				rgba(0, 0, 0, 0.2) 4px
 			),
-			linear-gradient(
-				to top,
-				var(--accent-amber) 0 var(--claude-share),
-				var(--accent-blue) var(--claude-share) 100%
-			);
+			var(--provider-gradient);
 		box-shadow: 0 0 4px color-mix(in srgb, var(--text-secondary) 30%, transparent);
 		transition: height 300ms ease;
 	}

--- a/src/lib/components/CostTracker.svelte
+++ b/src/lib/components/CostTracker.svelte
@@ -1,6 +1,8 @@
 <script lang="ts">
 	import { onMount } from 'svelte';
 	import { getConversation } from '$lib/api';
+	import { toolsLoadedFor, withConversationLoader } from '$lib/stores/conversation-loader';
+	import { get } from 'svelte/store';
 	import type { HistoryEntry, Conversation, CostData, SessionCostRecord, SessionProvider } from '$lib/types';
 	import TokenDistanceVisualizer from './token-distance/TokenDistanceVisualizer.svelte';
 	import HistoryCardOverlay from './HistoryCardOverlay.svelte';
@@ -283,11 +285,10 @@
 		});
 	}
 
-	let loadingConversation = $state(false);
+	let conversationRequestId = 0;
 
 	async function handleSessionClick(session: import('$lib/types').SessionCostRecord) {
-		if (loadingConversation) return;
-		loadingConversation = true;
+		const requestId = ++conversationRequestId;
 		selectedEntry = {
 			sessionId: session.sessionId,
 			display: session.sessionName || session.sessionId.slice(0, 8),
@@ -299,12 +300,16 @@
 			surface: session.surface,
 		};
 		conversation = null;
+		toolsLoadedFor.set(null);
 		try {
-			conversation = await getConversation(session.sessionId);
+			const conv = await withConversationLoader(session.sessionId, 'conversation', () =>
+				getConversation(session.sessionId, false)
+			);
+			if (requestId !== conversationRequestId) return;
+			if (get(toolsLoadedFor) === session.sessionId) return;
+			conversation = conv;
 		} catch (e) {
 			console.error('Failed to load conversation:', e);
-		} finally {
-			loadingConversation = false;
 		}
 	}
 
@@ -877,7 +882,7 @@
 	/>
 {/if}
 {#if selectedEntry}
-	<HistoryCardOverlay entry={selectedEntry} {conversation} onclose={() => { selectedEntry = null; conversation = null; }} />
+	<HistoryCardOverlay entry={selectedEntry} {conversation} onclose={() => { selectedEntry = null; conversation = null; }} onconversation={(conv) => { if (selectedEntry?.sessionId === conv.sessionId) conversation = conv; }} />
 {/if}
 </div>
 

--- a/src/lib/components/ExpandedCardOverlay.svelte
+++ b/src/lib/components/ExpandedCardOverlay.svelte
@@ -52,7 +52,7 @@
 	import { getSessionStatusColor, getSessionStatusLabel, getSubagentStatusColor, getSubagentStatusLabel, getWorkerStatusColor, getWorkerStatusLabel } from '$lib/status-utils';
 	import { isTauri } from '$lib/ws';
 	import ProviderBadge from './ProviderBadge.svelte';
-	import { canSessionAction, providerOf } from '$lib/provider';
+	import { canSessionAction, providerOf, providerSessionKey, sessionKeyOf } from '$lib/provider';
 
 	interface Props {
 		session: Session;
@@ -161,7 +161,7 @@
 		}
 	});
 
-	let costRecord = $derived($sessionCostMap.get(session.id));
+	let costRecord = $derived($sessionCostMap.get(sessionKeyOf(session)));
 	let primaryCostLabel = $derived(
 		costRecord ? formatCostOrTokens(costRecord.cost, costRecord.totalTokens, $costMode, isCostAvailable(costRecord)) : null
 	);
@@ -172,11 +172,12 @@
 
 	// resolvedWorkers works for both PM (views own workers) and a worker
 	// (views siblings under the same PM). Highlights the current session in the list.
-	// When the session is a PM, workerOf is null, so we fall back to session.id
+	// When the session is a PM, workerOf is null, so we fall back to its
+	// provider-scoped key
 	// and resolvedWorkers IS myWorkers; the PM badge shows when length > 0 and
 	// workerOf is null (i.e. this session is itself the PM).
 	let resolvedWorkers = $derived(
-		$workersByPm.get(session.workerOf ?? session.id) ?? []
+		$workersByPm.get(session.workerOf ? providerSessionKey('claudeCode', session.workerOf) : sessionKeyOf(session)) ?? []
 	);
 	let isPm = $derived(
 		PM_ORCHESTRATION_ENABLED && !session.workerOf && resolvedWorkers.length > 0
@@ -185,9 +186,15 @@
 		PM_ORCHESTRATION_ENABLED && resolvedWorkers.length > 0
 	);
 
+	function subagentKey(subagent: SubagentInfo): string {
+		return providerSessionKey(subagent.provider, subagent.id);
+	}
+
 	let mySubagents = $derived([
-		...($visibleSubagentsBySession.get(session.id) ?? []),
-		...($codexSubagentsByParent.get(session.id) ?? []).map((child): SubagentInfo => ({
+		// The Claude subagent endpoint is Claude-only and still keys its response
+		// by the raw Claude session ID. Never consult it for another provider.
+		...(providerOf(session) === 'claudeCode' ? ($visibleSubagentsBySession.get(providerSessionKey('claudeCode', session.id)) ?? []) : []),
+		...($codexSubagentsByParent.get(sessionKeyOf(session)) ?? []).map((child): SubagentInfo => ({
 			id: child.id,
 			sessionId: child.id,
 			provider: providerOf(child),
@@ -200,19 +207,19 @@
 		}))
 	]);
 	let hasSubagents = $derived(mySubagents.length > 0);
-	let visibleCodexParentId = $derived($codexVisibleParentByChild.get(session.id) ?? null);
+	let visibleCodexParentId = $derived($codexVisibleParentByChild.get(sessionKeyOf(session)) ?? null);
 	let subagentsCollapsed = $state(false);
 
 	// Subagent preview: when set, the conversation area renders a synthesized
 	// transcript (prompt + result) for the clicked subagent instead of the
 	// parent session's messages.
 	//
-	// State is keyed by parent session id in a module-level Svelte rune map so
+	// State is keyed by the parent provider-scoped key in a module-level Svelte rune map so
 	// that re-renders triggered by store updates (new JSONL events arriving)
 	// do NOT reset the preview. Switching sessions naturally shows a fresh
 	// (empty) preview because the key changes.
 	let previewState = $derived(
-		previewStateBySession.get(session.id) ?? {
+		previewStateBySession.get(sessionKeyOf(session)) ?? {
 			selection: null,
 			transcript: null,
 			loading: false,
@@ -226,10 +233,11 @@
 
 	async function openSubagentPreview(sa: SubagentInfo) {
 		if ((sa.provider === 'codex' || sa.provider === 'cursor') && sa.sessionId) {
-			expandedSessionId.set(sa.sessionId);
+			expandedSessionId.set(providerSessionKey(sa.provider, sa.sessionId));
 			return;
 		}
-		const sid = session.id;
+		const sid = sessionKeyOf(session);
+		const rawParentSessionId = session.id;
 		const initialState: PreviewState = {
 			selection: sa,
 			transcript: null,
@@ -249,13 +257,13 @@
 
 		try {
 			const tr = await invoke<SubagentTranscript>('get_subagent_transcript', {
-				parentSessionId: sid,
+				parentSessionId: rawParentSessionId,
 				subagentId: sa.id,
 			});
 			// Guard: user may have switched to a different selection before
 			// this resolved. Only commit if the selection is still this one.
 			const current = previewStateBySession.get(sid);
-			if (current?.selection?.id === sa.id) {
+			if (current?.selection && subagentKey(current.selection) === subagentKey(sa)) {
 				previewStateBySession.set(sid, {
 					...current,
 					transcript: tr,
@@ -263,7 +271,7 @@
 			}
 		} catch (err) {
 			const current = previewStateBySession.get(sid);
-			if (current?.selection?.id === sa.id) {
+			if (current?.selection && subagentKey(current.selection) === subagentKey(sa)) {
 				previewStateBySession.set(sid, {
 					...current,
 					error: String(err),
@@ -271,7 +279,7 @@
 			}
 		} finally {
 			const current = previewStateBySession.get(sid);
-			if (current?.selection?.id === sa.id) {
+			if (current?.selection && subagentKey(current.selection) === subagentKey(sa)) {
 				previewStateBySession.set(sid, {
 					...current,
 					loading: false,
@@ -281,12 +289,12 @@
 	}
 
 	function closeSubagentPreview() {
-		const sid = session.id;
+		const sid = sessionKeyOf(session);
 		previewStateBySession.delete(sid);
 	}
 
-	function openWorker(id: string) {
-		expandedSessionId.set(id);
+	function openWorker(worker: Session) {
+		expandedSessionId.set(sessionKeyOf(worker));
 	}
 
 
@@ -617,15 +625,15 @@
 					</button>
 					{#if !workersCollapsed}
 						{#if session.workerOf}
-							<button class="back-to-pm" onclick={() => expandedSessionId.set(session.workerOf!)}>← Back to PM</button>
+							<button class="back-to-pm" onclick={() => expandedSessionId.set(providerSessionKey('claudeCode', session.workerOf!))}>← Back to PM</button>
 						{/if}
 						<div class="workers-list">
-							{#each resolvedWorkers as w (w.id)}
+							{#each resolvedWorkers as w (sessionKeyOf(w))}
 								<button
 									type="button"
 									class="worker-row"
-									class:active={w.id === session.id}
-									onclick={() => openWorker(w.id)}
+									class:active={sessionKeyOf(w) === sessionKeyOf(session)}
+									onclick={() => openWorker(w)}
 								>
 									<span class="worker-name">{w.customTitle || w.summary || w.sessionName}</span>
 									<span class="worker-status" style="color: {getWorkerStatusColor(w.status)}">
@@ -657,11 +665,11 @@
 							<button class="back-to-pm" onclick={closeSubagentPreview}>← Back to conversation</button>
 						{/if}
 						<div class="subagents-list">
-							{#each mySubagents as sa (sa.id)}
+							{#each mySubagents as sa (subagentKey(sa))}
 								<button
 									type="button"
 									class="subagent-row"
-									class:active={previewedSubagent?.id === sa.id}
+									class:active={previewedSubagent ? subagentKey(previewedSubagent) === subagentKey(sa) : false}
 									onclick={() => openSubagentPreview(sa)}
 									title={sa.description || sa.agentType}
 								>

--- a/src/lib/components/ExpandedCardOverlay.svelte
+++ b/src/lib/components/ExpandedCardOverlay.svelte
@@ -199,7 +199,7 @@
 			sessionId: child.id,
 			provider: providerOf(child),
 			agentType: child.agentRole || child.agentNickname || 'subagent',
-			description: child.agentNickname || child.summary || child.firstPrompt || child.agentRole || (providerOf(child) === 'cursor' ? 'Cursor subagent' : 'Codex subagent'),
+				description: child.agentNickname || child.codexTitle || child.cursorTitle || child.summary || child.firstPrompt || child.agentRole || (providerOf(child) === 'cursor' ? 'Cursor subagent' : 'Codex subagent'),
 			startedAt: child.startedAtMs ? new Date(child.startedAtMs).toISOString() : child.modified,
 			completedAt: child.status === SessionStatus.Working ? null : child.modified,
 			parentSessionId: session.id,
@@ -351,7 +351,7 @@
 								onmouseenter={() => tipEnter(session.id)}
 								onmouseleave={tipLeave}
 								onmousemove={tipMove}
-							>{session.customTitle || session.summary || session.firstPrompt || 'New Session'}</h2>
+							>{session.customTitle || session.officialName || session.codexTitle || session.cursorTitle || session.summary || session.firstPrompt || 'New Session'}</h2>
 							{#if PM_ORCHESTRATION_ENABLED && session.workerOf}
 								<!-- svelte-ignore a11y_no_static_element_interactions -->
 								<span
@@ -635,7 +635,7 @@
 									class:active={sessionKeyOf(w) === sessionKeyOf(session)}
 									onclick={() => openWorker(w)}
 								>
-									<span class="worker-name">{w.customTitle || w.summary || w.sessionName}</span>
+								<span class="worker-name">{w.customTitle || w.codexTitle || w.cursorTitle || w.summary || w.sessionName}</span>
 									<span class="worker-status" style="color: {getWorkerStatusColor(w.status)}">
 										{getWorkerStatusLabel(w.status)}
 									</span>

--- a/src/lib/components/ExpandedCardOverlay.svelte
+++ b/src/lib/components/ExpandedCardOverlay.svelte
@@ -43,14 +43,25 @@
 	import TodoPanel from './TodoPanel.svelte';
 	import { createSlidingWindow, BATCH_SIZE } from '$lib/slidingWindow.svelte';
 	import { sessionCostMap, costMode } from '$lib/stores/cost';
-	import { workersByPm, expandedSessionId, codexSubagentsByParent, codexVisibleParentByChild } from '$lib/stores/sessions';
+	import { currentConversation, workersByPm, expandedSessionId, codexSubagentsByParent, codexVisibleParentByChild } from '$lib/stores/sessions';
 	import { visibleSubagentsBySession } from '$lib/stores/subagents';
 	import { PM_ORCHESTRATION_ENABLED } from '$lib/feature-flags';
 	import { formatCost, formatTokens, formatCostOrTokens, modelDisplayName } from '$lib/cost-utils';
+	import { isCostAvailable } from '$lib/cost-semantics';
 	import { formatTimeSince, formatDurationMs } from '$lib/time-utils';
 	import { getSessionStatusColor, getSessionStatusLabel, getSubagentStatusColor, getSubagentStatusLabel, getWorkerStatusColor, getWorkerStatusLabel } from '$lib/status-utils';
 	import { isTauri } from '$lib/ws';
 	import ProviderBadge from './ProviderBadge.svelte';
+	import { getConversation } from '$lib/api';
+	import {
+		conversationLoad,
+		conversationLoadLabel,
+		isSessionLoading,
+		isToolsLoading,
+		toolsLoadedFor,
+		withConversationLoader
+	} from '$lib/stores/conversation-loader';
+	import ConversationLoadBar from './ConversationLoadBar.svelte';
 	import { canSessionAction } from '$lib/provider';
 
 	interface Props {
@@ -66,7 +77,7 @@
 	let messagesContainer = $state<HTMLDivElement>(undefined!);
 	let isInitialLoad = $state(true);
 	let hasScrolledToBottom = $state(false);
-	let showTools = $state(true);
+	let showTools = $state(false);
 	let showThinking = $state(true);
 	let navSheetOpen = $state(false);
 	let idCopied = $state(false);
@@ -101,6 +112,12 @@
 		).length;
 	});
 
+	let toolsLoading = $derived(isToolsLoading(session.id, $conversationLoad));
+	let sessionLoading = $derived(isSessionLoading(session.id, $conversationLoad));
+	let loadLabel = $derived(
+		$conversationLoad?.sessionId === session.id ? conversationLoadLabel($conversationLoad) : null
+	);
+
 	// Stagger messages only on the overlay's first render. After that,
 	// streaming/polling appends new messages — those should appear instantly.
 	function messageIn(node: Element, params: { index: number }) {
@@ -112,6 +129,31 @@
 		// Close the bottom sheet on mobile after navigating
 		navSheetOpen = false;
 	}
+
+	async function toggleTools() {
+		const next = !showTools;
+		if (sessionLoading) return;
+		if (next && $toolsLoadedFor !== session.id) {
+			try {
+				const conv = await withConversationLoader(session.id, 'tools', () =>
+					getConversation(session.id, true)
+				);
+				if (conv.sessionId === session.id) {
+					currentConversation.set(conv);
+					toolsLoadedFor.set(session.id);
+				}
+			} catch (error) {
+				console.error('Failed to load tools:', error);
+				return;
+			}
+		}
+		showTools = next;
+	}
+
+	$effect(() => {
+		session.id;
+		showTools = false;
+	});
 
 	onMount(() => {
 		isInitialLoad = false;
@@ -162,7 +204,7 @@
 
 	let costRecord = $derived($sessionCostMap.get(session.id));
 	let primaryCostLabel = $derived(
-		costRecord ? formatCostOrTokens(costRecord.cost, costRecord.totalTokens, $costMode, costRecord.costAvailable ?? costRecord.provider !== 'codex') : null
+		costRecord ? formatCostOrTokens(costRecord.cost, costRecord.totalTokens, $costMode, isCostAvailable(costRecord)) : null
 	);
 
 	let isPermission = $derived(session.status === SessionStatus.NeedsAttention);
@@ -384,11 +426,15 @@
 							<span class="session-name-badge">{session.sessionName}</span>
 							<span class="separator">·</span>
 							<span class="message-count">{#if conversation && conversation.messages.length > BATCH_SIZE}{sw.startIndex + 1}–{sw.endIndex} / {/if}{conversation?.messages.length ?? 0} messages</span>
+							{#if loadLabel}
+								<span class="separator">·</span>
+								<span class="load-label">{loadLabel}</span>
+							{/if}
 							{#if costRecord}
 								<span class="separator">·</span>
-								<span class="cost-breakdown" title="{costRecord.costAvailable ?? costRecord.provider !== 'codex' ? `Total cost: ${formatCost(costRecord.cost)}` : 'USD pricing unavailable'} · {formatTokens(costRecord.totalTokens)} tokens · {modelDisplayName(costRecord.model)}">
+								<span class="cost-breakdown" title="{isCostAvailable(costRecord) ? `Total cost: ${formatCost(costRecord.cost)}` : 'USD pricing unavailable'} · {formatTokens(costRecord.totalTokens)} tokens · {modelDisplayName(costRecord.model)}">
 									<span class="cost-primary">{primaryCostLabel}</span>
-									<span class="cost-secondary">· {$costMode === 'usd' ? formatTokens(costRecord.totalTokens) + ' tok' : formatCostOrTokens(costRecord.cost, costRecord.totalTokens, 'usd', costRecord.costAvailable ?? costRecord.provider !== 'codex')}</span>
+									<span class="cost-secondary">· {$costMode === 'usd' ? formatTokens(costRecord.totalTokens) + ' tok' : formatCostOrTokens(costRecord.cost, costRecord.totalTokens, 'usd', isCostAvailable(costRecord))}</span>
 									<span class="cost-secondary">· {modelDisplayName(costRecord.model)}</span>
 								</span>
 							{/if}
@@ -439,9 +485,11 @@
 					<button
 						type="button"
 						class="header-button toggle-tools"
-						class:active={showTools}
-						onclick={() => showTools = !showTools}
-						title={showTools ? "Hide Tools" : "Show Tools"}
+						class:active={showTools && !toolsLoading}
+						class:loading={toolsLoading}
+						disabled={sessionLoading}
+						onclick={toggleTools}
+						title={toolsLoading ? "Loading tools" : sessionLoading ? "Loading conversation" : showTools ? "Hide Tools" : "Show Tools"}
 					>
 						<span>⚙</span>
 					</button>
@@ -454,6 +502,7 @@
 					</button>
 				</div>
 			</header>
+			<ConversationLoadBar sessionId={session.id} />
 
 			{#if tooltipText}
 				<div class="id-tooltip" style="left: {tooltipX}px; top: {tooltipY}px;">
@@ -1263,6 +1312,13 @@
 		color: var(--text-muted);
 	}
 
+	.load-label {
+		font-family: var(--font-pixel);
+		font-size: 11px;
+		letter-spacing: 0.08em;
+		color: var(--status-working);
+	}
+
 	.header-actions {
 		display: flex;
 		align-items: center;
@@ -1283,6 +1339,11 @@
 		color: var(--text-primary);
 	}
 
+	.header-button:disabled {
+		opacity: 1;
+		cursor: default;
+	}
+
 	.header-button span {
 		font-family: var(--font-mono);
 		font-size: 14px;
@@ -1296,6 +1357,22 @@
 	.header-button.active.toggle-tools {
 		color: var(--status-input);
 		opacity: 1;
+	}
+
+	.header-button.loading.toggle-tools {
+		color: var(--status-working);
+		opacity: 1;
+	}
+
+	.header-button.loading.toggle-tools span {
+		display: inline-block;
+		animation: gear-spin 0.8s linear infinite;
+	}
+
+	@keyframes gear-spin {
+		to {
+			transform: rotate(360deg);
+		}
 	}
 
 	.header-divider {

--- a/src/lib/components/ExpandedCardOverlay.svelte
+++ b/src/lib/components/ExpandedCardOverlay.svelte
@@ -47,11 +47,12 @@
 	import { visibleSubagentsBySession } from '$lib/stores/subagents';
 	import { PM_ORCHESTRATION_ENABLED } from '$lib/feature-flags';
 	import { formatCost, formatTokens, formatCostOrTokens, modelDisplayName } from '$lib/cost-utils';
+	import { isCostAvailable } from '$lib/cost-semantics';
 	import { formatTimeSince, formatDurationMs } from '$lib/time-utils';
 	import { getSessionStatusColor, getSessionStatusLabel, getSubagentStatusColor, getSubagentStatusLabel, getWorkerStatusColor, getWorkerStatusLabel } from '$lib/status-utils';
 	import { isTauri } from '$lib/ws';
 	import ProviderBadge from './ProviderBadge.svelte';
-	import { canSessionAction } from '$lib/provider';
+	import { canSessionAction, providerOf } from '$lib/provider';
 
 	interface Props {
 		session: Session;
@@ -162,7 +163,7 @@
 
 	let costRecord = $derived($sessionCostMap.get(session.id));
 	let primaryCostLabel = $derived(
-		costRecord ? formatCostOrTokens(costRecord.cost, costRecord.totalTokens, $costMode, costRecord.costAvailable ?? costRecord.provider !== 'codex') : null
+		costRecord ? formatCostOrTokens(costRecord.cost, costRecord.totalTokens, $costMode, isCostAvailable(costRecord)) : null
 	);
 
 	let isPermission = $derived(session.status === SessionStatus.NeedsAttention);
@@ -189,9 +190,9 @@
 		...($codexSubagentsByParent.get(session.id) ?? []).map((child): SubagentInfo => ({
 			id: child.id,
 			sessionId: child.id,
-			provider: 'codex',
+			provider: providerOf(child),
 			agentType: child.agentRole || child.agentNickname || 'subagent',
-			description: child.agentNickname || child.summary || child.firstPrompt || child.agentRole || 'Codex subagent',
+			description: child.agentNickname || child.summary || child.firstPrompt || child.agentRole || (providerOf(child) === 'cursor' ? 'Cursor subagent' : 'Codex subagent'),
 			startedAt: child.startedAtMs ? new Date(child.startedAtMs).toISOString() : child.modified,
 			completedAt: child.status === SessionStatus.Working ? null : child.modified,
 			parentSessionId: session.id,
@@ -224,7 +225,7 @@
 	let previewError = $derived(previewState.error);
 
 	async function openSubagentPreview(sa: SubagentInfo) {
-		if (sa.provider === 'codex' && sa.sessionId) {
+		if ((sa.provider === 'codex' || sa.provider === 'cursor') && sa.sessionId) {
 			expandedSessionId.set(sa.sessionId);
 			return;
 		}
@@ -386,9 +387,9 @@
 							<span class="message-count">{#if conversation && conversation.messages.length > BATCH_SIZE}{sw.startIndex + 1}–{sw.endIndex} / {/if}{conversation?.messages.length ?? 0} messages</span>
 							{#if costRecord}
 								<span class="separator">·</span>
-								<span class="cost-breakdown" title="{costRecord.costAvailable ?? costRecord.provider !== 'codex' ? `Total cost: ${formatCost(costRecord.cost)}` : 'USD pricing unavailable'} · {formatTokens(costRecord.totalTokens)} tokens · {modelDisplayName(costRecord.model)}">
+								<span class="cost-breakdown" title="{isCostAvailable(costRecord) ? `Total cost: ${formatCost(costRecord.cost)}` : 'USD pricing unavailable'} · {formatTokens(costRecord.totalTokens)} tokens · {modelDisplayName(costRecord.model)}">
 									<span class="cost-primary">{primaryCostLabel}</span>
-									<span class="cost-secondary">· {$costMode === 'usd' ? formatTokens(costRecord.totalTokens) + ' tok' : formatCostOrTokens(costRecord.cost, costRecord.totalTokens, 'usd', costRecord.costAvailable ?? costRecord.provider !== 'codex')}</span>
+									<span class="cost-secondary">· {$costMode === 'usd' ? formatTokens(costRecord.totalTokens) + ' tok' : formatCostOrTokens(costRecord.cost, costRecord.totalTokens, 'usd', isCostAvailable(costRecord))}</span>
 									<span class="cost-secondary">· {modelDisplayName(costRecord.model)}</span>
 								</span>
 							{/if}

--- a/src/lib/components/ExpandedCardOverlay.svelte
+++ b/src/lib/components/ExpandedCardOverlay.svelte
@@ -131,22 +131,23 @@
 	}
 
 	async function toggleTools() {
+		const requestedId = session.id;
 		const next = !showTools;
 		if (sessionLoading) return;
-		if (next && $toolsLoadedFor !== session.id) {
+		if (next && $toolsLoadedFor !== requestedId) {
 			try {
-				const conv = await withConversationLoader(session.id, 'tools', () =>
-					getConversation(session.id, true)
+				const conv = await withConversationLoader(requestedId, 'tools', () =>
+					getConversation(requestedId, true)
 				);
-				if (conv.sessionId === session.id) {
-					currentConversation.set(conv);
-					toolsLoadedFor.set(session.id);
-				}
+				if (session.id !== requestedId || conv.sessionId !== requestedId) return;
+				currentConversation.set(conv);
+				toolsLoadedFor.set(requestedId);
 			} catch (error) {
 				console.error('Failed to load tools:', error);
 				return;
 			}
 		}
+		if (session.id !== requestedId) return;
 		showTools = next;
 	}
 

--- a/src/lib/components/HistoryCardOverlay.svelte
+++ b/src/lib/components/HistoryCardOverlay.svelte
@@ -170,7 +170,7 @@
 					<div class="header-info">
 						<div class="header-title">
 							<ProviderBadge provider={entry.provider} surface={entry.surface} />
-							<h2 id="overlay-title" class="project-name">{entry.projectName}</h2>
+							<h2 id="overlay-title" class="project-name">{entry.customTitle || entry.codexTitle || entry.cursorTitle || entry.projectName}</h2>
 						</div>
 						<div class="header-meta">
 							<span class="message-count">{#if conversation && conversation.messages.length > BATCH_SIZE}{sw.startIndex + 1}–{sw.endIndex} / {/if}{conversation?.messages.length ?? 0} messages</span>

--- a/src/lib/components/HistoryCardOverlay.svelte
+++ b/src/lib/components/HistoryCardOverlay.svelte
@@ -10,6 +10,7 @@
 	import { formatCost, formatTokens, formatCostOrTokens, modelDisplayName } from '$lib/cost-utils';
 	import { isCostAvailable } from '$lib/cost-semantics';
 	import ProviderBadge from './ProviderBadge.svelte';
+	import { providerSessionKey } from '$lib/provider';
 
 	interface Props {
 		entry: HistoryEntry;
@@ -29,7 +30,7 @@
 
 	const sw = createSlidingWindow();
 
-	let costRecord = $derived($sessionCostMap.get(entry.sessionId));
+	let costRecord = $derived($sessionCostMap.get(providerSessionKey(entry.provider, entry.sessionId)));
 	let primaryCostLabel = $derived(
 		costRecord ? formatCostOrTokens(costRecord.cost, costRecord.totalTokens, $costMode, isCostAvailable(costRecord)) : null
 	);
@@ -185,16 +186,23 @@
 					</div>
 				</div>
 
-				<button
-					type="button"
-					class="resume-chip"
-					class:copied
-					onclick={copyResumeCommand}
-					title="Click to copy resume command"
-				>
-					<span class="resume-label">{copied ? 'COPIED!' : 'RESUME'}</span>
-					<code class="resume-cmd">{resumeCommand}</code>
-				</button>
+				{#if entry.provider === 'cursor'}
+					<div class="resume-chip readonly" title="Cursor Agent transcripts are read-only">
+						<span class="resume-label">READ ONLY</span>
+						<code class="resume-cmd">Cursor Agent transcript</code>
+					</div>
+				{:else}
+					<button
+						type="button"
+						class="resume-chip"
+						class:copied
+						onclick={copyResumeCommand}
+						title="Click to copy resume command"
+					>
+						<span class="resume-label">{copied ? 'COPIED!' : 'RESUME'}</span>
+						<code class="resume-cmd">{resumeCommand}</code>
+					</button>
+				{/if}
 
 				<div class="header-actions">
 					<button
@@ -446,6 +454,15 @@
 
 	.resume-chip.copied {
 		border-color: var(--accent-green);
+	}
+
+	.resume-chip.readonly {
+		cursor: default;
+		opacity: 0.8;
+	}
+
+	.resume-chip.readonly:hover {
+		border-color: var(--border-default);
 	}
 
 	.resume-label {

--- a/src/lib/components/HistoryCardOverlay.svelte
+++ b/src/lib/components/HistoryCardOverlay.svelte
@@ -8,20 +8,32 @@
 	import { createSlidingWindow, BATCH_SIZE, MAX_VISIBLE } from '$lib/slidingWindow.svelte';
 	import { sessionCostMap, costMode } from '$lib/stores/cost';
 	import { formatCost, formatTokens, formatCostOrTokens, modelDisplayName } from '$lib/cost-utils';
+	import { isCostAvailable } from '$lib/cost-semantics';
 	import ProviderBadge from './ProviderBadge.svelte';
+	import { getConversation } from '$lib/api';
+	import {
+		conversationLoad,
+		conversationLoadLabel,
+		isSessionLoading,
+		isToolsLoading,
+		toolsLoadedFor,
+		withConversationLoader
+	} from '$lib/stores/conversation-loader';
+	import ConversationLoadBar from './ConversationLoadBar.svelte';
 
 	interface Props {
 		entry: HistoryEntry;
 		conversation: Conversation | null;
 		searchQuery?: string;
 		onclose: () => void;
+		onconversation?: (conversation: Conversation) => void;
 	}
 
-	let { entry, conversation, searchQuery, onclose }: Props = $props();
+	let { entry, conversation, searchQuery, onclose, onconversation }: Props = $props();
 
 	let messagesContainer = $state<HTMLDivElement>(undefined!);
 	let hasScrolledToBottom = $state(false);
-	let showTools = $state(true);
+	let showTools = $state(false);
 	let showThinking = $state(true);
 	let navSheetOpen = $state(false);
 	let copied = $state(false);
@@ -30,7 +42,7 @@
 
 	let costRecord = $derived($sessionCostMap.get(entry.sessionId));
 	let primaryCostLabel = $derived(
-		costRecord ? formatCostOrTokens(costRecord.cost, costRecord.totalTokens, $costMode, costRecord.costAvailable ?? costRecord.provider !== 'codex') : null
+		costRecord ? formatCostOrTokens(costRecord.cost, costRecord.totalTokens, $costMode, isCostAvailable(costRecord)) : null
 	);
 	let resumeCommand = $derived(
 		entry.provider === 'codex'
@@ -43,10 +55,41 @@
 		return sw.sliceMessages(conversation.messages);
 	});
 
+	let toolsLoading = $derived(isToolsLoading(entry.sessionId, $conversationLoad));
+	let sessionLoading = $derived(isSessionLoading(entry.sessionId, $conversationLoad));
+	let loadLabel = $derived(
+		$conversationLoad?.sessionId === entry.sessionId ? conversationLoadLabel($conversationLoad) : null
+	);
+
 	function handleNavItemClick() {
 		// Close the bottom sheet on mobile after navigating
 		navSheetOpen = false;
 	}
+
+	async function toggleTools() {
+		const next = !showTools;
+		if (sessionLoading) return;
+		if (next && $toolsLoadedFor !== entry.sessionId) {
+			try {
+				const conv = await withConversationLoader(entry.sessionId, 'tools', () =>
+					getConversation(entry.sessionId, true)
+				);
+				if (conv.sessionId === entry.sessionId) {
+					onconversation?.(conv);
+					toolsLoadedFor.set(entry.sessionId);
+				}
+			} catch (error) {
+				console.error('Failed to load tools:', error);
+				return;
+			}
+		}
+		showTools = next;
+	}
+
+	$effect(() => {
+		entry.sessionId;
+		showTools = false;
+	});
 
 	onMount(() => {
 		const handleKeydown = (e: KeyboardEvent) => {
@@ -170,11 +213,15 @@
 						</div>
 						<div class="header-meta">
 							<span class="message-count">{#if conversation && conversation.messages.length > BATCH_SIZE}{sw.startIndex + 1}–{sw.endIndex} / {/if}{conversation?.messages.length ?? 0} messages</span>
+							{#if loadLabel}
+								<span class="separator">·</span>
+								<span class="load-label">{loadLabel}</span>
+							{/if}
 							{#if costRecord}
 								<span class="separator">·</span>
-								<span class="cost-breakdown" title="{costRecord.costAvailable ?? costRecord.provider !== 'codex' ? `Total cost: ${formatCost(costRecord.cost)}` : 'USD pricing unavailable'} · {formatTokens(costRecord.totalTokens)} tokens · {modelDisplayName(costRecord.model)}">
+								<span class="cost-breakdown" title="{isCostAvailable(costRecord) ? `Total cost: ${formatCost(costRecord.cost)}` : 'USD pricing unavailable'} · {formatTokens(costRecord.totalTokens)} tokens · {modelDisplayName(costRecord.model)}">
 									<span class="cost-primary">{primaryCostLabel}</span>
-									<span class="cost-secondary">· {$costMode === 'usd' ? formatTokens(costRecord.totalTokens) + ' tok' : formatCostOrTokens(costRecord.cost, costRecord.totalTokens, 'usd', costRecord.costAvailable ?? costRecord.provider !== 'codex')}</span>
+									<span class="cost-secondary">· {$costMode === 'usd' ? formatTokens(costRecord.totalTokens) + ' tok' : formatCostOrTokens(costRecord.cost, costRecord.totalTokens, 'usd', isCostAvailable(costRecord))}</span>
 									<span class="cost-secondary">· {modelDisplayName(costRecord.model)}</span>
 								</span>
 							{/if}
@@ -206,9 +253,11 @@
 					<button
 						type="button"
 						class="header-button toggle-tools"
-						class:active={showTools}
-						onclick={() => showTools = !showTools}
-						title={showTools ? "Hide Tools" : "Show Tools"}
+						class:active={showTools && !toolsLoading}
+						class:loading={toolsLoading}
+						disabled={sessionLoading}
+						onclick={toggleTools}
+						title={toolsLoading ? "Loading tools" : sessionLoading ? "Loading conversation" : showTools ? "Hide Tools" : "Show Tools"}
 					>
 						<span>⚙</span>
 					</button>
@@ -221,6 +270,7 @@
 					</button>
 				</div>
 			</header>
+			<ConversationLoadBar sessionId={entry.sessionId} />
 
 			<!-- Conversation Area -->
 			<div class="conversation-area" bind:this={messagesContainer} onscroll={handleScroll}>
@@ -398,6 +448,13 @@
 		color: var(--text-muted);
 	}
 
+	.load-label {
+		font-family: var(--font-pixel);
+		font-size: 11px;
+		letter-spacing: 0.08em;
+		color: var(--status-working);
+	}
+
 	.separator {
 		color: var(--text-muted);
 	}
@@ -483,6 +540,11 @@
 		color: var(--text-primary);
 	}
 
+	.header-button:disabled {
+		opacity: 1;
+		cursor: default;
+	}
+
 	.header-button span {
 		font-family: var(--font-mono);
 		font-size: 14px;
@@ -496,6 +558,22 @@
 	.header-button.active.toggle-tools {
 		color: var(--status-input);
 		opacity: 1;
+	}
+
+	.header-button.loading.toggle-tools {
+		color: var(--status-working);
+		opacity: 1;
+	}
+
+	.header-button.loading.toggle-tools span {
+		display: inline-block;
+		animation: gear-spin 0.8s linear infinite;
+	}
+
+	@keyframes gear-spin {
+		to {
+			transform: rotate(360deg);
+		}
 	}
 
 	.header-divider {

--- a/src/lib/components/HistoryCardOverlay.svelte
+++ b/src/lib/components/HistoryCardOverlay.svelte
@@ -67,22 +67,23 @@
 	}
 
 	async function toggleTools() {
+		const requestedId = entry.sessionId;
 		const next = !showTools;
 		if (sessionLoading) return;
-		if (next && $toolsLoadedFor !== entry.sessionId) {
+		if (next && $toolsLoadedFor !== requestedId) {
 			try {
-				const conv = await withConversationLoader(entry.sessionId, 'tools', () =>
-					getConversation(entry.sessionId, true)
+				const conv = await withConversationLoader(requestedId, 'tools', () =>
+					getConversation(requestedId, true)
 				);
-				if (conv.sessionId === entry.sessionId) {
-					onconversation?.(conv);
-					toolsLoadedFor.set(entry.sessionId);
-				}
+				if (entry.sessionId !== requestedId || conv.sessionId !== requestedId) return;
+				onconversation?.(conv);
+				toolsLoadedFor.set(requestedId);
 			} catch (error) {
 				console.error('Failed to load tools:', error);
 				return;
 			}
 		}
+		if (entry.sessionId !== requestedId) return;
 		showTools = next;
 	}
 

--- a/src/lib/components/HistoryCardOverlay.svelte
+++ b/src/lib/components/HistoryCardOverlay.svelte
@@ -8,6 +8,7 @@
 	import { createSlidingWindow, BATCH_SIZE, MAX_VISIBLE } from '$lib/slidingWindow.svelte';
 	import { sessionCostMap, costMode } from '$lib/stores/cost';
 	import { formatCost, formatTokens, formatCostOrTokens, modelDisplayName } from '$lib/cost-utils';
+	import { isCostAvailable } from '$lib/cost-semantics';
 	import ProviderBadge from './ProviderBadge.svelte';
 
 	interface Props {
@@ -30,11 +31,13 @@
 
 	let costRecord = $derived($sessionCostMap.get(entry.sessionId));
 	let primaryCostLabel = $derived(
-		costRecord ? formatCostOrTokens(costRecord.cost, costRecord.totalTokens, $costMode, costRecord.costAvailable ?? costRecord.provider !== 'codex') : null
+		costRecord ? formatCostOrTokens(costRecord.cost, costRecord.totalTokens, $costMode, isCostAvailable(costRecord)) : null
 	);
 	let resumeCommand = $derived(
 		entry.provider === 'codex'
 			? `cd "${entry.project}" && codex resume ${entry.sessionId}`
+			: entry.provider === 'cursor'
+				? `Cursor Agent · ${entry.sessionId}`
 			: `cd "${entry.project}" && claude --resume ${entry.sessionId}`
 	);
 
@@ -172,9 +175,9 @@
 							<span class="message-count">{#if conversation && conversation.messages.length > BATCH_SIZE}{sw.startIndex + 1}–{sw.endIndex} / {/if}{conversation?.messages.length ?? 0} messages</span>
 							{#if costRecord}
 								<span class="separator">·</span>
-								<span class="cost-breakdown" title="{costRecord.costAvailable ?? costRecord.provider !== 'codex' ? `Total cost: ${formatCost(costRecord.cost)}` : 'USD pricing unavailable'} · {formatTokens(costRecord.totalTokens)} tokens · {modelDisplayName(costRecord.model)}">
+								<span class="cost-breakdown" title="{isCostAvailable(costRecord) ? `Total cost: ${formatCost(costRecord.cost)}` : 'USD pricing unavailable'} · {formatTokens(costRecord.totalTokens)} tokens · {modelDisplayName(costRecord.model)}">
 									<span class="cost-primary">{primaryCostLabel}</span>
-									<span class="cost-secondary">· {$costMode === 'usd' ? formatTokens(costRecord.totalTokens) + ' tok' : formatCostOrTokens(costRecord.cost, costRecord.totalTokens, 'usd', costRecord.costAvailable ?? costRecord.provider !== 'codex')}</span>
+									<span class="cost-secondary">· {$costMode === 'usd' ? formatTokens(costRecord.totalTokens) + ' tok' : formatCostOrTokens(costRecord.cost, costRecord.totalTokens, 'usd', isCostAvailable(costRecord))}</span>
 									<span class="cost-secondary">· {modelDisplayName(costRecord.model)}</span>
 								</span>
 							{/if}

--- a/src/lib/components/MemoryViewer.svelte
+++ b/src/lib/components/MemoryViewer.svelte
@@ -113,6 +113,8 @@
 		</div>
 		{#if $providerFilter === 'codex'}
 			<div class="empty-hint">Codex stores durable memory in ~/.codex/memories/</div>
+		{:else if $providerFilter === 'cursor'}
+			<div class="empty-hint">Cursor Agent memory is not monitored yet.</div>
 		{:else if $providerFilter === 'claudeCode'}
 			<div class="empty-hint">Claude Code stores memory in ~/.claude/projects/*/memory/</div>
 		{:else}

--- a/src/lib/components/MessageNavMap.svelte
+++ b/src/lib/components/MessageNavMap.svelte
@@ -11,7 +11,7 @@
 		hideHeader?: boolean;
 	}
 
-	let { conversation, scrollContainer, showTools = $bindable(true), showThinking = $bindable(true), onExpandToIndex, hideHeader = false }: Props = $props();
+	let { conversation, scrollContainer, showTools = $bindable(false), showThinking = $bindable(true), onExpandToIndex, hideHeader = false }: Props = $props();
 
 	// Filter for "milestone" messages - user messages, tool blocks, and thinking steps
 	let items = $derived.by(() => {
@@ -72,8 +72,22 @@
 
 	function truncateContent(content: string | undefined): string {
 		if (!content) return '...';
-		const clean = content.replace(/[#*`]/g, '').trim();
-		return clean.length > 40 ? clean.substring(0, 40) + '...' : clean;
+		const limit = 40;
+		let preview = '';
+		for (const character of content) {
+			if (character === '#' || character === '*' || character === '`') continue;
+			if (character === '\n' || character === '\r') {
+				if (preview.length === 0) continue;
+				break;
+			}
+			preview += character;
+			if (preview.length >= limit) break;
+		}
+		preview = preview.trim();
+		if (!preview) return '...';
+		return content.length > preview.length || preview.length >= limit
+			? `${preview.slice(0, limit)}...`
+			: preview;
 	}
 </script>
 

--- a/src/lib/components/ProviderBadge.svelte
+++ b/src/lib/components/ProviderBadge.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
 	import type { SessionProvider, SessionSurface } from '$lib/types';
-	import { providerLabel, surfaceLabel } from '$lib/provider';
+	import { providerLabel, providerOf, surfaceLabel } from '$lib/provider';
 
 	interface Props {
 		provider?: SessionProvider;
@@ -10,12 +10,12 @@
 	}
 
 	let { provider = 'claudeCode', surface, compact = false, noun = 'session' }: Props = $props();
-	let normalized = $derived<SessionProvider>(provider === 'codex' ? 'codex' : 'claudeCode');
+	let normalized = $derived<SessionProvider>(providerOf({ provider }));
 	let surfaceText = $derived(normalized === 'codex' ? surfaceLabel(surface) : null);
 </script>
 
 <span class="provider-stack" class:compact aria-label={`${providerLabel(normalized)} ${noun}${surfaceText ? `, ${surfaceText}` : ''}`}>
-	<span class="provider-badge" class:codex={normalized === 'codex'}>{providerLabel(normalized)}</span>
+	<span class="provider-badge" class:codex={normalized === 'codex'} class:cursor={normalized === 'cursor'}>{providerLabel(normalized)}</span>
 	{#if surfaceText}<span class="surface-badge">{surfaceText}</span>{/if}
 </span>
 
@@ -30,6 +30,7 @@
 	}
 	.provider-badge { color: var(--accent-amber); border-color: color-mix(in srgb, var(--accent-amber) 55%, var(--border-default)); }
 	.provider-badge.codex { color: var(--accent-blue); border-color: color-mix(in srgb, var(--accent-blue) 55%, var(--border-default)); }
+	.provider-badge.cursor { color: var(--accent-purple); border-color: color-mix(in srgb, var(--accent-purple) 55%, var(--border-default)); }
 	.surface-badge { height: 16px; padding: 0 4px; border-color: var(--border-default); border-style: dashed; font-size: 7px; color: var(--text-secondary); }
 	.compact .provider-badge { height: 16px; font-size: 7px; }
 	.compact .surface-badge { display: none; }

--- a/src/lib/components/ProviderFilter.svelte
+++ b/src/lib/components/ProviderFilter.svelte
@@ -11,7 +11,8 @@
 	const options: Array<{ value: ProviderFilterValue; label: string; short: string }> = [
 		{ value: 'all', label: 'All providers', short: 'ALL' },
 		{ value: 'claudeCode', label: 'Claude Code', short: 'CLAUDE CODE' },
-		{ value: 'codex', label: 'Codex', short: 'CODEX' }
+		{ value: 'codex', label: 'Codex', short: 'CODEX' },
+		{ value: 'cursor', label: 'Cursor', short: 'CURSOR' }
 	];
 	let dropdownOpen = $state(false);
 	let activeIndex = $state(0);
@@ -200,6 +201,7 @@
 	.option-marker { width: 5px; height: 5px; border: 1px solid var(--border-default); }
 	.option-marker.claudeCode { border-color: var(--accent-amber); background: var(--accent-amber); }
 	.option-marker.codex { border-color: var(--accent-blue); background: var(--accent-blue); }
+	.option-marker.cursor { border-color: var(--accent-purple); background: var(--accent-purple); }
 	.option-check { color: var(--text-secondary); text-align: right; }
 	.provider-select.compact { gap: 5px; }
 	.compact .select-label { font-size: 7px; }

--- a/src/lib/components/SessionCard.svelte
+++ b/src/lib/components/SessionCard.svelte
@@ -7,7 +7,7 @@
 	import { isCostAvailable } from '$lib/cost-semantics';
 	import { PM_ORCHESTRATION_ENABLED } from '$lib/feature-flags';
 	import ProviderBadge from './ProviderBadge.svelte';
-	import { canSessionAction } from '$lib/provider';
+	import { canSessionAction, sessionKeyOf } from '$lib/provider';
 
 	interface Props {
 		session: Session;
@@ -56,10 +56,10 @@
 	let workerTip = $derived(session.workerOf ? `Worker of ${session.workerOf}` : '');
 	let workerIdShort = $derived(session.workerOf?.slice(0, 8) ?? '');
 
-	let myWorkers = $derived($workersByPm.get(session.id) ?? []);
+	let myWorkers = $derived($workersByPm.get(sessionKeyOf(session)) ?? []);
 	let isPm = $derived(myWorkers.length > 0);
 
-	let costRecord = $derived($sessionCostMap.get(session.id));
+	let costRecord = $derived($sessionCostMap.get(sessionKeyOf(session)));
 	let costLabel = $derived(
 		costRecord ? formatCostOrTokens(costRecord.cost, costRecord.totalTokens, $costMode, isCostAvailable(costRecord)) : null
 	);

--- a/src/lib/components/SessionCard.svelte
+++ b/src/lib/components/SessionCard.svelte
@@ -4,6 +4,7 @@
 	import { sessionCostMap, costMode } from '$lib/stores/cost';
 	import { workersByPm } from '$lib/stores/sessions';
 	import { formatCostOrTokens } from '$lib/cost-utils';
+	import { isCostAvailable } from '$lib/cost-semantics';
 	import { PM_ORCHESTRATION_ENABLED } from '$lib/feature-flags';
 	import ProviderBadge from './ProviderBadge.svelte';
 	import { canSessionAction } from '$lib/provider';
@@ -60,7 +61,7 @@
 
 	let costRecord = $derived($sessionCostMap.get(session.id));
 	let costLabel = $derived(
-		costRecord ? formatCostOrTokens(costRecord.cost, costRecord.totalTokens, $costMode, costRecord.costAvailable ?? costRecord.provider !== 'codex') : null
+		costRecord ? formatCostOrTokens(costRecord.cost, costRecord.totalTokens, $costMode, isCostAvailable(costRecord)) : null
 	);
 
 	function getStatusColor(): string {

--- a/src/lib/components/SessionCard.svelte
+++ b/src/lib/components/SessionCard.svelte
@@ -45,6 +45,8 @@
 	let cardTitle = $derived(
 		session.customTitle
 		|| session.officialName
+		|| session.codexTitle
+		|| session.cursorTitle
 		|| session.summary
 		|| session.firstPrompt
 	);

--- a/src/lib/components/SessionHistory.svelte
+++ b/src/lib/components/SessionHistory.svelte
@@ -126,6 +126,10 @@
 		return false;
 	}
 
+	function entryTitle(entry: HistoryEntry): string {
+		return entry.customTitle || entry.codexTitle || entry.cursorTitle || '';
+	}
+
 	// ── Filtering & sorting ──────────────────────────────────────────
 	let filtered = $derived.by(() => {
 		let entries = allEntries.filter((entry) => matchesProvider(entry, $providerFilter));
@@ -135,7 +139,7 @@
 			entries = entries.filter((e) => {
 				const display = norm(e.display);
 				const project = norm(e.projectName);
-				const title = e.customTitle ? norm(e.customTitle) : '';
+				const title = norm(entryTitle(e));
 				return (
 					phraseMatch(display, needle) ||
 					phraseMatch(project, needle) ||
@@ -396,7 +400,7 @@
 							>
 								<span class="row-number">{i + 1}</span>
 								<span class="row-prompt">
-									{#if entry.customTitle}<span class="row-title">{@html highlight(entry.customTitle, query)}</span>{/if}
+									{#if entryTitle(entry)}<span class="row-title">{@html highlight(entryTitle(entry), query)}</span>{/if}
 									<span class="row-display">{@html highlight((snippet ?? entry.display) || '(no prompt)', query)}</span>
 								</span>
 								<span class="row-badge-slot"><ProviderBadge provider={entry.provider} surface={entry.surface} compact />{#if activeSessionIds.has(entryKey(entry))}<span class="active-badge">ACTIVE</span>{/if}</span>
@@ -423,7 +427,7 @@
 							<span class="row-time">{relativeTime(entry.timestamp)}</span>
 						</div>
 						<span class="row-prompt">
-							{#if entry.customTitle}<span class="row-title">{@html highlight(entry.customTitle, query)}</span>{/if}
+							{#if entryTitle(entry)}<span class="row-title">{@html highlight(entryTitle(entry), query)}</span>{/if}
 							<span class="row-display">{@html highlight((snippet ?? entry.display) || '(no prompt)', query)}</span>
 						</span>
 					</div>

--- a/src/lib/components/SessionHistory.svelte
+++ b/src/lib/components/SessionHistory.svelte
@@ -2,6 +2,8 @@
 	import { onMount } from 'svelte';
 	import { browser } from '$app/environment';
 	import { deepSearchSessions, getConversation } from '$lib/api';
+	import { toolsLoadedFor, withConversationLoader } from '$lib/stores/conversation-loader';
+	import { get } from 'svelte/store';
 	import type { HistoryEntry, Conversation, DeepSearchHit } from '$lib/types';
 	import HistoryCardOverlay from './HistoryCardOverlay.svelte';
 	import { flyIn } from '$lib/transitions';
@@ -32,6 +34,7 @@
 	// Conversation viewer state
 	let selectedEntry = $state<HistoryEntry | null>(null);
 	let conversation = $state<Conversation | null>(null);
+	let conversationRequestId = 0;
 	// ── Persistence ──────────────────────────────────────────────────
 	onMount(() => {
 		if (browser) {
@@ -207,10 +210,17 @@
 
 	// ── Actions ──────────────────────────────────────────────────────
 	async function handleSelectEntry(entry: HistoryEntry) {
+		const requestId = ++conversationRequestId;
 		selectedEntry = entry;
 		conversation = null;
+		toolsLoadedFor.set(null);
 		try {
-			conversation = await getConversation(entry.sessionId);
+			const conv = await withConversationLoader(entry.sessionId, 'conversation', () =>
+				getConversation(entry.sessionId, false)
+			);
+			if (requestId !== conversationRequestId) return;
+			if (get(toolsLoadedFor) === entry.sessionId) return;
+			conversation = conv;
 		} catch (e) {
 			console.error('Failed to load conversation:', e);
 		}
@@ -425,7 +435,7 @@
 
 <!-- ── Conversation overlay ───────────────────────────────────────── -->
 {#if selectedEntry}
-	<HistoryCardOverlay entry={selectedEntry} {conversation} searchQuery={query.trim() && deepSearchResults?.has(selectedEntry.sessionId) ? query.trim() : undefined} onclose={handleCloseConversation} />
+	<HistoryCardOverlay entry={selectedEntry} {conversation} searchQuery={query.trim() && deepSearchResults?.has(selectedEntry.sessionId) ? query.trim() : undefined} onclose={handleCloseConversation} onconversation={(conv) => { if (selectedEntry?.sessionId === conv.sessionId) conversation = conv; }} />
 {/if}
 
 <style>

--- a/src/lib/components/SessionHistory.svelte
+++ b/src/lib/components/SessionHistory.svelte
@@ -7,7 +7,7 @@
 	import { flyIn } from '$lib/transitions';
 	import { historyEntries, historyLoading, historyError, refreshSessionHistory } from '$lib/stores/history';
 	import { providerFilter } from '$lib/stores/provider-filter';
-	import { matchesProvider, providerFilterLabel } from '$lib/provider';
+	import { matchesProvider, providerFilterLabel, providerSessionKey } from '$lib/provider';
 	import ProviderBadge from './ProviderBadge.svelte';
 
 	// ── Props ────────────────────────────────────────────────────────
@@ -28,10 +28,12 @@
 	let deepSearching = $state(false);
 	// Map of sessionId → matching snippet. null = no search run yet.
 	let deepSearchResults = $state<Map<string, string> | null>(null);
+	const entryKey = (entry: HistoryEntry) => providerSessionKey(entry.provider, entry.sessionId);
 
 	// Conversation viewer state
 	let selectedEntry = $state<HistoryEntry | null>(null);
 	let conversation = $state<Conversation | null>(null);
+	let conversationRequestId = 0;
 	// ── Persistence ──────────────────────────────────────────────────
 	onMount(() => {
 		if (browser) {
@@ -83,7 +85,11 @@
 			deepSearching = true;
 			try {
 				const hits = await deepSearchSessions(q, cs, ww);
-				if (!cancelled) deepSearchResults = new Map(hits.map((h) => [h.sessionId, h.snippet]));
+				if (!cancelled) {
+					deepSearchResults = new Map(
+						hits.map((h) => [providerSessionKey(h.provider, h.sessionId), h.snippet]),
+					);
+				}
 			} catch (e) {
 				if (!cancelled) console.error('Deep search failed:', e);
 			} finally {
@@ -139,15 +145,15 @@
 
 			// If deep search has run, also include sessions that matched full content
 			if (deepSearchResults !== null) {
-				const metaIds = new Set(entries.map((e) => e.sessionId));
-				const deepOnly = allEntries.filter(
-					(e) => matchesProvider(e, $providerFilter) && deepSearchResults!.has(e.sessionId) && !metaIds.has(e.sessionId)
-				);
+					const metaIds = new Set(entries.map(entryKey));
+					const deepOnly = allEntries.filter(
+						(e) => matchesProvider(e, $providerFilter) && deepSearchResults!.has(entryKey(e)) && !metaIds.has(entryKey(e))
+					);
 				entries = [...entries, ...deepOnly];
 			}
 		} else if (deepSearchResults !== null) {
 			// No text query but deep search ran — show all deep search hits
-			entries = allEntries.filter((e) => matchesProvider(e, $providerFilter) && deepSearchResults!.has(e.sessionId));
+				entries = allEntries.filter((e) => matchesProvider(e, $providerFilter) && deepSearchResults!.has(entryKey(e)));
 		}
 
 		return [...entries].sort((a, b) =>
@@ -207,12 +213,17 @@
 
 	// ── Actions ──────────────────────────────────────────────────────
 	async function handleSelectEntry(entry: HistoryEntry) {
+		const requestId = ++conversationRequestId;
 		selectedEntry = entry;
 		conversation = null;
 		try {
-			conversation = await getConversation(entry.sessionId);
+		const result = await getConversation(entry.sessionId, entry.provider);
+		const resultKey = providerSessionKey(result.provider ?? entry.provider, result.sessionId);
+		if (requestId === conversationRequestId && resultKey === entryKey(entry)) {
+			conversation = result;
+		}
 		} catch (e) {
-			console.error('Failed to load conversation:', e);
+			if (requestId === conversationRequestId) console.error('Failed to load conversation:', e);
 		}
 	}
 
@@ -375,8 +386,8 @@
 						<span class="group-count">{group.entries.length}</span>
 					</div>
 					{#if !collapsedProjects.has(group.project)}
-						{#each group.entries as entry, i (entry.sessionId)}
-							{@const snippet = query.trim() ? (deepSearchResults?.get(entry.sessionId) ?? null) : null}
+						{#each group.entries as entry, i (entryKey(entry))}
+							{@const snippet = query.trim() ? (deepSearchResults?.get(entryKey(entry)) ?? null) : null}
 							<button
 								class="session-row session-row-grid"
 								class:has-snippet={!!snippet}
@@ -388,7 +399,7 @@
 									{#if entry.customTitle}<span class="row-title">{@html highlight(entry.customTitle, query)}</span>{/if}
 									<span class="row-display">{@html highlight((snippet ?? entry.display) || '(no prompt)', query)}</span>
 								</span>
-								<span class="row-badge-slot"><ProviderBadge provider={entry.provider} surface={entry.surface} compact />{#if activeSessionIds.has(entry.sessionId)}<span class="active-badge">ACTIVE</span>{/if}</span>
+								<span class="row-badge-slot"><ProviderBadge provider={entry.provider} surface={entry.surface} compact />{#if activeSessionIds.has(entryKey(entry))}<span class="active-badge">ACTIVE</span>{/if}</span>
 								<span class="row-time">{relativeTime(entry.timestamp)}</span>
 							</button>
 						{/each}
@@ -396,8 +407,8 @@
 				</div>
 			{/each}
 		{:else}
-			{#each filtered as entry, i (entry.sessionId)}
-				{@const snippet = query.trim() ? (deepSearchResults?.get(entry.sessionId) ?? null) : null}
+			{#each filtered as entry, i (entryKey(entry))}
+				{@const snippet = query.trim() ? (deepSearchResults?.get(entryKey(entry)) ?? null) : null}
 				<button
 					class="session-row session-row-flat"
 					class:has-snippet={!!snippet}
@@ -408,7 +419,7 @@
 					<div class="row-content">
 						<div class="row-top-grid">
 							<span class="row-project">{entry.projectName}</span>
-								<span class="row-badge-slot"><ProviderBadge provider={entry.provider} surface={entry.surface} compact />{#if activeSessionIds.has(entry.sessionId)}<span class="active-badge">ACTIVE</span>{/if}</span>
+								<span class="row-badge-slot"><ProviderBadge provider={entry.provider} surface={entry.surface} compact />{#if activeSessionIds.has(entryKey(entry))}<span class="active-badge">ACTIVE</span>{/if}</span>
 							<span class="row-time">{relativeTime(entry.timestamp)}</span>
 						</div>
 						<span class="row-prompt">
@@ -425,7 +436,7 @@
 
 <!-- ── Conversation overlay ───────────────────────────────────────── -->
 {#if selectedEntry}
-	<HistoryCardOverlay entry={selectedEntry} {conversation} searchQuery={query.trim() && deepSearchResults?.has(selectedEntry.sessionId) ? query.trim() : undefined} onclose={handleCloseConversation} />
+	<HistoryCardOverlay entry={selectedEntry} {conversation} searchQuery={query.trim() && deepSearchResults?.has(entryKey(selectedEntry)) ? query.trim() : undefined} onclose={handleCloseConversation} />
 {/if}
 
 <style>

--- a/src/lib/components/SessionItem.svelte
+++ b/src/lib/components/SessionItem.svelte
@@ -63,7 +63,7 @@
 			{/if}
 			<span class="time-since">{formatTimeSince(session.modified)}</span>
 		</div>
-		<div class="first-prompt">{truncatePrompt(session.summary || session.firstPrompt)}</div>
+		<div class="first-prompt">{truncatePrompt(session.customTitle || session.officialName || session.codexTitle || session.cursorTitle || session.summary || session.firstPrompt)}</div>
 		<div class="message-count">{session.messageCount} messages</div>
 	</div>
 </button>

--- a/src/lib/components/SessionList.svelte
+++ b/src/lib/components/SessionList.svelte
@@ -1,13 +1,14 @@
 <script lang="ts">
 	import { sessions, selectedSessionId } from '$lib/stores/sessions';
 	import SessionItem from './SessionItem.svelte';
+	import { sessionKeyOf } from '$lib/provider';
 
 	// Subscribe to stores
 	let currentSessions = $derived($sessions);
 	let currentSelectedId = $derived($selectedSessionId);
 
-	function selectSession(sessionId: string) {
-		selectedSessionId.set(sessionId);
+	function selectSession(sessionKey: string) {
+		selectedSessionId.set(sessionKey);
 	}
 </script>
 
@@ -25,11 +26,11 @@
 			</div>
 		{:else}
 			<div class="session-items">
-				{#each currentSessions as session (session.id)}
+				{#each currentSessions as session (sessionKeyOf(session))}
 					<SessionItem
 						{session}
-						selected={session.id === currentSelectedId}
-						onclick={() => selectSession(session.id)}
+						selected={sessionKeyOf(session) === currentSelectedId}
+						onclick={() => selectSession(sessionKeyOf(session))}
 					/>
 				{/each}
 			</div>

--- a/src/lib/components/SessionList.svelte
+++ b/src/lib/components/SessionList.svelte
@@ -20,8 +20,8 @@
 	<div class="list-content">
 		{#if currentSessions.length === 0}
 			<div class="empty-state">
-				<p>No active Claude sessions detected</p>
-				<p class="empty-hint">Start a Claude Code session to see it here</p>
+				<p>No active sessions detected</p>
+				<p class="empty-hint">Start a Claude Code, Codex, or Cursor Agent session to see it here</p>
 			</div>
 		{:else}
 			<div class="session-items">

--- a/src/lib/components/ToastNotifications.svelte
+++ b/src/lib/components/ToastNotifications.svelte
@@ -26,20 +26,20 @@
 	}
 
 	.toast {
-		background: var(--bg-elevated, #1a1a2e);
-		border: 1px solid var(--status-input, #f5a623);
+		background: var(--bg-elevated);
+		border: 1px solid var(--status-input);
 		padding: 12px 16px;
-		animation: toast-in 0.3s ease-out;
+		animation: toast-in 0.2s linear;
 	}
 
 	@keyframes toast-in {
 		from {
 			opacity: 0;
-			transform: translateX(100%);
+			transform: translateY(-8px);
 		}
 		to {
 			opacity: 1;
-			transform: translateX(0);
+			transform: translateY(0);
 		}
 	}
 
@@ -47,7 +47,7 @@
 		font-family: var(--font-pixel, monospace);
 		font-size: 12px;
 		font-weight: 600;
-		color: var(--text-primary, #fff);
+		color: var(--text-primary);
 		text-transform: uppercase;
 		letter-spacing: 0.05em;
 		margin-bottom: 4px;
@@ -59,7 +59,7 @@
 	.toast-body {
 		font-family: var(--font-mono, monospace);
 		font-size: 12px;
-		color: var(--text-secondary, #aaa);
+		color: var(--text-secondary);
 		line-height: 1.4;
 	}
 </style>

--- a/src/lib/components/TodoPanel.svelte
+++ b/src/lib/components/TodoPanel.svelte
@@ -2,6 +2,7 @@
 	import { tasksBySession } from '$lib/stores/tasks';
 	import { flyInX } from '$lib/transitions';
 	import type { Session, Task } from '$lib/types';
+	import { providerOf, providerSessionKey } from '$lib/provider';
 
 	interface Props {
 		session: Session;
@@ -13,7 +14,7 @@
 
 	let { session, collapsed = false, onToggle, transitionIndex = 0 }: Props = $props();
 
-	let tasks = $derived($tasksBySession.get(session.id) ?? []);
+	let tasks = $derived(providerOf(session) === 'claudeCode' ? ($tasksBySession.get(providerSessionKey('claudeCode', session.id)) ?? []) : []);
 	let total = $derived(tasks.length);
 	let completed = $derived(tasks.filter((t) => t.status === 'completed').length);
 

--- a/src/lib/cost-semantics.ts
+++ b/src/lib/cost-semantics.ts
@@ -9,7 +9,7 @@ export interface CostSummary {
 
 /** Missing availability is tolerated for older Claude payloads, but never prices Codex implicitly. */
 export function isCostAvailable(session: SessionCostRecord): boolean {
-	return session.costAvailable ?? session.provider !== 'codex';
+	return session.costAvailable ?? (session.provider !== 'codex' && session.provider !== 'cursor');
 }
 
 export function summarizeCostSessions(sessions: SessionCostRecord[]): CostSummary {

--- a/src/lib/cost-utils.ts
+++ b/src/lib/cost-utils.ts
@@ -53,7 +53,7 @@ export function buildSessionCostMap(data: CostData | null): Map<string, SessionC
 				existing.cachedInputTokens = (existing.cachedInputTokens || 0) + (rec.cachedInputTokens || 0);
 				existing.outputTokens = (existing.outputTokens || 0) + (rec.outputTokens || 0);
 				existing.reasoningOutputTokens = (existing.reasoningOutputTokens || 0) + (rec.reasoningOutputTokens || 0);
-				existing.costAvailable = (existing.costAvailable ?? existing.provider !== 'codex') && (rec.costAvailable ?? rec.provider !== 'codex');
+				existing.costAvailable = (existing.costAvailable ?? (existing.provider !== 'codex' && existing.provider !== 'cursor')) && (rec.costAvailable ?? (rec.provider !== 'codex' && rec.provider !== 'cursor'));
 				if (rec.timestamp > existing.timestamp) {
 					existing.timestamp = rec.timestamp;
 					existing.model = rec.model;

--- a/src/lib/cost-utils.ts
+++ b/src/lib/cost-utils.ts
@@ -4,6 +4,7 @@
  */
 
 import type { CostData, SessionCostRecord } from './types';
+import { providerSessionKey } from './provider';
 
 export type CostMode = 'usd' | 'tokens';
 
@@ -43,9 +44,10 @@ export function buildSessionCostMap(data: CostData | null): Map<string, SessionC
 
 	for (const day of data.dailyCosts) {
 		for (const rec of day.sessions) {
-			const existing = map.get(rec.sessionId);
+			const key = providerSessionKey(rec.provider, rec.sessionId);
+			const existing = map.get(key);
 			if (!existing) {
-				map.set(rec.sessionId, { ...rec });
+				map.set(key, { ...rec });
 			} else {
 				existing.cost += rec.cost;
 				existing.totalTokens += rec.totalTokens;

--- a/src/lib/demo/data.ts
+++ b/src/lib/demo/data.ts
@@ -198,6 +198,25 @@ export function getDemoSessions(): Session[] {
 				modified: minutesAgo(1), status: SessionStatus.Working, latestMessage: 'Validating policy state', pendingToolName: null,
 				provider: 'codex', surface: 'app', agentKind: 'internal', parentThreadId: 'demo-codex-root',
 				rootSessionId: 'demo-codex-root', internalKind: 'guardian'
+		},
+		{
+				id: 'demo-cursor-root', pid: 92001, sessionName: 'c9watch', customTitle: 'Cursor agent detection',
+				projectPath: '/Users/demo/projects/c9watch', gitBranch: 'feature/cursor-agent-detection',
+				firstPrompt: 'Detect Cursor Agent sessions and their Task subagents', summary: 'Watching Cursor transcripts',
+				messageCount: 14, modified: minutesAgo(1), status: SessionStatus.Working,
+				latestMessage: 'Parsing agent-transcripts JSONL and grouping Task subagents...', pendingToolName: null,
+				provider: 'cursor', surface: 'cursor', agentKind: 'root', rootSessionId: 'demo-cursor-root',
+				actionCapabilities: { conversation: true, open: false, stop: false, rename: false }
+		},
+		{
+				id: 'demo-cursor-subagent', pid: 92002, sessionName: 'c9watch', customTitle: null,
+				projectPath: '/Users/demo/projects/c9watch', gitBranch: 'feature/cursor-agent-detection',
+				firstPrompt: 'Explore how Cursor stores agent transcripts', summary: 'Exploring Cursor transcript layout',
+				messageCount: 6, modified: minutesAgo(1), status: SessionStatus.Working,
+				latestMessage: 'Reading ~/.cursor/projects/*/agent-transcripts...', pendingToolName: null,
+				provider: 'cursor', surface: 'cursor', agentKind: 'subagent', parentThreadId: 'demo-cursor-root',
+				rootSessionId: 'demo-cursor-root', agentNickname: 'Explore session discovery', agentRole: 'explore',
+				actionCapabilities: { conversation: true, open: false, stop: false, rename: false }
 		}
 	];
 }
@@ -213,6 +232,11 @@ export function getDemoHistoryEntries(): HistoryEntry[] {
 			sessionId: 'demo-codex-root', display: 'Implement mixed-provider monitoring',
 			timestamp: Date.now() - 12 * 60_000, project: '/Users/demo/projects/c9watch', projectName: 'c9watch',
 			customTitle: 'Codex monitoring rollout', provider: 'codex', surface: 'app'
+		},
+		{
+			sessionId: 'demo-cursor-root', display: 'Detect Cursor Agent sessions and their Task subagents',
+			timestamp: Date.now() - 4 * 60_000, project: '/Users/demo/projects/c9watch', projectName: 'c9watch',
+			customTitle: 'Cursor agent detection', provider: 'cursor', surface: 'cursor'
 		}
 	];
 }
@@ -256,6 +280,20 @@ export const demoConversations: Record<string, Conversation> = {
 		messages: [
 			{ timestamp: minutesAgo(5), messageType: 'User', content: 'Audit provider filtering across all session surfaces.' },
 			{ timestamp: minutesAgo(2), messageType: 'Assistant', content: 'History, cost, monitor, and popover now consume the same persisted provider filter.' }
+		]
+	},
+	'demo-cursor-root': {
+		sessionId: 'demo-cursor-root',
+		messages: [
+			{ timestamp: minutesAgo(4), messageType: 'User', content: 'Detect Cursor Agent sessions and their Task subagents' },
+			{ timestamp: minutesAgo(1), messageType: 'Assistant', content: 'Parsing agent-transcripts JSONL and grouping Task subagents under the parent chat.' }
+		]
+	},
+	'demo-cursor-subagent': {
+		sessionId: 'demo-cursor-subagent',
+		messages: [
+			{ timestamp: minutesAgo(3), messageType: 'User', content: 'Explore how Cursor stores agent transcripts' },
+			{ timestamp: minutesAgo(1), messageType: 'Assistant', content: 'Root chats live at <uuid>/<uuid>.jsonl; Task children are sibling files under subagents/.' }
 		]
 	},
 	'demo-1': {

--- a/src/lib/provider.ts
+++ b/src/lib/provider.ts
@@ -4,16 +4,24 @@ export type ProviderFilter = 'all' | SessionProvider;
 export type SessionAction = 'open' | 'stop' | 'rename' | 'conversation';
 type ProviderRecord = { provider?: SessionProvider | null };
 
+const KNOWN_PROVIDERS: SessionProvider[] = ['claudeCode', 'codex', 'cursor'];
+
 export function providerOf(record: ProviderRecord): SessionProvider {
-	return record.provider === 'codex' ? 'codex' : 'claudeCode';
+	return record.provider && KNOWN_PROVIDERS.includes(record.provider)
+		? record.provider
+		: 'claudeCode';
 }
 
 export function providerLabel(provider: SessionProvider): string {
-	return provider === 'codex' ? 'CODEX' : 'CLAUDE CODE';
+	if (provider === 'codex') return 'CODEX';
+	if (provider === 'cursor') return 'CURSOR';
+	return 'CLAUDE CODE';
 }
 
 export function surfaceLabel(surface?: SessionSurface): string | null {
-	if (!surface || surface === 'unknown' || surface === 'claudeCode') return null;
+	if (!surface || surface === 'unknown' || surface === 'claudeCode' || surface === 'cursor') {
+		return null;
+	}
 	return surface.toUpperCase();
 }
 
@@ -24,6 +32,7 @@ export function matchesProvider(record: ProviderRecord, filter: ProviderFilter):
 export function providerFilterLabel(filter: ProviderFilter): string {
 	if (filter === 'codex') return 'Codex';
 	if (filter === 'claudeCode') return 'Claude Code';
+	if (filter === 'cursor') return 'Cursor';
 	return 'All providers';
 }
 
@@ -35,7 +44,8 @@ export function isHiddenInternalSession(session: Session): boolean {
 }
 
 export function isCodexSubagent(session: Session): boolean {
-	return providerOf(session) === 'codex' && session.agentKind === 'subagent' && !isHiddenInternalSession(session);
+	const provider = providerOf(session);
+	return (provider === 'codex' || provider === 'cursor') && session.agentKind === 'subagent' && !isHiddenInternalSession(session);
 }
 
 export interface CodexHierarchy {
@@ -44,7 +54,7 @@ export interface CodexHierarchy {
 }
 
 /**
- * Flatten visible Codex descendants beneath their nearest visible root.
+ * Flatten visible Codex/Cursor descendants beneath their nearest visible root.
  * If every referenced ancestor has expired or is missing, the highest
  * surviving subagent is promoted so no normal agent disappears from the UI.
  */

--- a/src/lib/provider.ts
+++ b/src/lib/provider.ts
@@ -12,6 +12,19 @@ export function providerOf(record: ProviderRecord): SessionProvider {
 		: 'claudeCode';
 }
 
+/** Build the identity used by maps and UI selection instead of raw IDs. */
+export function providerSessionKey(provider: SessionProvider | undefined, id: string): string {
+	const normalized = provider && KNOWN_PROVIDERS.includes(provider) ? provider : 'claudeCode';
+	return `${normalized}:${id}`;
+}
+
+export function sessionKeyOf(session: Pick<Session, 'id' | 'provider' | 'sessionKey'>): string {
+	// Derive the key from the canonical provider/id pair.  Do not trust a
+	// stale or malformed serialized sessionKey: it is a compatibility field,
+	// while provider + id is the identity boundary that prevents collisions.
+	return providerSessionKey(providerOf(session), session.id);
+}
+
 export function providerLabel(provider: SessionProvider): string {
 	if (provider === 'codex') return 'CODEX';
 	if (provider === 'cursor') return 'CURSOR';
@@ -59,18 +72,18 @@ export interface CodexHierarchy {
  * surviving subagent is promoted so no normal agent disappears from the UI.
  */
 export function resolveCodexHierarchy(sessions: Session[]): CodexHierarchy {
-	const byId = new Map(sessions.map((session) => [session.id, session]));
+	const byId = new Map(sessions.map((session) => [sessionKeyOf(session), session]));
 	const topLevelIds = new Set(
 		sessions
 			.filter((session) => !isHiddenInternalSession(session) && !isCodexSubagent(session))
-			.map((session) => session.id)
+			.map((session) => sessionKeyOf(session))
 	);
 	const subagentsByParent = new Map<string, Session[]>();
 
 	function nextExistingAncestor(session: Session): Session | null {
 		for (const id of [session.parentThreadId, session.rootSessionId]) {
 			if (!id || id === session.id) continue;
-			const ancestor = byId.get(id);
+			const ancestor = byId.get(providerSessionKey(providerOf(session), id));
 			if (ancestor) return ancestor;
 		}
 		return null;
@@ -81,11 +94,11 @@ export function resolveCodexHierarchy(sessions: Session[]): CodexHierarchy {
 
 		let cursor = session;
 		let anchor: Session = session;
-		const visited = new Set([session.id]);
+		const visited = new Set([sessionKeyOf(session)]);
 		while (true) {
 			const ancestor = nextExistingAncestor(cursor);
-			if (!ancestor || visited.has(ancestor.id)) break;
-			visited.add(ancestor.id);
+			if (!ancestor || visited.has(sessionKeyOf(ancestor))) break;
+			visited.add(sessionKeyOf(ancestor));
 			if (!isHiddenInternalSession(ancestor) && !isCodexSubagent(ancestor)) {
 				anchor = ancestor;
 				break;
@@ -94,13 +107,13 @@ export function resolveCodexHierarchy(sessions: Session[]): CodexHierarchy {
 			cursor = ancestor;
 		}
 
-		if (anchor.id === session.id) {
-			topLevelIds.add(session.id);
+		if (sessionKeyOf(anchor) === sessionKeyOf(session)) {
+			topLevelIds.add(sessionKeyOf(session));
 			continue;
 		}
-		const group = subagentsByParent.get(anchor.id) ?? [];
+		const group = subagentsByParent.get(sessionKeyOf(anchor)) ?? [];
 		group.push(session);
-		subagentsByParent.set(anchor.id, group);
+		subagentsByParent.set(sessionKeyOf(anchor), group);
 	}
 
 	return { topLevelIds, subagentsByParent };

--- a/src/lib/stores/conversation-loader.ts
+++ b/src/lib/stores/conversation-loader.ts
@@ -1,0 +1,89 @@
+import { get, writable } from 'svelte/store';
+import { listen } from '@tauri-apps/api/event';
+import { isTauri, useWebSocket, wsClient } from '$lib/ws';
+
+export type ConversationLoadKind = 'conversation' | 'tools';
+
+export interface ConversationLoadState {
+	sessionId: string;
+	kind: ConversationLoadKind;
+	bytesRead: number;
+	bytesTotal: number;
+	generation: number;
+}
+
+export interface ConversationProgressEvent {
+	sessionId: string;
+	bytesRead: number;
+	bytesTotal: number;
+}
+
+export const conversationLoad = writable<ConversationLoadState | null>(null);
+
+/** Session whose in-memory conversation already includes tool dumps. */
+export const toolsLoadedFor = writable<string | null>(null);
+
+let progressListenerStarted = false;
+let loadGeneration = 0;
+
+export function conversationLoadPercent(state: ConversationLoadState | null): number | null {
+	if (!state || state.bytesTotal <= 0) return null;
+	return Math.min(100, Math.floor((state.bytesRead / state.bytesTotal) * 100));
+}
+
+export function conversationLoadLabel(state: ConversationLoadState | null): string | null {
+	if (!state) return null;
+	const kind = state.kind === 'tools' ? 'LOADING TOOLS' : 'LOADING';
+	const percent = conversationLoadPercent(state);
+	return percent == null ? kind : `${kind} · ${percent}%`;
+}
+
+export function isSessionLoading(sessionId: string, state: ConversationLoadState | null): boolean {
+	return state?.sessionId === sessionId;
+}
+
+export function isToolsLoading(sessionId: string, state: ConversationLoadState | null): boolean {
+	return state?.sessionId === sessionId && state.kind === 'tools';
+}
+
+function applyProgress(payload: ConversationProgressEvent) {
+	conversationLoad.update((state) => {
+		if (!state || state.sessionId !== payload.sessionId) return state;
+		return {
+			...state,
+			bytesRead: payload.bytesRead,
+			bytesTotal: payload.bytesTotal
+		};
+	});
+}
+
+export async function initConversationProgressListener() {
+	if (progressListenerStarted) return;
+	progressListenerStarted = true;
+
+	if (useWebSocket()) {
+		wsClient.on('conversationProgress', applyProgress);
+		return;
+	}
+	if (isTauri()) {
+		await listen<ConversationProgressEvent>('conversation-progress', (event) => {
+			applyProgress(event.payload);
+		});
+	}
+}
+
+export async function withConversationLoader<T>(
+	sessionId: string,
+	kind: ConversationLoadKind,
+	task: () => Promise<T>
+): Promise<T> {
+	const generation = ++loadGeneration;
+	conversationLoad.set({ sessionId, kind, bytesRead: 0, bytesTotal: 0, generation });
+	try {
+		return await task();
+	} finally {
+		if (get(conversationLoad)?.generation === generation) {
+			conversationLoad.set(null);
+		}
+	}
+}

--- a/src/lib/stores/cost.ts
+++ b/src/lib/stores/cost.ts
@@ -9,6 +9,7 @@ import { browser } from '$app/environment';
 import { getCostData } from '../api';
 import type { CostData, SessionCostRecord } from '../types';
 import { buildSessionCostMap, type CostMode } from '../cost-utils';
+import { providerSessionKey } from '../provider';
 
 const COST_MODE_KEY = 'c9watch.costMode';
 
@@ -51,6 +52,6 @@ export async function refreshCostData(): Promise<void> {
 }
 
 /** Convenience: snapshot the cost record for one session. */
-export function getSessionCost(sessionId: string): SessionCostRecord | undefined {
-	return get(sessionCostMap).get(sessionId);
+export function getSessionCost(sessionId: string, provider?: SessionCostRecord['provider']): SessionCostRecord | undefined {
+	return get(sessionCostMap).get(providerSessionKey(provider, sessionId));
 }

--- a/src/lib/stores/provider-filter.ts
+++ b/src/lib/stores/provider-filter.ts
@@ -5,7 +5,7 @@ import type { ProviderFilter } from '$lib/provider';
 const STORAGE_KEY = 'c9watch.providerFilter';
 
 function sanitize(value: string | null): ProviderFilter {
-	return value === 'claudeCode' || value === 'codex' ? value : 'all';
+	return value === 'claudeCode' || value === 'codex' || value === 'cursor' ? value : 'all';
 }
 
 export const providerFilter = writable<ProviderFilter>(

--- a/src/lib/stores/sessions.ts
+++ b/src/lib/stores/sessions.ts
@@ -10,7 +10,7 @@ import { SessionStatus } from '../types';
 import { isDemoMode } from '../demo/mode';
 import { openSession } from '../api';
 import { wsClient, useWebSocket, getStoredWsUrl, isTauri } from '../ws';
-import { resolveCodexHierarchy } from '../provider';
+import { providerSessionKey, resolveCodexHierarchy, sessionKeyOf } from '../provider';
 
 /**
  * Store containing all active sessions
@@ -18,7 +18,7 @@ import { resolveCodexHierarchy } from '../provider';
 export const sessions = writable<Session[]>([]);
 
 /**
- * Store containing the currently expanded session ID (for overlay)
+ * Store containing the currently expanded provider-scoped session key.
  */
 export const expandedSessionId = writable<string | null>(null);
 
@@ -64,9 +64,10 @@ export const workersByPm = derived(sessions, ($sessions) => {
 	const m = new Map<string, Session[]>();
 	for (const s of $sessions) {
 		if (s.workerOf) {
-			const arr = m.get(s.workerOf) ?? [];
+			const ownerKey = providerSessionKey('claudeCode', s.workerOf);
+			const arr = m.get(ownerKey) ?? [];
 			arr.push(s);
-			m.set(s.workerOf, arr);
+			m.set(ownerKey, arr);
 		}
 	}
 	return m;
@@ -81,7 +82,7 @@ export const codexSubagentsByParent = derived(codexHierarchy, ($hierarchy) => $h
 export const codexVisibleParentByChild = derived(codexSubagentsByParent, ($groups) => {
 	const parents = new Map<string, string>();
 	for (const [parentId, children] of $groups) {
-		for (const child of children) parents.set(child.id, parentId);
+		for (const child of children) parents.set(sessionKeyOf(child), parentId);
 	}
 	return parents;
 });
@@ -143,6 +144,8 @@ export const statusSummary = derived(sessions, ($sessions) => {
 interface NotificationMetadata {
 	notificationId: number;
 	sessionId: string;
+	sessionKey?: string;
+	provider?: Session['provider'];
 	pid: number;
 	projectPath: string;
 	title: string;
@@ -185,7 +188,7 @@ async function initWebSocketListeners() {
 		}
 	});
 
-	wsClient.on('notification', (data: { title: string; body: string; sessionId: string; pid: number }) => {
+	wsClient.on('notification', (data: { title: string; body: string; sessionId: string; sessionKey?: string; provider?: Session['provider']; pid: number }) => {
 		if (get(isDemoMode)) return;
 		showInAppNotification(data.title, data.body);
 	});

--- a/src/lib/stores/sessions.ts
+++ b/src/lib/stores/sessions.ts
@@ -11,6 +11,7 @@ import { isDemoMode } from '../demo/mode';
 import { openSession } from '../api';
 import { wsClient, useWebSocket, getStoredWsUrl, isTauri } from '../ws';
 import { resolveCodexHierarchy } from '../provider';
+import { initConversationProgressListener } from './conversation-loader';
 
 /**
  * Store containing all active sessions
@@ -161,6 +162,7 @@ export async function initializeSessionListeners() {
 	} else {
 		await initTauriListeners();
 	}
+	await initConversationProgressListener();
 }
 
 // ── WebSocket mode ──────────────────────────────────────────────────

--- a/src/lib/stores/subagents.ts
+++ b/src/lib/stores/subagents.ts
@@ -10,6 +10,7 @@ import { writable, derived, get } from 'svelte/store';
 import { invoke } from '@tauri-apps/api/core';
 import { sessions } from './sessions';
 import { isTauri } from '../ws';
+import { providerSessionKey } from '../provider';
 
 export type SubagentStatus = 'running' | 'completed';
 
@@ -58,10 +59,12 @@ async function refreshOnce() {
 	if (!isTauri()) return;
 	try {
 		const raw = await invoke<Record<string, SubagentInfo[]>>('get_subagents');
-		const m = new Map<string, SubagentInfo[]>();
-		for (const [k, v] of Object.entries(raw)) {
-			m.set(k, v);
-		}
+			const m = new Map<string, SubagentInfo[]>();
+			for (const [k, v] of Object.entries(raw)) {
+				// Accept the provider-scoped key from current backends and normalize
+				// older Claude-only payloads that used the raw session ID.
+				m.set(k.includes(':') ? k : providerSessionKey('claudeCode', k), v);
+			}
 		subagentsBySession.set(m);
 	} catch {
 		// Backend may be unavailable in non-Tauri contexts; ignore.

--- a/src/lib/stores/subagents.ts
+++ b/src/lib/stores/subagents.ts
@@ -21,7 +21,7 @@ export interface SubagentInfo {
 	completedAt: string | null;
 	parentSessionId: string;
 	status: SubagentStatus;
-	provider?: 'claudeCode' | 'codex';
+	provider?: 'claudeCode' | 'codex' | 'cursor';
 	sessionId?: string;
 }
 

--- a/src/lib/stores/tasks.ts
+++ b/src/lib/stores/tasks.ts
@@ -11,8 +11,9 @@ import { invoke } from '@tauri-apps/api/core';
 import { sessions } from './sessions';
 import { isTauri } from '../ws';
 import type { Task, TaskStatus } from '../types';
+import { providerOf, providerSessionKey } from '../provider';
 
-/** Raw map: session id -> ordered task list (sorted by numeric id). */
+/** Provider-scoped session key -> ordered task list (sorted by numeric id). */
 export const tasksBySession = writable<Map<string, Task[]>>(new Map());
 
 let pollHandle: ReturnType<typeof setInterval> | null = null;
@@ -24,7 +25,11 @@ function normalizeStatus(s: unknown): TaskStatus {
 
 async function refreshOnce() {
 	if (!isTauri()) return;
-	const ids = get(sessions).map((s) => s.id);
+	// TodoWrite tasks are a Claude Code namespace. Do not query or cache them
+	// for Codex/Cursor sessions whose opaque IDs may collide with Claude IDs.
+	const ids = get(sessions)
+		.filter((s) => providerOf(s) === 'claudeCode')
+		.map((s) => s.id);
 	const next = new Map<string, Task[]>();
 
 	await Promise.all(
@@ -45,7 +50,7 @@ async function refreshOnce() {
 					};
 				});
 				if (tasks.length > 0) {
-					next.set(sessionId, tasks);
+					next.set(providerSessionKey('claudeCode', sessionId), tasks);
 				}
 			} catch {
 				// Backend may be unavailable; skip silently (mirrors subagents).

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -12,8 +12,8 @@ export enum SessionStatus {
   Connecting = 'Connecting'            // Session starting up
 }
 
-export type SessionProvider = 'claudeCode' | 'codex';
-export type SessionSurface = 'claudeCode' | 'app' | 'cli' | 'exec' | 'integration' | 'unknown';
+export type SessionProvider = 'claudeCode' | 'codex' | 'cursor';
+export type SessionSurface = 'claudeCode' | 'app' | 'cli' | 'exec' | 'integration' | 'cursor' | 'unknown';
 export type AgentKind = 'root' | 'subagent' | 'internal';
 
 export interface SessionActionCapabilities {

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -34,6 +34,9 @@ export interface Session {
   /** Session UUID */
   id: string;
 
+  /** Provider-scoped identity; falls back to provider + id for old payloads. */
+  sessionKey?: string;
+
   /** Process ID of the running Claude instance */
   pid: number;
 
@@ -135,6 +138,8 @@ export interface Message {
 export interface Conversation {
   /** Session ID this conversation belongs to */
   sessionId: string;
+  /** Provider namespace used to verify the response identity. */
+  provider?: SessionProvider;
 
   /** Array of messages in chronological order */
   messages: Message[];
@@ -146,6 +151,8 @@ export interface Conversation {
  */
 export interface DeepSearchHit {
   sessionId: string;
+  provider?: SessionProvider;
+  surface?: SessionSurface;
   /** ~200-char snippet from the first matching message line, with '…' padding if truncated. */
   snippet: string;
 }
@@ -156,6 +163,9 @@ export interface DeepSearchHit {
 export interface HistoryEntry {
   /** Session UUID */
   sessionId: string;
+
+  /** Provider-scoped identity for UI maps; old payloads can derive it. */
+  sessionKey?: string;
 
   /** The user's prompt text as displayed in Claude Code. May be an empty string. */
   display: string;

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -46,6 +46,12 @@ export interface Session {
   /** Custom title override for the session - if set, shown instead of summary/firstPrompt */
   customTitle: string | null;
 
+  /** Current Codex UI thread name from ~/.codex/session_index.jsonl. */
+  codexTitle?: string | null;
+
+  /** Current Cursor UI composer name from state.vscdb. */
+  cursorTitle?: string | null;
+
   /** Full path to project directory */
   projectPath: string;
 
@@ -185,6 +191,11 @@ export interface HistoryEntry {
 
   /** Custom title override — if set, shown instead of the first prompt */
   customTitle: string | null;
+
+  /** Current Codex UI thread name from ~/.codex/session_index.jsonl. */
+  codexTitle?: string | null;
+  /** Current Cursor UI composer name from state.vscdb. */
+  cursorTitle?: string | null;
   provider?: SessionProvider;
   surface?: SessionSurface;
 }

--- a/src/lib/ws.ts
+++ b/src/lib/ws.ts
@@ -99,6 +99,10 @@ class WsClient {
 				this.emit('notification', msg.data);
 				return;
 			}
+			if (msg.type === 'conversationProgress') {
+				this.emit('conversationProgress', msg.data);
+				return;
+			}
 
 			// Request-response: resolve or reject the pending promise
 			if (msg.type === 'error') {

--- a/src/routes/(app)/+page.svelte
+++ b/src/routes/(app)/+page.svelte
@@ -35,7 +35,7 @@
 	import type { DetectionDiagnostics } from '$lib/types';
 	import ProviderFilter from '$lib/components/ProviderFilter.svelte';
 	import { providerFilter } from '$lib/stores/provider-filter';
-	import { matchesProvider, providerFilterLabel } from '$lib/provider';
+	import { matchesProvider, providerFilterLabel, providerSessionKey, providerOf, sessionKeyOf } from '$lib/provider';
 
 	let demoActive = $derived($isDemoMode);
 	let showQRModal = $state(false);
@@ -43,7 +43,7 @@
 	let needsConnection = $state(!isTauri());
 
 	let sessions = $derived($sortedSessions);
-	let activeSessionIds = $derived(new Set(sessions.map((s) => s.id)));
+	let activeSessionIds = $derived(new Set(sessions.map((s) => sessionKeyOf(s))));
 	let summary = $derived($statusSummary);
 	let expandedId = $derived($expandedSessionId);
 	let conversation = $derived($currentConversation);
@@ -265,7 +265,7 @@
 	// records render as ordinary sessions and the HUMANS/WORKERS split is gone.
 	let filteredSessions = $derived.by(() => {
 		const providerSessions = sessions
-			.filter((session) => $visibleTopLevelSessionIds.has(session.id))
+			.filter((session) => $visibleTopLevelSessionIds.has(sessionKeyOf(session)))
 			.filter((session) => matchesProvider(session, $providerFilter));
 		return !PM_ORCHESTRATION_ENABLED
 			? providerSessions
@@ -314,7 +314,7 @@
 		).length
 	});
 
-	let expandedSession = $derived(sessions.find((s) => s.id === expandedId) || null);
+	let expandedSession = $derived(sessions.find((s) => sessionKeyOf(s) === expandedId) || null);
 
 	$effect(() => {
 		if (expandedSession && !matchesProvider(expandedSession, $providerFilter)) {
@@ -327,11 +327,13 @@
 		const sessionId = expandedId;
 		const requestId = ++conversationRequestId;
 		currentConversation.set(null);
-		if (sessionId) {
-			getConversation(sessionId)
-				.then((conv) => {
-					if (requestId === conversationRequestId && conv.sessionId === sessionId) {
-						currentConversation.set(conv);
+		const selected = expandedSession;
+		if (sessionId && selected) {
+				getConversation(selected.id, selected.provider)
+					.then((conv) => {
+						const responseKey = providerSessionKey(conv.provider ?? providerOf(selected), conv.sessionId);
+						if (requestId === conversationRequestId && responseKey === sessionId) {
+							currentConversation.set(conv);
 					}
 				})
 				.catch((error) => {
@@ -342,7 +344,7 @@
 	});
 
 	function handleExpand(session: Session) {
-		expandedSessionId.set(session.id);
+		expandedSessionId.set(sessionKeyOf(session));
 	}
 
 	function handleClose() {
@@ -661,7 +663,7 @@
 										<span class="status-count">{group.attention.length}</span>
 									</div>
 									<div class="session-grid">
-										{#each group.attention as session, i (session.id)}
+						{#each group.attention as session, i (sessionKeyOf(session))}
 											<div
 												class="card-wrapper"
 												in:flyIn|global={{ index: baseIdx + 1 + i }}
@@ -688,7 +690,7 @@
 										<span class="status-count">{group.idle.length}</span>
 									</div>
 									<div class="session-grid">
-										{#each group.idle as session, i (session.id)}
+						{#each group.idle as session, i (sessionKeyOf(session))}
 											<div
 												class="card-wrapper"
 												in:flyIn|global={{ index: baseIdx + 1 + group.attention.length + i }}
@@ -715,7 +717,7 @@
 										<span class="status-count">{group.working.length}</span>
 									</div>
 									<div class="session-grid">
-										{#each group.working as session, i (session.id)}
+						{#each group.working as session, i (sessionKeyOf(session))}
 											<div
 												class="card-wrapper"
 												in:flyIn|global={{ index: baseIdx + 1 + group.attention.length + group.idle.length + i }}
@@ -749,7 +751,7 @@
 							</div>
 
 							<div class="all-sessions-grid" class:compact={isCompact}>
-								{#each group.sessions as session, i (session.id)}
+					{#each group.sessions as session, i (sessionKeyOf(session))}
 									<div
 										class="card-wrapper"
 										in:flyIn|global={{ index: baseIdx + 1 + i }}

--- a/src/routes/(app)/+page.svelte
+++ b/src/routes/(app)/+page.svelte
@@ -452,7 +452,7 @@
 				<span class="drag-dots" transition:fade={{ duration: 250 }}>⠿ ⠿ ⠿</span>
 			{/if}
 		</div>
-		<div class="global-provider-filter"><ProviderFilter compact /></div>
+		<div class="global-provider-filter"><ProviderFilter compact variant="select" /></div>
 		<button
 			class="tab-btn"
 			class:active={activeTab === 'settings'}
@@ -626,7 +626,7 @@
 							</div>
 						{:else}
 							<h2>No {providerFilterLabel($providerFilter)} Sessions</h2>
-							<p>{ $providerFilter === 'all' ? 'Start a Claude Code or Codex session' : `Start a ${providerFilterLabel($providerFilter)} session` }</p>
+							<p>{ $providerFilter === 'all' ? 'Start a Claude Code, Codex, or Cursor Agent session' : `Start a ${providerFilterLabel($providerFilter)} session` }</p>
 							<div class="empty-hint">
 								<span class="hint-icon">
 									<svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">

--- a/src/routes/(app)/+page.svelte
+++ b/src/routes/(app)/+page.svelte
@@ -12,6 +12,8 @@
 		visibleTopLevelSessionIds
 	} from '$lib/stores/sessions';
 	import { getConversation, stopSession, openSession } from '$lib/api';
+	import { toolsLoadedFor, withConversationLoader } from '$lib/stores/conversation-loader';
+	import { get } from 'svelte/store';
 	import { isDemoMode, toggleDemoMode } from '$lib/demo';
 	import { PM_ORCHESTRATION_ENABLED } from '$lib/feature-flags';
 	import { isTauri } from '$lib/ws';
@@ -327,12 +329,13 @@
 		const sessionId = expandedId;
 		const requestId = ++conversationRequestId;
 		currentConversation.set(null);
+		toolsLoadedFor.set(null);
 		if (sessionId) {
-			getConversation(sessionId)
+			withConversationLoader(sessionId, 'conversation', () => getConversation(sessionId, false))
 				.then((conv) => {
-					if (requestId === conversationRequestId && conv.sessionId === sessionId) {
-						currentConversation.set(conv);
-					}
+					if (requestId !== conversationRequestId || conv.sessionId !== sessionId) return;
+					if (get(toolsLoadedFor) === sessionId) return;
+					currentConversation.set(conv);
 				})
 				.catch((error) => {
 					console.error('Failed to fetch conversation:', error);

--- a/src/routes/popover/+page.svelte
+++ b/src/routes/popover/+page.svelte
@@ -183,7 +183,7 @@
 							</svg>
 							{/if}
 						</div>
-						<div class="card-title">{session.customTitle || session.firstPrompt}</div>
+						<div class="card-title">{session.customTitle || session.officialName || session.codexTitle || session.cursorTitle || session.summary || session.firstPrompt}</div>
 						{#if session.latestMessage}
 							<div class="card-latest">{session.latestMessage}</div>
 						{/if}

--- a/src/routes/popover/+page.svelte
+++ b/src/routes/popover/+page.svelte
@@ -8,11 +8,11 @@
 	import { listen } from '@tauri-apps/api/event';
 	import { isDemoMode, loadDemoDataIfActive } from '$lib/demo';
 	import { providerFilter } from '$lib/stores/provider-filter';
-	import { canSessionAction, matchesProvider, providerFilterLabel } from '$lib/provider';
+	import { canSessionAction, matchesProvider, providerFilterLabel, sessionKeyOf } from '$lib/provider';
 	import ProviderFilter from '$lib/components/ProviderFilter.svelte';
 	import ProviderBadge from '$lib/components/ProviderBadge.svelte';
 
-	let sessions = $derived($sortedSessions.filter((session) => $visibleTopLevelSessionIds.has(session.id)).filter((session) => matchesProvider(session, $providerFilter)));
+	let sessions = $derived($sortedSessions.filter((session) => $visibleTopLevelSessionIds.has(sessionKeyOf(session))).filter((session) => matchesProvider(session, $providerFilter)));
 	let summary = $derived({
 		working: sessions.filter((s) => s.status === SessionStatus.Working || s.status === SessionStatus.Connecting).length,
 		permission: sessions.filter((s) => s.status === SessionStatus.NeedsAttention).length,
@@ -169,7 +169,7 @@
 			</div>
 		{:else}
 			<div class="session-list">
-				{#each sessions as session (session.id)}
+				{#each sessions as session (sessionKeyOf(session))}
 					<button class="session-card" disabled={!canSessionAction(session, 'open')} onclick={() => handleOpen(session)}>
 						<div class="card-top">
 							<span class="session-dot" style="background: {getStatusColor(session.status)}"></span>


### PR DESCRIPTION
Adds Cursor Agent discovery, monitoring, history and conversation viewing, provider-native Codex/Cursor titles, and provider-qualified session identity across UI, CLI and WebSocket routing. Shared provider sources reuse parsing state; file identity and prefix checks recover from transcript rewrites. Release metadata and gated release workflow advance to v0.10.0.

The archive optimization and memory hotfix are already merged through #122 and #123. This branch integrates both, preserves response_item conversation text while skipping irrelevant tool payloads, retains bounded archive memory, correlates WebSocket requests, rejects stale overlay results and throttles progress updates. Removed incomplete Pi references; Pi support remains in #121.

Validation: default Rust suite 379 passed, CLI-only 360 passed, plus 3 parser integration tests per configuration; 2 library tests and 1 background integration test remain ignored. Svelte check reports zero errors/warnings, frontend production build and WebSocket regression tests pass. Final commit is also covered by PR CI. Native Cursor end-to-end, signing and notarization are not established by these source checks.
