### PR TITLE
perf: reuse Codex archive cache and load conversation tools on demand

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,6 +32,9 @@ jobs:
       - name: Svelte check
         run: npm run check
 
+      - name: WebSocket request regression tests
+        run: node --test scripts/test-ws.mjs
+
       - name: Rust check
         run: cargo check --manifest-path src-tauri/Cargo.toml
 

--- a/scripts/test-ws.mjs
+++ b/scripts/test-ws.mjs
@@ -1,0 +1,54 @@
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import vm from 'node:vm';
+import ts from 'typescript';
+import { test } from 'node:test';
+
+function client() {
+  const exports = {};
+  const code = ts.transpileModule(readFileSync(new URL('../src/lib/ws.ts', import.meta.url), 'utf8'), {
+    compilerOptions: { module: ts.ModuleKind.CommonJS, target: ts.ScriptTarget.ES2022 }
+  }).outputText;
+  vm.runInNewContext(code, { exports, console, setTimeout, clearTimeout, WebSocket: { OPEN: 1 } });
+  const client = exports.wsClient;
+  const sent = [];
+  client.ws = { readyState: 1, send: text => sent.push(JSON.parse(text)) };
+  return { client, sent, reply: msg => client.handleMessage({ data: JSON.stringify(msg) }) };
+}
+
+test('conversations and actions receive their own out-of-order responses', async () => {
+  const { client: c, sent, reply } = client();
+  const conversation = c.request('getConversation', { sessionId: 'one' });
+  const action = c.request('openSession', { pid: 123 });
+  reply({ type: 'ok', requestId: sent[1].requestId });
+  assert.equal((await action).type, 'ok');
+  reply({ type: 'conversation', requestId: sent[0].requestId, data: { sessionId: 'one' } });
+  assert.equal((await conversation).sessionId, 'one');
+});
+
+test('superseded request rejects without settling the next conversation', async () => {
+  const { client: c, sent, reply } = client();
+  const first = c.request('getConversation', { sessionId: 'one' });
+  const rejected = assert.rejects(first, /superseded/);
+  const second = c.request('getConversation', { sessionId: 'two' });
+  reply({ type: 'error', requestId: sent[0].requestId, message: 'Conversation request superseded' });
+  await rejected;
+  reply({ type: 'conversation', requestId: sent[0].requestId, data: { sessionId: 'stale' } });
+  reply({ type: 'conversation', requestId: sent[1].requestId, data: { sessionId: 'two' } });
+  assert.equal((await second).sessionId, 'two');
+});
+
+test('push events do not settle requests and disconnect rejects all pending requests', async () => {
+  const { client: c, sent, reply } = client();
+  let updates = 0;
+  c.on('sessionsUpdated', () => updates++);
+  const one = assert.rejects(c.request('getSessions'), /closed/);
+  const two = assert.rejects(c.request('getConversation'), /closed/);
+  reply({ type: 'sessionsUpdated', data: [] });
+  reply({ type: 'conversationProgress', data: { requestId: sent[1].requestId } });
+  assert.equal(updates, 1);
+  assert.equal(c.pending.size, 2);
+  c.rejectPending('Connection closed');
+  await Promise.all([one, two]);
+  assert.equal(c.pending.size, 0);
+});

--- a/src-tauri/src/cli/mod.rs
+++ b/src-tauri/src/cli/mod.rs
@@ -471,7 +471,7 @@ fn cmd_status(project_filter: Option<&str>, pretty: bool) -> Result<(), String> 
 
 fn cmd_view(session_id: &str, last: Option<usize>, pretty: bool) -> Result<(), String> {
     let resolved_id = resolve_session_id_lightweight(session_id)?;
-    let mut conversation = session::conversation::get_conversation_data(&resolved_id)?;
+    let mut conversation = session::conversation::get_conversation_data(&resolved_id, true)?;
 
     if let Some(n) = last {
         let len = conversation.messages.len();

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -26,10 +26,10 @@ use polling::{start_polling, Session};
 #[cfg(feature = "gui")]
 use serde::Serialize;
 #[cfg(feature = "gui")]
-use session::conversation::Conversation;
+use session::conversation::{Conversation, ConversationProgress};
 // Re-export for web_server.rs which uses crate::get_conversation_data
 #[cfg(feature = "gui")]
-pub use session::conversation::get_conversation_data;
+pub use session::conversation::{get_conversation_data, get_conversation_data_with_progress};
 #[cfg(feature = "gui")]
 use std::sync::{Arc, Mutex};
 #[cfg(feature = "gui")]
@@ -74,8 +74,27 @@ async fn get_sessions(
 
 #[cfg(all(not(mobile), feature = "gui"))]
 #[tauri::command]
-async fn get_conversation(session_id: String) -> Result<Conversation, String> {
-    get_conversation_data(&session_id)
+async fn get_conversation(
+    app: tauri::AppHandle,
+    session_id: String,
+    include_tools: Option<bool>,
+) -> Result<Conversation, String> {
+    let include_tools = include_tools.unwrap_or(false);
+    tauri::async_runtime::spawn_blocking(move || {
+        let emit_id = session_id.clone();
+        get_conversation_data_with_progress(&session_id, include_tools, &mut |bytes_read, bytes_total| {
+            let _ = app.emit(
+                "conversation-progress",
+                ConversationProgress {
+                    session_id: emit_id.clone(),
+                    bytes_read,
+                    bytes_total,
+                },
+            );
+        })
+    })
+    .await
+    .map_err(|error| format!("Failed to load conversation: {error}"))?
 }
 
 #[cfg(all(not(mobile), feature = "gui"))]
@@ -410,6 +429,7 @@ pub fn run() {
 
             let (sessions_tx, _rx) = tokio::sync::broadcast::channel::<String>(16);
             let (notifications_tx, _nrx) = tokio::sync::broadcast::channel::<String>(16);
+            let (progress_tx, _prx) = tokio::sync::broadcast::channel::<String>(32);
 
             let server_info = ServerInfo {
                 token: token.clone(),
@@ -423,6 +443,7 @@ pub fn run() {
                 auth_token: token,
                 sessions_tx: sessions_tx.clone(),
                 notifications_tx: notifications_tx.clone(),
+                progress_tx,
             });
             tauri::async_runtime::spawn(web_server::start_server(ws_state));
 

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -429,7 +429,6 @@ pub fn run() {
 
             let (sessions_tx, _rx) = tokio::sync::broadcast::channel::<String>(16);
             let (notifications_tx, _nrx) = tokio::sync::broadcast::channel::<String>(16);
-            let (progress_tx, _prx) = tokio::sync::broadcast::channel::<String>(32);
 
             let server_info = ServerInfo {
                 token: token.clone(),
@@ -443,7 +442,6 @@ pub fn run() {
                 auth_token: token,
                 sessions_tx: sessions_tx.clone(),
                 notifications_tx: notifications_tx.clone(),
-                progress_tx,
             });
             tauri::async_runtime::spawn(web_server::start_server(ws_state));
 

--- a/src-tauri/src/session/codex.rs
+++ b/src-tauri/src/session/codex.rs
@@ -941,26 +941,6 @@ fn path_matches_thread(path: &Path, suffix: &str) -> bool {
         .is_some_and(|name| name.starts_with("rollout-") && name.ends_with(suffix))
 }
 
-fn scan_recent_thread_rollouts(sessions_root: &Path, suffix: &str) -> Vec<PathBuf> {
-    let now = Local::now();
-    [now, now - chrono::Duration::days(1)]
-        .into_iter()
-        .flat_map(|day| {
-            let dir = sessions_root
-                .join(day.format("%Y").to_string())
-                .join(day.format("%m").to_string())
-                .join(day.format("%d").to_string());
-            fs::read_dir(dir)
-                .ok()
-                .into_iter()
-                .flatten()
-                .flatten()
-                .map(|entry| entry.path())
-        })
-        .filter(|path| path.is_file() && path_matches_thread(path, suffix))
-        .collect()
-}
-
 fn collect_thread_rollouts(sessions_root: &Path, suffix: &str) -> Vec<PathBuf> {
     collect_rollout_paths(sessions_root)
         .into_iter()
@@ -968,9 +948,8 @@ fn collect_thread_rollouts(sessions_root: &Path, suffix: &str) -> Vec<PathBuf> {
         .collect()
 }
 
-/// Cache is a hint: union today's/yesterday's files so resume/compaction
-/// rollouts are not missed. If the cache is cold or every cached path is gone,
-/// fall through to a full walk.
+/// Cache is only a seed. Always walk so resume/compaction fragments outside
+/// today/yesterday are not dropped just because an older cached path still exists.
 fn resolve_thread_rollout_paths(sessions_root: &Path, thread_id: &str) -> Vec<PathBuf> {
     resolve_thread_rollout_paths_with_cache(
         sessions_root,
@@ -985,20 +964,13 @@ fn resolve_thread_rollout_paths_with_cache(
     cached: Option<Vec<PathBuf>>,
 ) -> Vec<PathBuf> {
     let suffix = thread_rollout_suffix(thread_id);
-    if let Some(mut paths) = cached {
-        for path in scan_recent_thread_rollouts(sessions_root, &suffix) {
-            if !paths.iter().any(|existing| existing == &path) {
-                paths.push(path);
-            }
-        }
-        paths.retain(|path| path.is_file());
-        if !paths.is_empty() {
-            paths.sort();
-            return paths;
+    let mut paths = cached.unwrap_or_default();
+    for path in collect_thread_rollouts(sessions_root, &suffix) {
+        if !paths.iter().any(|existing| existing == &path) {
+            paths.push(path);
         }
     }
-
-    let mut paths = collect_thread_rollouts(sessions_root, &suffix);
+    paths.retain(|path| path.is_file());
     paths.sort();
     paths
 }
@@ -2644,6 +2616,39 @@ mod tests {
             Some(vec![old_day.join("deleted.jsonl")]),
         );
         assert_eq!(resolved, vec![old_path]);
+    }
+
+    #[test]
+    fn conversation_lookup_walks_for_fragments_outside_cached_days() {
+        let temp = TempDir::new().unwrap();
+        let cached_day = temp.path().join("2026/07/12");
+        let later_day = temp.path().join("2026/07/14");
+        fs::create_dir_all(&cached_day).unwrap();
+        fs::create_dir_all(&later_day).unwrap();
+        let cached_path = cached_day.join("rollout-2026-07-12T23-00-00-thread-id.jsonl");
+        let later_path = later_day.join("rollout-2026-07-14T01-00-00-thread-id.jsonl");
+        write_lines(
+            &cached_path,
+            &root_fixture(Value::String("cli".into()), "codex-tui"),
+            true,
+        );
+        write_lines(
+            &later_path,
+            &[event(
+                "2026-07-14T01:00:00Z",
+                "event_msg",
+                serde_json::json!({"type":"user_message","message":"later fragment"}),
+            )],
+            true,
+        );
+
+        let resolved = resolve_thread_rollout_paths_with_cache(
+            temp.path(),
+            "thread-id",
+            Some(vec![cached_path.clone()]),
+        );
+        assert!(resolved.contains(&cached_path));
+        assert!(resolved.contains(&later_path));
     }
 
     #[test]

--- a/src-tauri/src/session/codex.rs
+++ b/src-tauri/src/session/codex.rs
@@ -129,7 +129,10 @@ pub struct CodexSessionSource {
     cache: HashMap<PathBuf, CacheEntry>,
     archive_index: HashMap<String, Vec<PathBuf>>,
     last_full_discovery: Option<SystemTime>,
+    /// When true, parse complete JSONL lines instead of the compact monitor path.
     capture_tool_messages: bool,
+    /// When true (and using the full-parse path), keep Codex tool use/result records.
+    include_tools: bool,
     #[cfg(test)]
     parse_count: usize,
     #[cfg(test)]
@@ -149,6 +152,7 @@ impl CodexSessionSource {
             archive_index: HashMap::new(),
             last_full_discovery: None,
             capture_tool_messages: false,
+            include_tools: false,
             #[cfg(test)]
             parse_count: 0,
             #[cfg(test)]
@@ -156,9 +160,10 @@ impl CodexSessionSource {
         }
     }
 
-    fn conversation_at_root(sessions_root: PathBuf) -> Self {
+    fn conversation_at_root(sessions_root: PathBuf, include_tools: bool) -> Self {
         Self {
             capture_tool_messages: true,
+            include_tools,
             ..Self::at_root(sessions_root)
         }
     }
@@ -227,6 +232,14 @@ impl CodexSessionSource {
     }
 
     fn summary_for(&mut self, path: &Path) -> Result<CodexRolloutSummary, std::io::Error> {
+        self.summary_for_with_progress(path, None)
+    }
+
+    fn summary_for_with_progress(
+        &mut self,
+        path: &Path,
+        mut on_progress: Option<&mut dyn FnMut(u64, u64)>,
+    ) -> Result<CodexRolloutSummary, std::io::Error> {
         let metadata = fs::metadata(path)?;
         let modified_nanos = metadata
             .modified()?
@@ -241,6 +254,9 @@ impl CodexSessionSource {
 
         if let Some(entry) = self.cache.get(path) {
             if entry.stamp == stamp {
+                if let Some(cb) = on_progress.as_mut() {
+                    cb(stamp.len, stamp.len);
+                }
                 return Ok(entry.summary.clone());
             }
         }
@@ -319,7 +335,10 @@ impl CodexSessionSource {
 
                 entry.offset = line_start + bytes_read as u64;
                 entry.logical_prefix_hash = hash_bytes(entry.logical_prefix_hash, &line);
-                apply_rollout_line(&mut entry.summary, &line, true);
+                apply_rollout_line(&mut entry.summary, &line, self.include_tools);
+                if let Some(cb) = on_progress.as_mut() {
+                    cb(entry.offset, stamp.len);
+                }
             }
         } else {
             loop {
@@ -567,14 +586,14 @@ fn apply_rollout_line(summary: &mut CodexRolloutSummary, line: &[u8], capture_to
     let Ok(value) = serde_json::from_slice::<Value>(line) else {
         return;
     };
-    apply_rollout_event_with_tools(summary, &value, capture_tool_messages);
+    apply_rollout_event_with_tools(summary, &value, capture_tool_messages, false);
 }
 
 fn apply_monitor_line(summary: &mut CodexRolloutSummary, line: &[u8]) {
     let Ok(value) = serde_json::from_slice::<Value>(line) else {
         return;
     };
-    apply_rollout_event_with_tools(summary, &value, false);
+    apply_rollout_event_with_tools(summary, &value, false, true);
 }
 
 fn truncate_monitor_message(message: &str) -> String {
@@ -912,6 +931,78 @@ fn collect_rollout_paths(root: &Path) -> Vec<PathBuf> {
     paths
 }
 
+fn thread_rollout_suffix(thread_id: &str) -> String {
+    format!("-{thread_id}.jsonl")
+}
+
+fn path_matches_thread(path: &Path, suffix: &str) -> bool {
+    path.file_name()
+        .and_then(|name| name.to_str())
+        .is_some_and(|name| name.starts_with("rollout-") && name.ends_with(suffix))
+}
+
+fn scan_recent_thread_rollouts(sessions_root: &Path, suffix: &str) -> Vec<PathBuf> {
+    let now = Local::now();
+    [now, now - chrono::Duration::days(1)]
+        .into_iter()
+        .flat_map(|day| {
+            let dir = sessions_root
+                .join(day.format("%Y").to_string())
+                .join(day.format("%m").to_string())
+                .join(day.format("%d").to_string());
+            fs::read_dir(dir)
+                .ok()
+                .into_iter()
+                .flatten()
+                .flatten()
+                .map(|entry| entry.path())
+        })
+        .filter(|path| path.is_file() && path_matches_thread(path, suffix))
+        .collect()
+}
+
+fn collect_thread_rollouts(sessions_root: &Path, suffix: &str) -> Vec<PathBuf> {
+    collect_rollout_paths(sessions_root)
+        .into_iter()
+        .filter(|path| path_matches_thread(path, suffix))
+        .collect()
+}
+
+/// Cache is a hint: union today's/yesterday's files so resume/compaction
+/// rollouts are not missed. If the cache is cold or every cached path is gone,
+/// fall through to a full walk.
+fn resolve_thread_rollout_paths(sessions_root: &Path, thread_id: &str) -> Vec<PathBuf> {
+    resolve_thread_rollout_paths_with_cache(
+        sessions_root,
+        thread_id,
+        super::codex_archive::cached_thread_paths(sessions_root, thread_id),
+    )
+}
+
+fn resolve_thread_rollout_paths_with_cache(
+    sessions_root: &Path,
+    thread_id: &str,
+    cached: Option<Vec<PathBuf>>,
+) -> Vec<PathBuf> {
+    let suffix = thread_rollout_suffix(thread_id);
+    if let Some(mut paths) = cached {
+        for path in scan_recent_thread_rollouts(sessions_root, &suffix) {
+            if !paths.iter().any(|existing| existing == &path) {
+                paths.push(path);
+            }
+        }
+        paths.retain(|path| path.is_file());
+        if !paths.is_empty() {
+            paths.sort();
+            return paths;
+        }
+    }
+
+    let mut paths = collect_thread_rollouts(sessions_root, &suffix);
+    paths.sort();
+    paths
+}
+
 fn thread_id_from_rollout_filename(path: &Path) -> Option<String> {
     let stem = path.file_stem()?.to_str()?;
     if stem.len() < 36 {
@@ -954,13 +1045,14 @@ fn parse_timestamp_millis(timestamp: &str) -> Option<i64> {
 
 #[cfg(test)]
 fn apply_rollout_event(summary: &mut CodexRolloutSummary, value: &Value) {
-    apply_rollout_event_with_tools(summary, value, false);
+    apply_rollout_event_with_tools(summary, value, false, true);
 }
 
 fn apply_rollout_event_with_tools(
     summary: &mut CodexRolloutSummary,
     value: &Value,
     capture_tool_messages: bool,
+    compact_for_monitor: bool,
 ) {
     let timestamp = value
         .get("timestamp")
@@ -975,9 +1067,7 @@ fn apply_rollout_event_with_tools(
     };
     match event_type {
         Some("session_meta") => apply_session_meta(summary, timestamp, payload),
-        Some("event_msg") => {
-            apply_event_message(summary, timestamp, payload, !capture_tool_messages)
-        }
+        Some("event_msg") => apply_event_message(summary, timestamp, payload, compact_for_monitor),
         Some("response_item") if capture_tool_messages => {
             apply_response_item(summary, timestamp, payload)
         }
@@ -1218,41 +1308,73 @@ fn rollback_messages(messages: &mut Vec<CodexMessage>, turns: usize) {
     }
 }
 
-pub fn find_codex_conversation(thread_id: &str) -> Result<Vec<CodexMessage>, String> {
+pub fn find_codex_conversation(
+    thread_id: &str,
+    include_tools: bool,
+) -> Result<Vec<CodexMessage>, String> {
+    find_codex_conversation_with_progress(thread_id, include_tools, &mut |_, _| {})
+}
+
+pub fn find_codex_conversation_with_progress(
+    thread_id: &str,
+    include_tools: bool,
+    on_progress: &mut dyn FnMut(u64, u64),
+) -> Result<Vec<CodexMessage>, String> {
     let home = dirs::home_dir().ok_or("Failed to get home directory")?;
-    find_codex_conversation_under(&home.join(".codex").join("sessions"), thread_id)
+    find_codex_conversation_under_with_progress(
+        &home.join(".codex").join("sessions"),
+        thread_id,
+        include_tools,
+        on_progress,
+    )
 }
 
 fn find_codex_conversation_under(
     sessions_root: &Path,
     thread_id: &str,
+    include_tools: bool,
 ) -> Result<Vec<CodexMessage>, String> {
-    let suffix = format!("-{thread_id}.jsonl");
-    let mut paths: Vec<_> = collect_rollout_paths(sessions_root)
-        .into_iter()
-        .filter(|path| {
-            path.file_name()
-                .and_then(|name| name.to_str())
-                .is_some_and(|name| name.ends_with(&suffix))
-        })
-        .collect();
-    paths.sort();
+    find_codex_conversation_under_with_progress(sessions_root, thread_id, include_tools, &mut |_, _| {})
+}
+
+fn find_codex_conversation_under_with_progress(
+    sessions_root: &Path,
+    thread_id: &str,
+    include_tools: bool,
+    on_progress: &mut dyn FnMut(u64, u64),
+) -> Result<Vec<CodexMessage>, String> {
+    let paths = resolve_thread_rollout_paths(sessions_root, thread_id);
     if paths.is_empty() {
         return Err(format!("Codex session {thread_id} not found"));
     }
 
-    let mut source = CodexSessionSource::conversation_at_root(sessions_root.to_path_buf());
+    let mut source =
+        CodexSessionSource::conversation_at_root(sessions_root.to_path_buf(), include_tools);
     let mut messages = Vec::new();
     let mut parsed_any = false;
     let mut last_error = None;
-    for path in paths {
-        match source.summary_for(&path) {
+    let file_lens: Vec<u64> = paths
+        .iter()
+        .map(|path| fs::metadata(path).map(|meta| meta.len()).unwrap_or(0))
+        .collect();
+    let total: u64 = file_lens.iter().sum();
+    on_progress(0, total);
+    let mut read_acc = 0u64;
+    for (path, file_len) in paths.into_iter().zip(file_lens) {
+        match source.summary_for_with_progress(
+            &path,
+            Some(&mut |file_read, _file_total| {
+                on_progress(read_acc.saturating_add(file_read.min(file_len)), total);
+            }),
+        ) {
             Ok(mut summary) => {
                 parsed_any = true;
                 messages.append(&mut summary.messages);
             }
             Err(error) => last_error = Some(error.to_string()),
         }
+        read_acc = read_acc.saturating_add(file_len);
+        on_progress(read_acc, total);
     }
     if !parsed_any {
         return Err(last_error.unwrap_or_else(|| format!("Codex session {thread_id} not found")));
@@ -1778,7 +1900,8 @@ mod tests {
         );
         assert!(monitor_summary.latest_message().unwrap().ends_with("..."));
 
-        let mut conversation = CodexSessionSource::conversation_at_root(temp.path().to_path_buf());
+        let mut conversation =
+            CodexSessionSource::conversation_at_root(temp.path().to_path_buf(), false);
         let conversation_summary = conversation.summary_for(&path).unwrap();
         assert_eq!(
             conversation_summary.latest_message().unwrap(),
@@ -2326,6 +2449,7 @@ mod tests {
                 "payload":{"type":"function_call","name":"exec_command","call_id":"call-1","arguments":"{\"cmd\":\"pwd\"}"}
             }),
             true,
+            false,
         );
         apply_rollout_event_with_tools(
             &mut summary,
@@ -2334,6 +2458,7 @@ mod tests {
                 "payload":{"type":"function_call_output","call_id":"call-1","output":"/tmp/project"}
             }),
             true,
+            false,
         );
 
         assert_eq!(summary.messages.len(), 2);
@@ -2401,7 +2526,7 @@ mod tests {
             serde_json::json!({"type":"message", "role":"user", "content":"injected"}),
         ));
         write_lines(&path, &lines, true);
-        let messages = find_codex_conversation_under(temp.path(), "thread-id").unwrap();
+        let messages = find_codex_conversation_under(temp.path(), "thread-id", true).unwrap();
         assert_eq!(messages.len(), 1);
         assert_eq!(messages[0].content, "hello");
     }
@@ -2425,10 +2550,100 @@ mod tests {
         ));
         write_lines(&path, &lines, true);
 
-        let messages = find_codex_conversation_under(temp.path(), "thread-id").unwrap();
+        let messages = find_codex_conversation_under(temp.path(), "thread-id", true).unwrap();
         assert_eq!(messages.len(), 3);
         assert_eq!(messages[1].message_type, MessageType::ToolUse);
         assert_eq!(messages[2].message_type, MessageType::ToolResult);
+
+        let without_tools = find_codex_conversation_under(temp.path(), "thread-id", false).unwrap();
+        assert_eq!(without_tools.len(), 1);
+        assert_eq!(without_tools[0].content, "hello");
+    }
+
+    #[test]
+    fn conversation_lookup_reports_byte_progress() {
+        let temp = TempDir::new().unwrap();
+        let day = temp.path().join("2026/07/13");
+        fs::create_dir_all(&day).unwrap();
+        let path = day.join("rollout-2026-07-13T00-00-00-thread-id.jsonl");
+        let lines = root_fixture(Value::String("cli".into()), "codex-tui");
+        write_lines(&path, &lines, true);
+        let total = fs::metadata(&path).unwrap().len();
+
+        let mut reports = Vec::new();
+        let messages = find_codex_conversation_under_with_progress(
+            temp.path(),
+            "thread-id",
+            false,
+            &mut |read, reported_total| reports.push((read, reported_total)),
+        )
+        .unwrap();
+
+        assert_eq!(messages.len(), 1);
+        assert!(!reports.is_empty());
+        assert_eq!(reports[0], (0, total));
+        assert_eq!(*reports.last().unwrap(), (total, total));
+        assert!(reports.windows(2).all(|pair| pair[0].0 <= pair[1].0));
+        assert!(reports.iter().all(|(_, reported)| *reported == total));
+    }
+
+    #[test]
+    fn conversation_lookup_unions_cached_paths_with_recent_day_files() {
+        let temp = TempDir::new().unwrap();
+        let old_day = temp.path().join("2026/07/12");
+        fs::create_dir_all(&old_day).unwrap();
+        let old_path = old_day.join("rollout-2026-07-12T23-00-00-thread-id.jsonl");
+        write_lines(
+            &old_path,
+            &root_fixture(Value::String("cli".into()), "codex-tui"),
+            true,
+        );
+
+        let now = Local::now();
+        let today = temp
+            .path()
+            .join(now.format("%Y").to_string())
+            .join(now.format("%m").to_string())
+            .join(now.format("%d").to_string());
+        fs::create_dir_all(&today).unwrap();
+        let new_path = today.join("rollout-today-thread-id.jsonl");
+        write_lines(
+            &new_path,
+            &[event(
+                "2026-08-19T00:00:04Z",
+                "event_msg",
+                serde_json::json!({"type":"user_message","message":"resumed"}),
+            )],
+            true,
+        );
+
+        let resolved = resolve_thread_rollout_paths_with_cache(
+            temp.path(),
+            "thread-id",
+            Some(vec![old_path.clone()]),
+        );
+        assert!(resolved.contains(&old_path));
+        assert!(resolved.contains(&new_path));
+    }
+
+    #[test]
+    fn conversation_lookup_falls_back_to_walk_when_cached_paths_are_gone() {
+        let temp = TempDir::new().unwrap();
+        let old_day = temp.path().join("2026/07/12");
+        fs::create_dir_all(&old_day).unwrap();
+        let old_path = old_day.join("rollout-2026-07-12T23-00-00-thread-id.jsonl");
+        write_lines(
+            &old_path,
+            &root_fixture(Value::String("cli".into()), "codex-tui"),
+            true,
+        );
+
+        let resolved = resolve_thread_rollout_paths_with_cache(
+            temp.path(),
+            "thread-id",
+            Some(vec![old_day.join("deleted.jsonl")]),
+        );
+        assert_eq!(resolved, vec![old_path]);
     }
 
     #[test]
@@ -2478,7 +2693,7 @@ mod tests {
             true,
         );
 
-        let messages = find_codex_conversation_under(temp.path(), "thread-id").unwrap();
+        let messages = find_codex_conversation_under(temp.path(), "thread-id", true).unwrap();
         assert_eq!(messages.len(), 2);
         assert_eq!(messages[0].content, "first prompt");
         assert_eq!(messages[1].content, "resumed answer");

--- a/src-tauri/src/session/codex_archive.rs
+++ b/src-tauri/src/session/codex_archive.rs
@@ -1286,7 +1286,18 @@ mod tests {
         let cache_path = directory.path().join("cache.json");
         load_snapshots(&root, &cache_path);
         let first = std::fs::read(&cache_path).unwrap();
+        let sentinel = UNIX_EPOCH + std::time::Duration::from_secs(1_000_000);
+        File::options()
+            .write(true)
+            .open(&cache_path)
+            .unwrap()
+            .set_times(std::fs::FileTimes::new().set_modified(sentinel))
+            .unwrap();
         let second = load_snapshots(&root, &cache_path);
+        assert_eq!(
+            std::fs::metadata(&cache_path).unwrap().modified().unwrap(),
+            sentinel
+        );
         assert_eq!(second[0].display, "hello");
         let after = std::fs::read(&cache_path).unwrap();
         assert_eq!(
@@ -1397,6 +1408,12 @@ mod tests {
             ],
         );
         let cache_path = directory.path().join("cache.json");
+        load_snapshots(&root, &cache_path);
+        // Simulate a fresh process so this exercises stream-id hydration from disk.
+        archive_state()
+            .lock()
+            .unwrap()
+            .remove(&(root.clone(), cache_path.clone()));
         let snapshots = load_snapshots(&root, &cache_path);
         let json = String::from_utf8(std::fs::read(&cache_path).unwrap()).unwrap();
         assert!(

--- a/src-tauri/src/session/codex_archive.rs
+++ b/src-tauri/src/session/codex_archive.rs
@@ -2,7 +2,7 @@ use serde::{Deserialize, Serialize};
 use serde_json::Value;
 use std::collections::{HashMap, HashSet};
 use std::fs::File;
-use std::io::{BufRead, BufReader, Read, Seek, SeekFrom};
+use std::io::{BufRead, BufReader, BufWriter, Read, Seek, SeekFrom, Write};
 use std::path::{Path, PathBuf};
 use std::sync::{Mutex, OnceLock};
 use std::time::UNIX_EPOCH;
@@ -114,7 +114,9 @@ struct ArchivedTokenEvent {
     #[serde(default)]
     cumulative: bool,
     /// Cumulative counters restart independently for each rollout stream.
-    #[serde(default)]
+    /// Omitted from the on-disk cache because it is always the parent file path
+    /// and was repeating ~100 bytes on every token event.
+    #[serde(default, skip_serializing)]
     stream_id: String,
 }
 
@@ -163,7 +165,7 @@ struct CachedRollout {
     snapshot: CodexRolloutSnapshot,
     #[serde(default)]
     offset: u64,
-    #[serde(default)]
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pending: Vec<u8>,
     #[serde(default)]
     current_model: String,
@@ -180,7 +182,23 @@ struct ArchiveCache {
     files: HashMap<String, CachedRollout>,
 }
 
-static ARCHIVE_CACHE_LOCK: OnceLock<Mutex<()>> = OnceLock::new();
+#[derive(Clone, Copy)]
+enum SnapshotView {
+    Full,
+    Listing,
+}
+
+struct ProcessArchive {
+    cache: ArchiveCache,
+    merged: Vec<CodexRolloutSnapshot>,
+}
+
+static ARCHIVE_STATE: OnceLock<Mutex<HashMap<(PathBuf, PathBuf), ProcessArchive>>> =
+    OnceLock::new();
+
+fn archive_state() -> &'static Mutex<HashMap<(PathBuf, PathBuf), ProcessArchive>> {
+    ARCHIVE_STATE.get_or_init(|| Mutex::new(HashMap::new()))
+}
 
 fn fingerprint(path: &Path) -> Option<FileFingerprint> {
     let metadata = path.metadata().ok()?;
@@ -591,35 +609,93 @@ fn write_cache(path: &Path, cache: &ArchiveCache) {
     if std::fs::create_dir_all(parent).is_err() {
         return;
     }
-    let Ok(json) = serde_json::to_vec(cache) else {
+    let temporary = path.with_extension("json.tmp");
+    let Ok(file) = File::create(&temporary) else {
         return;
     };
-    let temporary = path.with_extension("json.tmp");
-    if std::fs::write(&temporary, json).is_ok() {
+    let mut writer = BufWriter::new(file);
+    let ok = serde_json::to_writer(&mut writer, cache).is_ok() && writer.flush().is_ok();
+    drop(writer);
+    if ok {
         let _ = std::fs::rename(temporary, path);
+    } else {
+        let _ = std::fs::remove_file(&temporary);
     }
 }
 
-pub(crate) fn load_snapshots(root: &Path, cache_path: &Path) -> Vec<CodexRolloutSnapshot> {
-    let _guard = ARCHIVE_CACHE_LOCK
-        .get_or_init(|| Mutex::new(()))
-        .lock()
-        .unwrap_or_else(|poisoned| poisoned.into_inner());
-    let mut cache: ArchiveCache = std::fs::read(cache_path)
+fn read_cache_file(path: &Path) -> ArchiveCache {
+    let mut cache: ArchiveCache = File::open(path)
         .ok()
-        .and_then(|bytes| serde_json::from_slice(&bytes).ok())
+        .and_then(|file| serde_json::from_reader(BufReader::new(file)).ok())
         .filter(|cache: &ArchiveCache| cache.version == CACHE_VERSION)
         .unwrap_or_else(|| ArchiveCache {
             version: CACHE_VERSION,
             files: HashMap::new(),
         });
+    for entry in cache.files.values_mut() {
+        hydrate_stream_ids(entry);
+    }
+    cache
+}
 
+fn hydrate_stream_ids(cached: &mut CachedRollout) {
+    if cached.snapshot.path.as_os_str().is_empty() {
+        if let Some(path) = cached.snapshot.paths.first() {
+            cached.snapshot.path = path.clone();
+        }
+    }
+    let path = cached.snapshot.path.to_string_lossy().into_owned();
+    if path.is_empty() {
+        return;
+    }
+    for event in &mut cached.snapshot.token_events {
+        if event.stream_id.is_empty() {
+            event.stream_id = path.clone();
+        }
+    }
+}
+
+fn listing_snapshot(snapshot: &CodexRolloutSnapshot) -> CodexRolloutSnapshot {
+    CodexRolloutSnapshot {
+        thread_id: snapshot.thread_id.clone(),
+        cwd: snapshot.cwd.clone(),
+        surface: snapshot.surface.clone(),
+        agent_kind: snapshot.agent_kind.clone(),
+        parent_thread_id: snapshot.parent_thread_id.clone(),
+        display: snapshot.display.clone(),
+        created_at_ms: snapshot.created_at_ms,
+        updated_at_ms: snapshot.updated_at_ms,
+        token_days: snapshot.token_days.clone(),
+        path: snapshot.path.clone(),
+        paths: snapshot.paths.clone(),
+        messages_complete: snapshot.messages_complete,
+        messages: Vec::new(),
+        token_events: Vec::new(),
+    }
+}
+
+fn merge_all(cache: &ArchiveCache) -> Vec<CodexRolloutSnapshot> {
+    let mut by_thread: HashMap<String, CodexRolloutSnapshot> = HashMap::new();
+    for entry in cache.files.values() {
+        let snapshot = entry.snapshot.clone();
+        if let Some(existing) = by_thread.get_mut(&snapshot.thread_id) {
+            merge_snapshot(existing, snapshot);
+        } else {
+            by_thread.insert(snapshot.thread_id.clone(), snapshot);
+        }
+    }
+    by_thread.into_values().collect()
+}
+
+fn refresh_cache(cache: &mut ArchiveCache, root: &Path) -> bool {
     let candidates = collect_rollouts(root);
     let active_paths: HashSet<String> = candidates
         .iter()
         .map(|path| path.to_string_lossy().to_string())
         .collect();
+    let before = cache.files.len();
     cache.files.retain(|path, _| active_paths.contains(path));
+    let mut dirty = cache.files.len() != before;
 
     for path in candidates {
         let Some(fingerprint) = fingerprint(&path) else {
@@ -633,29 +709,69 @@ pub(crate) fn load_snapshots(root: &Path, cache_path: &Path) -> Vec<CodexRollout
         {
             continue;
         }
+        dirty = true;
         let previous = cache.files.remove(&key);
-        if let Some(cached) = refresh_rollout(&path, fingerprint, previous) {
+        if let Some(mut cached) = refresh_rollout(&path, fingerprint, previous) {
             if !cached.snapshot.thread_id.is_empty() {
+                hydrate_stream_ids(&mut cached);
                 cache.files.insert(key, cached);
             }
-        } else {
-            cache.files.remove(&key);
         }
     }
-    write_cache(cache_path, &cache);
+    dirty
+}
 
-    // A resumed thread may span several rollout paths. Merge their authoritative
-    // events so older prompts and token usage survive without double counting overlap.
-    let mut by_thread: HashMap<String, CodexRolloutSnapshot> = HashMap::new();
-    for entry in cache.files.into_values() {
-        let snapshot = entry.snapshot;
-        if let Some(existing) = by_thread.get_mut(&snapshot.thread_id) {
-            merge_snapshot(existing, snapshot);
-        } else {
-            by_thread.insert(snapshot.thread_id.clone(), snapshot);
+fn load_snapshots_with(
+    root: &Path,
+    cache_path: &Path,
+    view: SnapshotView,
+) -> Vec<CodexRolloutSnapshot> {
+    let key = (root.to_path_buf(), cache_path.to_path_buf());
+    let mut state = archive_state()
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner());
+    let archive = state.entry(key).or_insert_with(|| ProcessArchive {
+        cache: read_cache_file(cache_path),
+        merged: Vec::new(),
+    });
+    let dirty = refresh_cache(&mut archive.cache, root);
+    if dirty || archive.merged.is_empty() {
+        archive.merged = merge_all(&archive.cache);
+        if dirty {
+            write_cache(cache_path, &archive.cache);
         }
     }
-    by_thread.into_values().collect()
+    match view {
+        SnapshotView::Full => archive.merged.clone(),
+        SnapshotView::Listing => archive.merged.iter().map(listing_snapshot).collect(),
+    }
+}
+
+pub(crate) fn load_snapshots(root: &Path, cache_path: &Path) -> Vec<CodexRolloutSnapshot> {
+    load_snapshots_with(root, cache_path, SnapshotView::Full)
+}
+
+pub(crate) fn load_listing_snapshots(root: &Path, cache_path: &Path) -> Vec<CodexRolloutSnapshot> {
+    load_snapshots_with(root, cache_path, SnapshotView::Listing)
+}
+
+/// Fast path for conversation loading when History/Cost already warmed the archive.
+pub(crate) fn cached_thread_paths(sessions_root: &Path, thread_id: &str) -> Option<Vec<PathBuf>> {
+    let cache_path = sessions_root.parent()?.join("c9watch-archive-cache.json");
+    let key = (sessions_root.to_path_buf(), cache_path);
+    let state = archive_state()
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner());
+    let snapshot = state
+        .get(&key)?
+        .merged
+        .iter()
+        .find(|item| item.thread_id == thread_id)?;
+    let mut paths = snapshot.paths.clone();
+    if !paths.contains(&snapshot.path) {
+        paths.push(snapshot.path.clone());
+    }
+    Some(paths)
 }
 
 fn merge_snapshot(existing: &mut CodexRolloutSnapshot, incoming: CodexRolloutSnapshot) {
@@ -719,6 +835,10 @@ fn merge_snapshot(existing: &mut CodexRolloutSnapshot, incoming: CodexRolloutSna
 
 pub(crate) fn load_default_snapshots(home: &Path) -> Vec<CodexRolloutSnapshot> {
     load_snapshots(&default_sessions_root(home), &default_cache_path(home))
+}
+
+pub(crate) fn load_default_listing(home: &Path) -> Vec<CodexRolloutSnapshot> {
+    load_listing_snapshots(&default_sessions_root(home), &default_cache_path(home))
 }
 
 pub(crate) fn search_rollout<F>(
@@ -1149,5 +1269,147 @@ mod tests {
         let truncated = load_snapshots(&root, &cache_path);
         assert_eq!(truncated[0].display, "replacement");
         assert_eq!(truncated[0].messages.len(), 1);
+    }
+
+    #[test]
+    fn unchanged_reload_does_not_rewrite_cache() {
+        let directory = tempfile::tempdir().unwrap();
+        let root = directory.path().join("sessions");
+        std::fs::create_dir_all(&root).unwrap();
+        write_rollout(
+            &root.join("stable.jsonl"),
+            &[
+                r#"{"timestamp":"2026-07-13T01:00:00Z","type":"session_meta","payload":{"id":"stable","cwd":"/tmp/p","source":"cli","originator":"codex-tui"}}"#,
+                r#"{"timestamp":"2026-07-13T01:01:00Z","type":"event_msg","payload":{"type":"user_message","message":"hello"}}"#,
+            ],
+        );
+        let cache_path = directory.path().join("cache.json");
+        load_snapshots(&root, &cache_path);
+        let first = std::fs::read(&cache_path).unwrap();
+        let second = load_snapshots(&root, &cache_path);
+        assert_eq!(second[0].display, "hello");
+        let after = std::fs::read(&cache_path).unwrap();
+        assert_eq!(
+            first, after,
+            "unchanged rollouts must not rewrite the archive cache"
+        );
+    }
+
+    #[test]
+    fn process_cache_survives_deleted_cache_file() {
+        let directory = tempfile::tempdir().unwrap();
+        let root = directory.path().join("sessions");
+        std::fs::create_dir_all(&root).unwrap();
+        write_rollout(
+            &root.join("cached.jsonl"),
+            &[
+                r#"{"timestamp":"2026-07-13T01:00:00Z","type":"session_meta","payload":{"id":"cached","cwd":"/tmp/p","source":"cli","originator":"codex-tui"}}"#,
+                r#"{"timestamp":"2026-07-13T01:01:00Z","type":"event_msg","payload":{"type":"user_message","message":"keep me"}}"#,
+            ],
+        );
+        let cache_path = directory.path().join("cache.json");
+        load_snapshots(&root, &cache_path);
+        std::fs::remove_file(&cache_path).unwrap();
+        let second = load_snapshots(&root, &cache_path);
+        assert_eq!(second[0].display, "keep me");
+        assert!(
+            !cache_path.exists(),
+            "memory hit must not rewrite an unchanged cache"
+        );
+    }
+
+    #[test]
+    fn listing_snapshots_omit_search_index_but_keep_cost_fields() {
+        let directory = tempfile::tempdir().unwrap();
+        let root = directory.path().join("sessions");
+        std::fs::create_dir_all(&root).unwrap();
+        write_rollout(
+            &root.join("listed.jsonl"),
+            &[
+                r#"{"timestamp":"2026-07-13T01:00:00Z","type":"session_meta","payload":{"id":"listed","cwd":"/tmp/p","source":"cli","originator":"codex-tui"}}"#,
+                r#"{"timestamp":"2026-07-13T01:01:00Z","type":"turn_context","payload":{"model":"gpt-5.4"}}"#,
+                r#"{"timestamp":"2026-07-13T01:02:00Z","type":"event_msg","payload":{"type":"user_message","message":"prompt text"}}"#,
+                r#"{"timestamp":"2026-07-13T01:03:00Z","type":"event_msg","payload":{"type":"token_count","info":{"total_token_usage":{"input_tokens":10,"output_tokens":4,"total_tokens":14}}}}"#,
+            ],
+        );
+        let cache_path = directory.path().join("cache.json");
+        let listing = load_listing_snapshots(&root, &cache_path);
+        assert_eq!(listing[0].display, "prompt text");
+        assert!(listing[0].messages.is_empty());
+        assert!(listing[0].token_events.is_empty());
+        assert_eq!(listing[0].token_days[0].usage.total_tokens, 14);
+
+        let full = load_snapshots(&root, &cache_path);
+        assert_eq!(full[0].messages.len(), 1);
+        assert_eq!(full[0].token_events.len(), 1);
+    }
+
+    #[test]
+    #[ignore]
+    fn real_home_archive_load_timing() {
+        let home = dirs::home_dir().expect("home directory");
+        let sessions = default_sessions_root(&home);
+        if !sessions.exists() {
+            return;
+        }
+        let started = std::time::Instant::now();
+        let first = load_default_listing(&home);
+        let first_elapsed = started.elapsed();
+        let started = std::time::Instant::now();
+        let second = load_default_listing(&home);
+        let second_elapsed = started.elapsed();
+        let started = std::time::Instant::now();
+        let full = load_default_snapshots(&home);
+        let full_elapsed = started.elapsed();
+        let messages: usize = full.iter().map(|snapshot| snapshot.messages.len()).sum();
+        eprintln!(
+            "codex archive listing {} sessions: first {first_elapsed:?}, second {second_elapsed:?}; full {} messages in {full_elapsed:?}",
+            first.len(),
+            messages
+        );
+        assert_eq!(first.len(), second.len());
+        assert_eq!(first.len(), full.len());
+        assert!(
+            second_elapsed * 4 < first_elapsed || second_elapsed.as_millis() < 200,
+            "warm listing should reuse the process cache (first {first_elapsed:?}, second {second_elapsed:?})"
+        );
+    }
+
+    #[test]
+    fn token_stream_id_is_not_persisted_and_still_merges_independent_streams() {
+        let directory = tempfile::tempdir().unwrap();
+        let root = directory.path().join("sessions");
+        std::fs::create_dir_all(&root).unwrap();
+        write_rollout(
+            &root.join("old.jsonl"),
+            &[
+                r#"{"timestamp":"2026-07-13T01:00:00Z","type":"session_meta","payload":{"id":"resumed","cwd":"/tmp/p","source":"cli","originator":"codex-tui"}}"#,
+                r#"{"timestamp":"2026-07-13T01:00:30Z","type":"turn_context","payload":{"model":"gpt-5.6-sol"}}"#,
+                r#"{"timestamp":"2026-07-13T01:01:00Z","type":"event_msg","payload":{"type":"token_count","info":{"total_token_usage":{"input_tokens":80,"output_tokens":20,"total_tokens":100}}}}"#,
+            ],
+        );
+        write_rollout(
+            &root.join("new.jsonl"),
+            &[
+                r#"{"timestamp":"2026-07-13T02:00:00Z","type":"session_meta","payload":{"id":"resumed","cwd":"/tmp/p","source":"cli","originator":"codex-tui"}}"#,
+                r#"{"timestamp":"2026-07-13T02:00:30Z","type":"turn_context","payload":{"model":"gpt-5.6-luna"}}"#,
+                r#"{"timestamp":"2026-07-13T02:01:00Z","type":"event_msg","payload":{"type":"token_count","info":{"total_token_usage":{"input_tokens":120,"output_tokens":30,"total_tokens":150}}}}"#,
+            ],
+        );
+        let cache_path = directory.path().join("cache.json");
+        let snapshots = load_snapshots(&root, &cache_path);
+        let json = String::from_utf8(std::fs::read(&cache_path).unwrap()).unwrap();
+        assert!(
+            !json.contains("streamId"),
+            "per-event stream ids must not bloat the on-disk cache"
+        );
+        assert_eq!(
+            snapshots[0]
+                .token_days
+                .iter()
+                .map(|day| day.usage.total_tokens)
+                .sum::<u64>(),
+            250
+        );
     }
 }

--- a/src-tauri/src/session/conversation.rs
+++ b/src-tauri/src/session/conversation.rs
@@ -1,5 +1,7 @@
-use crate::session::{extract_messages, parse_all_entries, ImageBlock, MessageType};
+use crate::session::parser::parse_all_entries_with_progress;
+use crate::session::{extract_messages, ImageBlock, MessageType};
 use serde::Serialize;
+use std::time::{Duration, Instant};
 
 /// Conversation structure
 #[derive(Debug, Clone, Serialize)]
@@ -7,6 +9,15 @@ use serde::Serialize;
 pub struct Conversation {
     pub session_id: String,
     pub messages: Vec<ConversationMessage>,
+}
+
+/// Byte-level load progress for a conversation parse.
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ConversationProgress {
+    pub session_id: String,
+    pub bytes_read: u64,
+    pub bytes_total: u64,
 }
 
 /// Individual message in a conversation
@@ -23,7 +34,38 @@ pub struct ConversationMessage {
 
 /// Get conversation data for a session by ID.
 /// Searches all project directories under ~/.claude/projects/ for the session file.
-pub fn get_conversation_data(session_id: &str) -> Result<Conversation, String> {
+/// When `include_tools` is false, tool use/result records are omitted so large
+/// Codex transcripts can open without shipping megabytes of tool dumps.
+pub fn get_conversation_data(
+    session_id: &str,
+    include_tools: bool,
+) -> Result<Conversation, String> {
+    get_conversation_data_with_progress(session_id, include_tools, &mut |_, _| {})
+}
+
+/// Like [`get_conversation_data`], reporting `(bytes_read, bytes_total)` while scanning.
+pub fn get_conversation_data_with_progress(
+    session_id: &str,
+    include_tools: bool,
+    on_progress: &mut dyn FnMut(u64, u64),
+) -> Result<Conversation, String> {
+    let mut last_read = u64::MAX;
+    let mut last_at = Instant::now()
+        .checked_sub(Duration::from_secs(1))
+        .unwrap_or_else(Instant::now);
+    let mut report = |read: u64, total: u64| {
+        let step = total.saturating_div(50).max(256 * 1024);
+        let due = last_read == u64::MAX
+            || read >= total
+            || read.saturating_sub(last_read) >= step
+            || last_at.elapsed() >= Duration::from_millis(80);
+        if due {
+            last_read = read;
+            last_at = Instant::now();
+            on_progress(read, total);
+        }
+    };
+
     let home_dir = dirs::home_dir().ok_or("Failed to get home directory")?;
     let claude_projects_dir = home_dir.join(".claude").join("projects");
 
@@ -38,19 +80,25 @@ pub fn get_conversation_data(session_id: &str) -> Result<Conversation, String> {
 
             let session_file = project_path.join(&session_filename);
             if session_file.exists() {
-                let entries = parse_all_entries(&session_file)
+                let entries = parse_all_entries_with_progress(&session_file, &mut report)
                     .map_err(|e| format!("Failed to parse session file: {}", e))?;
 
                 let messages = extract_messages(&entries);
 
                 let conversation_messages: Vec<ConversationMessage> = messages
                     .into_iter()
-                    .map(|(timestamp, msg_type, content, images)| ConversationMessage {
-                        timestamp,
-                        message_type: msg_type,
-                        content,
-                        images,
+                    .filter(|(_, msg_type, _, _)| {
+                        include_tools
+                            || !matches!(msg_type, MessageType::ToolUse | MessageType::ToolResult)
                     })
+                    .map(
+                        |(timestamp, msg_type, content, images)| ConversationMessage {
+                            timestamp,
+                            message_type: msg_type,
+                            content,
+                            images,
+                        },
+                    )
                     .collect();
 
                 return Ok(Conversation {
@@ -61,7 +109,11 @@ pub fn get_conversation_data(session_id: &str) -> Result<Conversation, String> {
         }
     }
 
-    if let Ok(messages) = crate::session::codex::find_codex_conversation(session_id) {
+    if let Ok(messages) = crate::session::codex::find_codex_conversation_with_progress(
+        session_id,
+        include_tools,
+        &mut report,
+    ) {
         return Ok(Conversation {
             session_id: session_id.to_string(),
             messages: messages

--- a/src-tauri/src/session/cost.rs
+++ b/src-tauri/src/session/cost.rs
@@ -554,7 +554,7 @@ fn scan_file(path: &std::path::Path) -> Vec<SessionCostRecord> {
 }
 
 fn codex_cost_records(home_dir: &std::path::Path) -> Vec<SessionCostRecord> {
-    super::codex_archive::load_default_snapshots(home_dir)
+    super::codex_archive::load_default_listing(home_dir)
         .into_iter()
         .filter(|snapshot| !snapshot.is_internal())
         .flat_map(|snapshot| {

--- a/src-tauri/src/session/history.rs
+++ b/src-tauri/src/session/history.rs
@@ -127,7 +127,7 @@ pub fn get_history() -> Result<Vec<HistoryEntry>, String> {
 }
 
 fn codex_history_entries(home_dir: &std::path::Path) -> Vec<HistoryEntry> {
-    super::codex_archive::load_default_snapshots(home_dir)
+    super::codex_archive::load_default_listing(home_dir)
         .into_iter()
         .filter(|snapshot| !snapshot.is_internal())
         .map(|snapshot| {

--- a/src-tauri/src/session/mod.rs
+++ b/src-tauri/src/session/mod.rs
@@ -34,7 +34,7 @@ mod codex_archive;
 pub use cost::{get_cost_data, CostData};
 
 pub(crate) fn codex_session_ids(home: &std::path::Path, prefix: &str) -> Vec<String> {
-    codex_archive::load_default_snapshots(home)
+    codex_archive::load_default_listing(home)
         .into_iter()
         .filter(|snapshot| snapshot.thread_id.starts_with(prefix))
         .map(|snapshot| snapshot.thread_id)

--- a/src-tauri/src/session/parser.rs
+++ b/src-tauri/src/session/parser.rs
@@ -318,16 +318,38 @@ pub fn parse_last_n_entries<P: AsRef<Path>>(
 
 /// Parse all entries from a session JSONL file
 pub fn parse_all_entries<P: AsRef<Path>>(path: P) -> Result<Vec<SessionEntry>, String> {
+    parse_all_entries_with_progress(path, &mut |_, _| {})
+}
+
+/// Like [`parse_all_entries`], but reports `(bytes_read, bytes_total)` while scanning.
+pub fn parse_all_entries_with_progress<P: AsRef<Path>>(
+    path: P,
+    on_progress: &mut dyn FnMut(u64, u64),
+) -> Result<Vec<SessionEntry>, String> {
     let file =
         File::open(path.as_ref()).map_err(|e| format!("Failed to open JSONL file: {}", e))?;
-
-    let reader = BufReader::new(file);
-    let lines: Vec<String> = reader
-        .lines()
-        .map_while(Result::ok)
-        .filter(|line| !line.trim().is_empty())
-        .collect();
-
+    let total = file.metadata().map(|m| m.len()).unwrap_or(0);
+    let mut reader = BufReader::new(file);
+    let mut lines = Vec::new();
+    let mut buf = String::new();
+    let mut read = 0u64;
+    on_progress(0, total);
+    loop {
+        buf.clear();
+        let n = reader
+            .read_line(&mut buf)
+            .map_err(|e| format!("Failed to read JSONL file: {}", e))?;
+        if n == 0 {
+            break;
+        }
+        read += n as u64;
+        on_progress(read, total);
+        let without_newline = buf.trim_end_matches(['\n', '\r']);
+        if !without_newline.trim().is_empty() {
+            lines.push(without_newline.to_string());
+        }
+    }
+    on_progress(total, total);
     Ok(parse_jsonl_entries(lines))
 }
 

--- a/src-tauri/src/web_server.rs
+++ b/src-tauri/src/web_server.rs
@@ -26,6 +26,7 @@ pub struct WsState {
     pub auth_token: String,
     pub sessions_tx: broadcast::Sender<String>,
     pub notifications_tx: broadcast::Sender<String>,
+    pub progress_tx: broadcast::Sender<String>,
 }
 
 // ── Protocol types ──────────────────────────────────────────────────
@@ -41,6 +42,8 @@ enum ClientMsg {
     GetConversation {
         #[serde(rename = "sessionId")]
         session_id: String,
+        #[serde(default, rename = "includeTools")]
+        include_tools: bool,
     },
 
     #[serde(rename = "stopSession")]
@@ -86,6 +89,9 @@ enum ServerMsg {
 
     #[serde(rename = "notification")]
     Notification { data: serde_json::Value },
+
+    #[serde(rename = "conversationProgress")]
+    ConversationProgress { data: serde_json::Value },
 
     #[serde(rename = "memoryFiles")]
     MemoryFiles { data: serde_json::Value },
@@ -193,6 +199,9 @@ async fn handle_socket(mut socket: WebSocket, state: Arc<WsState>) {
     crate::debug_log::log_info("[ws-server] Client connected");
     let mut sessions_rx = state.sessions_tx.subscribe();
     let mut notifications_rx = state.notifications_tx.subscribe();
+    let mut progress_rx = state.progress_tx.subscribe();
+
+    let mut inflight: Option<tokio::task::JoinHandle<ServerMsg>> = None;
 
     loop {
         tokio::select! {
@@ -201,15 +210,40 @@ async fn handle_socket(mut socket: WebSocket, state: Arc<WsState>) {
                 match msg {
                     Some(Ok(Message::Text(text))) => {
                         let text_str: &str = &text;
-                        let response = match serde_json::from_str::<ClientMsg>(text_str) {
-                            Ok(client_msg) => handle_message(client_msg).await,
-                            Err(e) => ServerMsg::Error {
-                                message: format!("Invalid message: {}", e),
-                            },
-                        };
-                        let json = serde_json::to_string(&response).unwrap_or_default();
-                        if socket.send(Message::Text(json)).await.is_err() {
-                            break;
+                        match serde_json::from_str::<ClientMsg>(text_str) {
+                            Ok(ClientMsg::GetConversation {
+                                session_id,
+                                include_tools,
+                            }) => {
+                                if let Some(previous) = inflight.take() {
+                                    previous.abort();
+                                }
+                                let progress_tx = state.progress_tx.clone();
+                                inflight = Some(tokio::spawn(async move {
+                                    load_conversation_response(
+                                        session_id,
+                                        include_tools,
+                                        progress_tx,
+                                    )
+                                    .await
+                                }));
+                            }
+                            Ok(client_msg) => {
+                                let response = handle_message(client_msg).await;
+                                let json = serde_json::to_string(&response).unwrap_or_default();
+                                if socket.send(Message::Text(json)).await.is_err() {
+                                    break;
+                                }
+                            }
+                            Err(e) => {
+                                let response = ServerMsg::Error {
+                                    message: format!("Invalid message: {}", e),
+                                };
+                                let json = serde_json::to_string(&response).unwrap_or_default();
+                                if socket.send(Message::Text(json)).await.is_err() {
+                                    break;
+                                }
+                            }
                         }
                     }
                     Some(Ok(Message::Ping(data))) => {
@@ -219,6 +253,25 @@ async fn handle_socket(mut socket: WebSocket, state: Arc<WsState>) {
                     }
                     Some(Ok(Message::Close(_))) | None => break,
                     _ => {}
+                }
+            }
+            result = async {
+                match inflight.as_mut() {
+                    Some(handle) => Some(handle.await),
+                    None => std::future::pending().await,
+                }
+            } => {
+                inflight = None;
+                let response = match result {
+                    Some(Ok(response)) => response,
+                    Some(Err(error)) => ServerMsg::Error {
+                        message: format!("Failed to load conversation: {error}"),
+                    },
+                    None => continue,
+                };
+                let json = serde_json::to_string(&response).unwrap_or_default();
+                if socket.send(Message::Text(json)).await.is_err() {
+                    break;
                 }
             }
             // Push session updates from polling loop
@@ -241,6 +294,15 @@ async fn handle_socket(mut socket: WebSocket, state: Arc<WsState>) {
                     break;
                 }
             }
+            Ok(progress_json) = progress_rx.recv() => {
+                let msg = ServerMsg::ConversationProgress {
+                    data: serde_json::from_str(&progress_json).unwrap_or_default(),
+                };
+                let json = serde_json::to_string(&msg).unwrap_or_default();
+                if socket.send(Message::Text(json)).await.is_err() {
+                    break;
+                }
+            }
         }
     }
 
@@ -248,6 +310,38 @@ async fn handle_socket(mut socket: WebSocket, state: Arc<WsState>) {
 }
 
 // ── Message dispatch ────────────────────────────────────────────────
+
+async fn load_conversation_response(
+    session_id: String,
+    include_tools: bool,
+    progress_tx: broadcast::Sender<String>,
+) -> ServerMsg {
+    let emit_id = session_id.clone();
+    match tokio::task::spawn_blocking(move || {
+        crate::get_conversation_data_with_progress(
+            &session_id,
+            include_tools,
+            &mut |bytes_read, bytes_total| {
+                let payload = serde_json::json!({
+                    "sessionId": emit_id,
+                    "bytesRead": bytes_read,
+                    "bytesTotal": bytes_total,
+                });
+                let _ = progress_tx.send(payload.to_string());
+            },
+        )
+    })
+    .await
+    {
+        Ok(Ok(conv)) => ServerMsg::Conversation {
+            data: serde_json::to_value(&conv).unwrap_or_default(),
+        },
+        Ok(Err(e)) => ServerMsg::Error { message: e },
+        Err(e) => ServerMsg::Error {
+            message: format!("Failed to load conversation: {e}"),
+        },
+    }
+}
 
 async fn handle_message(msg: ClientMsg) -> ServerMsg {
     match msg {
@@ -258,13 +352,15 @@ async fn handle_message(msg: ClientMsg) -> ServerMsg {
             Err(e) => ServerMsg::Error { message: e },
         },
 
-        ClientMsg::GetConversation { session_id } => {
-            match crate::get_conversation_data(&session_id) {
-                Ok(conv) => ServerMsg::Conversation {
-                    data: serde_json::to_value(&conv).unwrap_or_default(),
-                },
-                Err(e) => ServerMsg::Error { message: e },
-            }
+        ClientMsg::GetConversation {
+            session_id,
+            include_tools,
+        } => {
+            load_conversation_response(session_id, include_tools, {
+                let (tx, _) = broadcast::channel(1);
+                tx
+            })
+            .await
         }
 
         ClientMsg::StopSession { pid } => match crate::actions::stop_session(pid) {

--- a/src-tauri/src/web_server.rs
+++ b/src-tauri/src/web_server.rs
@@ -26,7 +26,6 @@ pub struct WsState {
     pub auth_token: String,
     pub sessions_tx: broadcast::Sender<String>,
     pub notifications_tx: broadcast::Sender<String>,
-    pub progress_tx: broadcast::Sender<String>,
 }
 
 // ── Protocol types ──────────────────────────────────────────────────
@@ -199,9 +198,10 @@ async fn handle_socket(mut socket: WebSocket, state: Arc<WsState>) {
     crate::debug_log::log_info("[ws-server] Client connected");
     let mut sessions_rx = state.sessions_tx.subscribe();
     let mut notifications_rx = state.notifications_tx.subscribe();
-    let mut progress_rx = state.progress_tx.subscribe();
+    let (progress_tx, mut progress_rx) = broadcast::channel::<String>(32);
 
     let mut inflight: Option<tokio::task::JoinHandle<ServerMsg>> = None;
+    let mut inflight_id: Option<u64> = None;
 
     loop {
         tokio::select! {
@@ -210,6 +210,8 @@ async fn handle_socket(mut socket: WebSocket, state: Arc<WsState>) {
                 match msg {
                     Some(Ok(Message::Text(text))) => {
                         let text_str: &str = &text;
+                        let request_id = serde_json::from_str::<serde_json::Value>(text_str)
+                            .ok().and_then(|value| value.get("requestId").and_then(|id| id.as_u64()));
                         match serde_json::from_str::<ClientMsg>(text_str) {
                             Ok(ClientMsg::GetConversation {
                                 session_id,
@@ -217,20 +219,26 @@ async fn handle_socket(mut socket: WebSocket, state: Arc<WsState>) {
                             }) => {
                                 if let Some(previous) = inflight.take() {
                                     previous.abort();
+                                    let cancelled = response_json(&ServerMsg::Error {
+                                        message: "Conversation request superseded".into(),
+                                    }, inflight_id.take());
+                                    if socket.send(Message::Text(cancelled)).await.is_err() { break; }
                                 }
-                                let progress_tx = state.progress_tx.clone();
+                                let progress_tx = progress_tx.clone();
+                                inflight_id = request_id;
                                 inflight = Some(tokio::spawn(async move {
                                     load_conversation_response(
                                         session_id,
                                         include_tools,
                                         progress_tx,
+                                        request_id,
                                     )
                                     .await
                                 }));
                             }
                             Ok(client_msg) => {
                                 let response = handle_message(client_msg).await;
-                                let json = serde_json::to_string(&response).unwrap_or_default();
+                                let json = response_json(&response, request_id);
                                 if socket.send(Message::Text(json)).await.is_err() {
                                     break;
                                 }
@@ -239,7 +247,7 @@ async fn handle_socket(mut socket: WebSocket, state: Arc<WsState>) {
                                 let response = ServerMsg::Error {
                                     message: format!("Invalid message: {}", e),
                                 };
-                                let json = serde_json::to_string(&response).unwrap_or_default();
+                                let json = response_json(&response, request_id);
                                 if socket.send(Message::Text(json)).await.is_err() {
                                     break;
                                 }
@@ -269,7 +277,7 @@ async fn handle_socket(mut socket: WebSocket, state: Arc<WsState>) {
                     },
                     None => continue,
                 };
-                let json = serde_json::to_string(&response).unwrap_or_default();
+                let json = response_json(&response, inflight_id.take());
                 if socket.send(Message::Text(json)).await.is_err() {
                     break;
                 }
@@ -306,15 +314,27 @@ async fn handle_socket(mut socket: WebSocket, state: Arc<WsState>) {
         }
     }
 
+    if let Some(handle) = inflight {
+        handle.abort();
+    }
     crate::debug_log::log_info("[ws-server] Client disconnected");
 }
 
 // ── Message dispatch ────────────────────────────────────────────────
 
+fn response_json(response: &ServerMsg, request_id: Option<u64>) -> String {
+    let mut value = serde_json::to_value(response).unwrap_or_default();
+    if let Some(id) = request_id {
+        value["requestId"] = id.into();
+    }
+    value.to_string()
+}
+
 async fn load_conversation_response(
     session_id: String,
     include_tools: bool,
     progress_tx: broadcast::Sender<String>,
+    request_id: Option<u64>,
 ) -> ServerMsg {
     let emit_id = session_id.clone();
     match tokio::task::spawn_blocking(move || {
@@ -324,6 +344,7 @@ async fn load_conversation_response(
             &mut |bytes_read, bytes_total| {
                 let payload = serde_json::json!({
                     "sessionId": emit_id,
+                    "requestId": request_id,
                     "bytesRead": bytes_read,
                     "bytesTotal": bytes_total,
                 });
@@ -356,10 +377,15 @@ async fn handle_message(msg: ClientMsg) -> ServerMsg {
             session_id,
             include_tools,
         } => {
-            load_conversation_response(session_id, include_tools, {
-                let (tx, _) = broadcast::channel(1);
-                tx
-            })
+            load_conversation_response(
+                session_id,
+                include_tools,
+                {
+                    let (tx, _) = broadcast::channel(1);
+                    tx
+                },
+                None,
+            )
             .await
         }
 
@@ -396,5 +422,41 @@ async fn handle_message(msg: ClientMsg) -> ServerMsg {
             },
             Err(e) => ServerMsg::Error { message: e },
         },
+    }
+}
+
+#[cfg(test)]
+mod protocol_tests {
+    use super::*;
+
+    #[test]
+    fn correlated_success_and_error_keep_request_ids() {
+        for response in [
+            ServerMsg::Ok,
+            ServerMsg::Error {
+                message: "superseded".into(),
+            },
+        ] {
+            let value: serde_json::Value =
+                serde_json::from_str(&response_json(&response, Some(42))).unwrap();
+            assert_eq!(value["requestId"], 42);
+        }
+        let value: serde_json::Value =
+            serde_json::from_str(&response_json(&ServerMsg::Ok, None)).unwrap();
+        assert!(value.get("requestId").is_none());
+    }
+
+    #[test]
+    fn conversation_requests_support_default_hidden_tools_and_correlation() {
+        let request: ClientMsg =
+            serde_json::from_str(r#"{"type":"getConversation","sessionId":"test","requestId":42}"#)
+                .unwrap();
+        assert!(matches!(
+            request,
+            ClientMsg::GetConversation {
+                include_tools: false,
+                ..
+            }
+        ));
     }
 }

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -25,15 +25,21 @@ export async function getSessions(): Promise<Session[]> {
 /**
  * Get the full conversation history for a specific session
  */
-export async function getConversation(sessionId: string): Promise<Conversation> {
+export async function getConversation(
+	sessionId: string,
+	includeTools = false
+): Promise<Conversation> {
 	if (get(isDemoMode)) {
 		return demoConversations[sessionId] ?? { sessionId, messages: [] };
 	}
 
 	if (useWebSocket()) {
-		return await wsClient.request<Conversation>('getConversation', { sessionId });
+		return await wsClient.request<Conversation>('getConversation', {
+			sessionId,
+			includeTools
+		});
 	}
-	return await invoke<Conversation>('get_conversation', { sessionId });
+	return await invoke<Conversation>('get_conversation', { sessionId, includeTools });
 }
 
 /**

--- a/src/lib/components/ConversationLoadBar.svelte
+++ b/src/lib/components/ConversationLoadBar.svelte
@@ -1,0 +1,58 @@
+<script lang="ts">
+	import { conversationLoad, conversationLoadPercent } from '$lib/stores/conversation-loader';
+
+	interface Props {
+		sessionId: string;
+	}
+
+	let { sessionId }: Props = $props();
+
+	let active = $derived($conversationLoad?.sessionId === sessionId);
+	let percent = $derived(conversationLoadPercent($conversationLoad));
+</script>
+
+{#if active}
+	<div
+		class="load-track"
+		role="progressbar"
+		aria-valuemin={0}
+		aria-valuemax={100}
+		aria-valuenow={percent ?? undefined}
+		aria-label="Loading conversation"
+	>
+		<div
+			class="load-fill"
+			class:indeterminate={percent == null}
+			style={percent == null ? undefined : `width: ${percent}%`}
+		></div>
+	</div>
+{/if}
+
+<style>
+	.load-track {
+		height: 2px;
+		background: var(--border-muted);
+		overflow: hidden;
+		flex-shrink: 0;
+	}
+
+	.load-fill {
+		height: 100%;
+		background: var(--status-working);
+		transition: width 80ms linear;
+	}
+
+	.load-fill.indeterminate {
+		width: 30%;
+		animation: load-slide 1s linear infinite;
+	}
+
+	@keyframes load-slide {
+		from {
+			transform: translateX(-100%);
+		}
+		to {
+			transform: translateX(350%);
+		}
+	}
+</style>

--- a/src/lib/components/CostTracker.svelte
+++ b/src/lib/components/CostTracker.svelte
@@ -1,6 +1,8 @@
 <script lang="ts">
 	import { onMount } from 'svelte';
 	import { getConversation } from '$lib/api';
+	import { toolsLoadedFor, withConversationLoader } from '$lib/stores/conversation-loader';
+	import { get } from 'svelte/store';
 	import type { HistoryEntry, Conversation, CostData, SessionCostRecord, SessionProvider } from '$lib/types';
 	import TokenDistanceVisualizer from './token-distance/TokenDistanceVisualizer.svelte';
 	import HistoryCardOverlay from './HistoryCardOverlay.svelte';
@@ -283,11 +285,10 @@
 		});
 	}
 
-	let loadingConversation = $state(false);
+	let conversationRequestId = 0;
 
 	async function handleSessionClick(session: import('$lib/types').SessionCostRecord) {
-		if (loadingConversation) return;
-		loadingConversation = true;
+		const requestId = ++conversationRequestId;
 		selectedEntry = {
 			sessionId: session.sessionId,
 			display: session.sessionName || session.sessionId.slice(0, 8),
@@ -299,12 +300,16 @@
 			surface: session.surface,
 		};
 		conversation = null;
+		toolsLoadedFor.set(null);
 		try {
-			conversation = await getConversation(session.sessionId);
+			const conv = await withConversationLoader(session.sessionId, 'conversation', () =>
+				getConversation(session.sessionId, false)
+			);
+			if (requestId !== conversationRequestId) return;
+			if (get(toolsLoadedFor) === session.sessionId) return;
+			conversation = conv;
 		} catch (e) {
 			console.error('Failed to load conversation:', e);
-		} finally {
-			loadingConversation = false;
 		}
 	}
 
@@ -877,7 +882,7 @@
 	/>
 {/if}
 {#if selectedEntry}
-	<HistoryCardOverlay entry={selectedEntry} {conversation} onclose={() => { selectedEntry = null; conversation = null; }} />
+	<HistoryCardOverlay entry={selectedEntry} {conversation} onclose={() => { selectedEntry = null; conversation = null; }} onconversation={(conv) => { if (selectedEntry?.sessionId === conv.sessionId) conversation = conv; }} />
 {/if}
 </div>
 

--- a/src/lib/components/ExpandedCardOverlay.svelte
+++ b/src/lib/components/ExpandedCardOverlay.svelte
@@ -43,14 +43,25 @@
 	import TodoPanel from './TodoPanel.svelte';
 	import { createSlidingWindow, BATCH_SIZE } from '$lib/slidingWindow.svelte';
 	import { sessionCostMap, costMode } from '$lib/stores/cost';
-	import { workersByPm, expandedSessionId, codexSubagentsByParent, codexVisibleParentByChild } from '$lib/stores/sessions';
+	import { currentConversation, workersByPm, expandedSessionId, codexSubagentsByParent, codexVisibleParentByChild } from '$lib/stores/sessions';
 	import { visibleSubagentsBySession } from '$lib/stores/subagents';
 	import { PM_ORCHESTRATION_ENABLED } from '$lib/feature-flags';
 	import { formatCost, formatTokens, formatCostOrTokens, modelDisplayName } from '$lib/cost-utils';
+	import { isCostAvailable } from '$lib/cost-semantics';
 	import { formatTimeSince, formatDurationMs } from '$lib/time-utils';
 	import { getSessionStatusColor, getSessionStatusLabel, getSubagentStatusColor, getSubagentStatusLabel, getWorkerStatusColor, getWorkerStatusLabel } from '$lib/status-utils';
 	import { isTauri } from '$lib/ws';
 	import ProviderBadge from './ProviderBadge.svelte';
+	import { getConversation } from '$lib/api';
+	import {
+		conversationLoad,
+		conversationLoadLabel,
+		isSessionLoading,
+		isToolsLoading,
+		toolsLoadedFor,
+		withConversationLoader
+	} from '$lib/stores/conversation-loader';
+	import ConversationLoadBar from './ConversationLoadBar.svelte';
 	import { canSessionAction } from '$lib/provider';
 
 	interface Props {
@@ -66,7 +77,7 @@
 	let messagesContainer = $state<HTMLDivElement>(undefined!);
 	let isInitialLoad = $state(true);
 	let hasScrolledToBottom = $state(false);
-	let showTools = $state(true);
+	let showTools = $state(false);
 	let showThinking = $state(true);
 	let navSheetOpen = $state(false);
 	let idCopied = $state(false);
@@ -101,6 +112,12 @@
 		).length;
 	});
 
+	let toolsLoading = $derived(isToolsLoading(session.id, $conversationLoad));
+	let sessionLoading = $derived(isSessionLoading(session.id, $conversationLoad));
+	let loadLabel = $derived(
+		$conversationLoad?.sessionId === session.id ? conversationLoadLabel($conversationLoad) : null
+	);
+
 	// Stagger messages only on the overlay's first render. After that,
 	// streaming/polling appends new messages — those should appear instantly.
 	function messageIn(node: Element, params: { index: number }) {
@@ -112,6 +129,31 @@
 		// Close the bottom sheet on mobile after navigating
 		navSheetOpen = false;
 	}
+
+	async function toggleTools() {
+		const next = !showTools;
+		if (sessionLoading) return;
+		if (next && $toolsLoadedFor !== session.id) {
+			try {
+				const conv = await withConversationLoader(session.id, 'tools', () =>
+					getConversation(session.id, true)
+				);
+				if (conv.sessionId === session.id) {
+					currentConversation.set(conv);
+					toolsLoadedFor.set(session.id);
+				}
+			} catch (error) {
+				console.error('Failed to load tools:', error);
+				return;
+			}
+		}
+		showTools = next;
+	}
+
+	$effect(() => {
+		session.id;
+		showTools = false;
+	});
 
 	onMount(() => {
 		isInitialLoad = false;
@@ -162,7 +204,7 @@
 
 	let costRecord = $derived($sessionCostMap.get(session.id));
 	let primaryCostLabel = $derived(
-		costRecord ? formatCostOrTokens(costRecord.cost, costRecord.totalTokens, $costMode, costRecord.costAvailable ?? costRecord.provider !== 'codex') : null
+		costRecord ? formatCostOrTokens(costRecord.cost, costRecord.totalTokens, $costMode, isCostAvailable(costRecord)) : null
 	);
 
 	let isPermission = $derived(session.status === SessionStatus.NeedsAttention);
@@ -384,11 +426,15 @@
 							<span class="session-name-badge">{session.sessionName}</span>
 							<span class="separator">·</span>
 							<span class="message-count">{#if conversation && conversation.messages.length > BATCH_SIZE}{sw.startIndex + 1}–{sw.endIndex} / {/if}{conversation?.messages.length ?? 0} messages</span>
+							{#if loadLabel}
+								<span class="separator">·</span>
+								<span class="load-label">{loadLabel}</span>
+							{/if}
 							{#if costRecord}
 								<span class="separator">·</span>
-								<span class="cost-breakdown" title="{costRecord.costAvailable ?? costRecord.provider !== 'codex' ? `Total cost: ${formatCost(costRecord.cost)}` : 'USD pricing unavailable'} · {formatTokens(costRecord.totalTokens)} tokens · {modelDisplayName(costRecord.model)}">
+								<span class="cost-breakdown" title="{isCostAvailable(costRecord) ? `Total cost: ${formatCost(costRecord.cost)}` : 'USD pricing unavailable'} · {formatTokens(costRecord.totalTokens)} tokens · {modelDisplayName(costRecord.model)}">
 									<span class="cost-primary">{primaryCostLabel}</span>
-									<span class="cost-secondary">· {$costMode === 'usd' ? formatTokens(costRecord.totalTokens) + ' tok' : formatCostOrTokens(costRecord.cost, costRecord.totalTokens, 'usd', costRecord.costAvailable ?? costRecord.provider !== 'codex')}</span>
+									<span class="cost-secondary">· {$costMode === 'usd' ? formatTokens(costRecord.totalTokens) + ' tok' : formatCostOrTokens(costRecord.cost, costRecord.totalTokens, 'usd', isCostAvailable(costRecord))}</span>
 									<span class="cost-secondary">· {modelDisplayName(costRecord.model)}</span>
 								</span>
 							{/if}
@@ -439,9 +485,11 @@
 					<button
 						type="button"
 						class="header-button toggle-tools"
-						class:active={showTools}
-						onclick={() => showTools = !showTools}
-						title={showTools ? "Hide Tools" : "Show Tools"}
+						class:active={showTools && !toolsLoading}
+						class:loading={toolsLoading}
+						disabled={sessionLoading}
+						onclick={toggleTools}
+						title={toolsLoading ? "Loading tools" : sessionLoading ? "Loading conversation" : showTools ? "Hide Tools" : "Show Tools"}
 					>
 						<span>⚙</span>
 					</button>
@@ -454,6 +502,7 @@
 					</button>
 				</div>
 			</header>
+			<ConversationLoadBar sessionId={session.id} />
 
 			{#if tooltipText}
 				<div class="id-tooltip" style="left: {tooltipX}px; top: {tooltipY}px;">
@@ -1263,6 +1312,13 @@
 		color: var(--text-muted);
 	}
 
+	.load-label {
+		font-family: var(--font-pixel);
+		font-size: 11px;
+		letter-spacing: 0.08em;
+		color: var(--status-working);
+	}
+
 	.header-actions {
 		display: flex;
 		align-items: center;
@@ -1283,6 +1339,11 @@
 		color: var(--text-primary);
 	}
 
+	.header-button:disabled {
+		opacity: 1;
+		cursor: default;
+	}
+
 	.header-button span {
 		font-family: var(--font-mono);
 		font-size: 14px;
@@ -1296,6 +1357,22 @@
 	.header-button.active.toggle-tools {
 		color: var(--status-input);
 		opacity: 1;
+	}
+
+	.header-button.loading.toggle-tools {
+		color: var(--status-working);
+		opacity: 1;
+	}
+
+	.header-button.loading.toggle-tools span {
+		display: inline-block;
+		animation: gear-spin 0.8s linear infinite;
+	}
+
+	@keyframes gear-spin {
+		to {
+			transform: rotate(360deg);
+		}
 	}
 
 	.header-divider {

--- a/src/lib/components/ExpandedCardOverlay.svelte
+++ b/src/lib/components/ExpandedCardOverlay.svelte
@@ -131,22 +131,23 @@
 	}
 
 	async function toggleTools() {
+		const requestedId = session.id;
 		const next = !showTools;
 		if (sessionLoading) return;
-		if (next && $toolsLoadedFor !== session.id) {
+		if (next && $toolsLoadedFor !== requestedId) {
 			try {
-				const conv = await withConversationLoader(session.id, 'tools', () =>
-					getConversation(session.id, true)
+				const conv = await withConversationLoader(requestedId, 'tools', () =>
+					getConversation(requestedId, true)
 				);
-				if (conv.sessionId === session.id) {
-					currentConversation.set(conv);
-					toolsLoadedFor.set(session.id);
-				}
+				if (session.id !== requestedId || conv.sessionId !== requestedId) return;
+				currentConversation.set(conv);
+				toolsLoadedFor.set(requestedId);
 			} catch (error) {
 				console.error('Failed to load tools:', error);
 				return;
 			}
 		}
+		if (session.id !== requestedId) return;
 		showTools = next;
 	}
 

--- a/src/lib/components/ExpandedCardOverlay.svelte
+++ b/src/lib/components/ExpandedCardOverlay.svelte
@@ -31,7 +31,7 @@
 </script>
 
 <script lang="ts">
-	import { onMount, tick } from 'svelte';
+	import { onDestroy, onMount, tick } from 'svelte';
 	import { fade, scale } from 'svelte/transition';
 	import { quintOut } from 'svelte/easing';
 	import { flyIn, flyInX, fadeIn } from '$lib/transitions';
@@ -130,6 +130,9 @@
 		navSheetOpen = false;
 	}
 
+	let disposed = false;
+	onDestroy(() => { disposed = true; });
+
 	async function toggleTools() {
 		const requestedId = session.id;
 		const next = !showTools;
@@ -139,7 +142,7 @@
 				const conv = await withConversationLoader(requestedId, 'tools', () =>
 					getConversation(requestedId, true)
 				);
-				if (session.id !== requestedId || conv.sessionId !== requestedId) return;
+				if (disposed || session.id !== requestedId || conv.sessionId !== requestedId) return;
 				currentConversation.set(conv);
 				toolsLoadedFor.set(requestedId);
 			} catch (error) {
@@ -147,7 +150,7 @@
 				return;
 			}
 		}
-		if (session.id !== requestedId) return;
+		if (disposed || session.id !== requestedId) return;
 		showTools = next;
 	}
 

--- a/src/lib/components/HistoryCardOverlay.svelte
+++ b/src/lib/components/HistoryCardOverlay.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-	import { onMount, tick } from 'svelte';
+	import { onDestroy, onMount, tick } from 'svelte';
 	import { fade, scale } from 'svelte/transition';
 	import { quintOut } from 'svelte/easing';
 	import type { HistoryEntry, Conversation } from '$lib/types';
@@ -66,6 +66,9 @@
 		navSheetOpen = false;
 	}
 
+	let disposed = false;
+	onDestroy(() => { disposed = true; });
+
 	async function toggleTools() {
 		const requestedId = entry.sessionId;
 		const next = !showTools;
@@ -75,7 +78,7 @@
 				const conv = await withConversationLoader(requestedId, 'tools', () =>
 					getConversation(requestedId, true)
 				);
-				if (entry.sessionId !== requestedId || conv.sessionId !== requestedId) return;
+				if (disposed || entry.sessionId !== requestedId || conv.sessionId !== requestedId) return;
 				onconversation?.(conv);
 				toolsLoadedFor.set(requestedId);
 			} catch (error) {
@@ -83,7 +86,7 @@
 				return;
 			}
 		}
-		if (entry.sessionId !== requestedId) return;
+		if (disposed || entry.sessionId !== requestedId) return;
 		showTools = next;
 	}
 

--- a/src/lib/components/HistoryCardOverlay.svelte
+++ b/src/lib/components/HistoryCardOverlay.svelte
@@ -8,20 +8,32 @@
 	import { createSlidingWindow, BATCH_SIZE, MAX_VISIBLE } from '$lib/slidingWindow.svelte';
 	import { sessionCostMap, costMode } from '$lib/stores/cost';
 	import { formatCost, formatTokens, formatCostOrTokens, modelDisplayName } from '$lib/cost-utils';
+	import { isCostAvailable } from '$lib/cost-semantics';
 	import ProviderBadge from './ProviderBadge.svelte';
+	import { getConversation } from '$lib/api';
+	import {
+		conversationLoad,
+		conversationLoadLabel,
+		isSessionLoading,
+		isToolsLoading,
+		toolsLoadedFor,
+		withConversationLoader
+	} from '$lib/stores/conversation-loader';
+	import ConversationLoadBar from './ConversationLoadBar.svelte';
 
 	interface Props {
 		entry: HistoryEntry;
 		conversation: Conversation | null;
 		searchQuery?: string;
 		onclose: () => void;
+		onconversation?: (conversation: Conversation) => void;
 	}
 
-	let { entry, conversation, searchQuery, onclose }: Props = $props();
+	let { entry, conversation, searchQuery, onclose, onconversation }: Props = $props();
 
 	let messagesContainer = $state<HTMLDivElement>(undefined!);
 	let hasScrolledToBottom = $state(false);
-	let showTools = $state(true);
+	let showTools = $state(false);
 	let showThinking = $state(true);
 	let navSheetOpen = $state(false);
 	let copied = $state(false);
@@ -30,7 +42,7 @@
 
 	let costRecord = $derived($sessionCostMap.get(entry.sessionId));
 	let primaryCostLabel = $derived(
-		costRecord ? formatCostOrTokens(costRecord.cost, costRecord.totalTokens, $costMode, costRecord.costAvailable ?? costRecord.provider !== 'codex') : null
+		costRecord ? formatCostOrTokens(costRecord.cost, costRecord.totalTokens, $costMode, isCostAvailable(costRecord)) : null
 	);
 	let resumeCommand = $derived(
 		entry.provider === 'codex'
@@ -43,10 +55,41 @@
 		return sw.sliceMessages(conversation.messages);
 	});
 
+	let toolsLoading = $derived(isToolsLoading(entry.sessionId, $conversationLoad));
+	let sessionLoading = $derived(isSessionLoading(entry.sessionId, $conversationLoad));
+	let loadLabel = $derived(
+		$conversationLoad?.sessionId === entry.sessionId ? conversationLoadLabel($conversationLoad) : null
+	);
+
 	function handleNavItemClick() {
 		// Close the bottom sheet on mobile after navigating
 		navSheetOpen = false;
 	}
+
+	async function toggleTools() {
+		const next = !showTools;
+		if (sessionLoading) return;
+		if (next && $toolsLoadedFor !== entry.sessionId) {
+			try {
+				const conv = await withConversationLoader(entry.sessionId, 'tools', () =>
+					getConversation(entry.sessionId, true)
+				);
+				if (conv.sessionId === entry.sessionId) {
+					onconversation?.(conv);
+					toolsLoadedFor.set(entry.sessionId);
+				}
+			} catch (error) {
+				console.error('Failed to load tools:', error);
+				return;
+			}
+		}
+		showTools = next;
+	}
+
+	$effect(() => {
+		entry.sessionId;
+		showTools = false;
+	});
 
 	onMount(() => {
 		const handleKeydown = (e: KeyboardEvent) => {
@@ -170,11 +213,15 @@
 						</div>
 						<div class="header-meta">
 							<span class="message-count">{#if conversation && conversation.messages.length > BATCH_SIZE}{sw.startIndex + 1}–{sw.endIndex} / {/if}{conversation?.messages.length ?? 0} messages</span>
+							{#if loadLabel}
+								<span class="separator">·</span>
+								<span class="load-label">{loadLabel}</span>
+							{/if}
 							{#if costRecord}
 								<span class="separator">·</span>
-								<span class="cost-breakdown" title="{costRecord.costAvailable ?? costRecord.provider !== 'codex' ? `Total cost: ${formatCost(costRecord.cost)}` : 'USD pricing unavailable'} · {formatTokens(costRecord.totalTokens)} tokens · {modelDisplayName(costRecord.model)}">
+								<span class="cost-breakdown" title="{isCostAvailable(costRecord) ? `Total cost: ${formatCost(costRecord.cost)}` : 'USD pricing unavailable'} · {formatTokens(costRecord.totalTokens)} tokens · {modelDisplayName(costRecord.model)}">
 									<span class="cost-primary">{primaryCostLabel}</span>
-									<span class="cost-secondary">· {$costMode === 'usd' ? formatTokens(costRecord.totalTokens) + ' tok' : formatCostOrTokens(costRecord.cost, costRecord.totalTokens, 'usd', costRecord.costAvailable ?? costRecord.provider !== 'codex')}</span>
+									<span class="cost-secondary">· {$costMode === 'usd' ? formatTokens(costRecord.totalTokens) + ' tok' : formatCostOrTokens(costRecord.cost, costRecord.totalTokens, 'usd', isCostAvailable(costRecord))}</span>
 									<span class="cost-secondary">· {modelDisplayName(costRecord.model)}</span>
 								</span>
 							{/if}
@@ -206,9 +253,11 @@
 					<button
 						type="button"
 						class="header-button toggle-tools"
-						class:active={showTools}
-						onclick={() => showTools = !showTools}
-						title={showTools ? "Hide Tools" : "Show Tools"}
+						class:active={showTools && !toolsLoading}
+						class:loading={toolsLoading}
+						disabled={sessionLoading}
+						onclick={toggleTools}
+						title={toolsLoading ? "Loading tools" : sessionLoading ? "Loading conversation" : showTools ? "Hide Tools" : "Show Tools"}
 					>
 						<span>⚙</span>
 					</button>
@@ -221,6 +270,7 @@
 					</button>
 				</div>
 			</header>
+			<ConversationLoadBar sessionId={entry.sessionId} />
 
 			<!-- Conversation Area -->
 			<div class="conversation-area" bind:this={messagesContainer} onscroll={handleScroll}>
@@ -398,6 +448,13 @@
 		color: var(--text-muted);
 	}
 
+	.load-label {
+		font-family: var(--font-pixel);
+		font-size: 11px;
+		letter-spacing: 0.08em;
+		color: var(--status-working);
+	}
+
 	.separator {
 		color: var(--text-muted);
 	}
@@ -483,6 +540,11 @@
 		color: var(--text-primary);
 	}
 
+	.header-button:disabled {
+		opacity: 1;
+		cursor: default;
+	}
+
 	.header-button span {
 		font-family: var(--font-mono);
 		font-size: 14px;
@@ -496,6 +558,22 @@
 	.header-button.active.toggle-tools {
 		color: var(--status-input);
 		opacity: 1;
+	}
+
+	.header-button.loading.toggle-tools {
+		color: var(--status-working);
+		opacity: 1;
+	}
+
+	.header-button.loading.toggle-tools span {
+		display: inline-block;
+		animation: gear-spin 0.8s linear infinite;
+	}
+
+	@keyframes gear-spin {
+		to {
+			transform: rotate(360deg);
+		}
 	}
 
 	.header-divider {

--- a/src/lib/components/HistoryCardOverlay.svelte
+++ b/src/lib/components/HistoryCardOverlay.svelte
@@ -67,22 +67,23 @@
 	}
 
 	async function toggleTools() {
+		const requestedId = entry.sessionId;
 		const next = !showTools;
 		if (sessionLoading) return;
-		if (next && $toolsLoadedFor !== entry.sessionId) {
+		if (next && $toolsLoadedFor !== requestedId) {
 			try {
-				const conv = await withConversationLoader(entry.sessionId, 'tools', () =>
-					getConversation(entry.sessionId, true)
+				const conv = await withConversationLoader(requestedId, 'tools', () =>
+					getConversation(requestedId, true)
 				);
-				if (conv.sessionId === entry.sessionId) {
-					onconversation?.(conv);
-					toolsLoadedFor.set(entry.sessionId);
-				}
+				if (entry.sessionId !== requestedId || conv.sessionId !== requestedId) return;
+				onconversation?.(conv);
+				toolsLoadedFor.set(requestedId);
 			} catch (error) {
 				console.error('Failed to load tools:', error);
 				return;
 			}
 		}
+		if (entry.sessionId !== requestedId) return;
 		showTools = next;
 	}
 

--- a/src/lib/components/MessageNavMap.svelte
+++ b/src/lib/components/MessageNavMap.svelte
@@ -11,7 +11,7 @@
 		hideHeader?: boolean;
 	}
 
-	let { conversation, scrollContainer, showTools = $bindable(true), showThinking = $bindable(true), onExpandToIndex, hideHeader = false }: Props = $props();
+	let { conversation, scrollContainer, showTools = $bindable(false), showThinking = $bindable(true), onExpandToIndex, hideHeader = false }: Props = $props();
 
 	// Filter for "milestone" messages - user messages, tool blocks, and thinking steps
 	let items = $derived.by(() => {
@@ -72,8 +72,22 @@
 
 	function truncateContent(content: string | undefined): string {
 		if (!content) return '...';
-		const clean = content.replace(/[#*`]/g, '').trim();
-		return clean.length > 40 ? clean.substring(0, 40) + '...' : clean;
+		const limit = 40;
+		let preview = '';
+		for (const character of content) {
+			if (character === '#' || character === '*' || character === '`') continue;
+			if (character === '\n' || character === '\r') {
+				if (preview.length === 0) continue;
+				break;
+			}
+			preview += character;
+			if (preview.length >= limit) break;
+		}
+		preview = preview.trim();
+		if (!preview) return '...';
+		return content.length > preview.length || preview.length >= limit
+			? `${preview.slice(0, limit)}...`
+			: preview;
 	}
 </script>
 

--- a/src/lib/components/SessionHistory.svelte
+++ b/src/lib/components/SessionHistory.svelte
@@ -227,6 +227,7 @@
 	}
 
 	function handleCloseConversation() {
+		conversationRequestId++;
 		selectedEntry = null;
 		conversation = null;
 	}

--- a/src/lib/components/SessionHistory.svelte
+++ b/src/lib/components/SessionHistory.svelte
@@ -2,6 +2,8 @@
 	import { onMount } from 'svelte';
 	import { browser } from '$app/environment';
 	import { deepSearchSessions, getConversation } from '$lib/api';
+	import { toolsLoadedFor, withConversationLoader } from '$lib/stores/conversation-loader';
+	import { get } from 'svelte/store';
 	import type { HistoryEntry, Conversation, DeepSearchHit } from '$lib/types';
 	import HistoryCardOverlay from './HistoryCardOverlay.svelte';
 	import { flyIn } from '$lib/transitions';
@@ -32,6 +34,7 @@
 	// Conversation viewer state
 	let selectedEntry = $state<HistoryEntry | null>(null);
 	let conversation = $state<Conversation | null>(null);
+	let conversationRequestId = 0;
 	// ── Persistence ──────────────────────────────────────────────────
 	onMount(() => {
 		if (browser) {
@@ -207,10 +210,17 @@
 
 	// ── Actions ──────────────────────────────────────────────────────
 	async function handleSelectEntry(entry: HistoryEntry) {
+		const requestId = ++conversationRequestId;
 		selectedEntry = entry;
 		conversation = null;
+		toolsLoadedFor.set(null);
 		try {
-			conversation = await getConversation(entry.sessionId);
+			const conv = await withConversationLoader(entry.sessionId, 'conversation', () =>
+				getConversation(entry.sessionId, false)
+			);
+			if (requestId !== conversationRequestId) return;
+			if (get(toolsLoadedFor) === entry.sessionId) return;
+			conversation = conv;
 		} catch (e) {
 			console.error('Failed to load conversation:', e);
 		}
@@ -425,7 +435,7 @@
 
 <!-- ── Conversation overlay ───────────────────────────────────────── -->
 {#if selectedEntry}
-	<HistoryCardOverlay entry={selectedEntry} {conversation} searchQuery={query.trim() && deepSearchResults?.has(selectedEntry.sessionId) ? query.trim() : undefined} onclose={handleCloseConversation} />
+	<HistoryCardOverlay entry={selectedEntry} {conversation} searchQuery={query.trim() && deepSearchResults?.has(selectedEntry.sessionId) ? query.trim() : undefined} onclose={handleCloseConversation} onconversation={(conv) => { if (selectedEntry?.sessionId === conv.sessionId) conversation = conv; }} />
 {/if}
 
 <style>

--- a/src/lib/components/ToastNotifications.svelte
+++ b/src/lib/components/ToastNotifications.svelte
@@ -26,20 +26,20 @@
 	}
 
 	.toast {
-		background: var(--bg-elevated, #1a1a2e);
-		border: 1px solid var(--status-input, #f5a623);
+		background: var(--bg-elevated);
+		border: 1px solid var(--status-input);
 		padding: 12px 16px;
-		animation: toast-in 0.3s ease-out;
+		animation: toast-in 0.2s linear;
 	}
 
 	@keyframes toast-in {
 		from {
 			opacity: 0;
-			transform: translateX(100%);
+			transform: translateY(-8px);
 		}
 		to {
 			opacity: 1;
-			transform: translateX(0);
+			transform: translateY(0);
 		}
 	}
 
@@ -47,7 +47,7 @@
 		font-family: var(--font-pixel, monospace);
 		font-size: 12px;
 		font-weight: 600;
-		color: var(--text-primary, #fff);
+		color: var(--text-primary);
 		text-transform: uppercase;
 		letter-spacing: 0.05em;
 		margin-bottom: 4px;
@@ -59,7 +59,7 @@
 	.toast-body {
 		font-family: var(--font-mono, monospace);
 		font-size: 12px;
-		color: var(--text-secondary, #aaa);
+		color: var(--text-secondary);
 		line-height: 1.4;
 	}
 </style>

--- a/src/lib/components/ToastNotifications.svelte
+++ b/src/lib/components/ToastNotifications.svelte
@@ -26,20 +26,20 @@
 	}
 
 	.toast {
-		background: var(--bg-elevated);
-		border: 1px solid var(--status-input);
+		background: var(--bg-elevated, #1a1a2e);
+		border: 1px solid var(--status-input, #f5a623);
 		padding: 12px 16px;
-		animation: toast-in 0.2s linear;
+		animation: toast-in 0.3s ease-out;
 	}
 
 	@keyframes toast-in {
 		from {
 			opacity: 0;
-			transform: translateY(-8px);
+			transform: translateX(100%);
 		}
 		to {
 			opacity: 1;
-			transform: translateY(0);
+			transform: translateX(0);
 		}
 	}
 
@@ -47,7 +47,7 @@
 		font-family: var(--font-pixel, monospace);
 		font-size: 12px;
 		font-weight: 600;
-		color: var(--text-primary);
+		color: var(--text-primary, #fff);
 		text-transform: uppercase;
 		letter-spacing: 0.05em;
 		margin-bottom: 4px;
@@ -59,7 +59,7 @@
 	.toast-body {
 		font-family: var(--font-mono, monospace);
 		font-size: 12px;
-		color: var(--text-secondary);
+		color: var(--text-secondary, #aaa);
 		line-height: 1.4;
 	}
 </style>

--- a/src/lib/stores/conversation-loader.ts
+++ b/src/lib/stores/conversation-loader.ts
@@ -1,0 +1,89 @@
+import { get, writable } from 'svelte/store';
+import { listen } from '@tauri-apps/api/event';
+import { isTauri, useWebSocket, wsClient } from '$lib/ws';
+
+export type ConversationLoadKind = 'conversation' | 'tools';
+
+export interface ConversationLoadState {
+	sessionId: string;
+	kind: ConversationLoadKind;
+	bytesRead: number;
+	bytesTotal: number;
+	generation: number;
+}
+
+export interface ConversationProgressEvent {
+	sessionId: string;
+	bytesRead: number;
+	bytesTotal: number;
+}
+
+export const conversationLoad = writable<ConversationLoadState | null>(null);
+
+/** Session whose in-memory conversation already includes tool dumps. */
+export const toolsLoadedFor = writable<string | null>(null);
+
+let progressListenerStarted = false;
+let loadGeneration = 0;
+
+export function conversationLoadPercent(state: ConversationLoadState | null): number | null {
+	if (!state || state.bytesTotal <= 0) return null;
+	return Math.min(100, Math.floor((state.bytesRead / state.bytesTotal) * 100));
+}
+
+export function conversationLoadLabel(state: ConversationLoadState | null): string | null {
+	if (!state) return null;
+	const kind = state.kind === 'tools' ? 'LOADING TOOLS' : 'LOADING';
+	const percent = conversationLoadPercent(state);
+	return percent == null ? kind : `${kind} · ${percent}%`;
+}
+
+export function isSessionLoading(sessionId: string, state: ConversationLoadState | null): boolean {
+	return state?.sessionId === sessionId;
+}
+
+export function isToolsLoading(sessionId: string, state: ConversationLoadState | null): boolean {
+	return state?.sessionId === sessionId && state.kind === 'tools';
+}
+
+function applyProgress(payload: ConversationProgressEvent) {
+	conversationLoad.update((state) => {
+		if (!state || state.sessionId !== payload.sessionId) return state;
+		return {
+			...state,
+			bytesRead: payload.bytesRead,
+			bytesTotal: payload.bytesTotal
+		};
+	});
+}
+
+export async function initConversationProgressListener() {
+	if (progressListenerStarted) return;
+	progressListenerStarted = true;
+
+	if (useWebSocket()) {
+		wsClient.on('conversationProgress', applyProgress);
+		return;
+	}
+	if (isTauri()) {
+		await listen<ConversationProgressEvent>('conversation-progress', (event) => {
+			applyProgress(event.payload);
+		});
+	}
+}
+
+export async function withConversationLoader<T>(
+	sessionId: string,
+	kind: ConversationLoadKind,
+	task: () => Promise<T>
+): Promise<T> {
+	const generation = ++loadGeneration;
+	conversationLoad.set({ sessionId, kind, bytesRead: 0, bytesTotal: 0, generation });
+	try {
+		return await task();
+	} finally {
+		if (get(conversationLoad)?.generation === generation) {
+			conversationLoad.set(null);
+		}
+	}
+}

--- a/src/lib/stores/sessions.ts
+++ b/src/lib/stores/sessions.ts
@@ -11,6 +11,7 @@ import { isDemoMode } from '../demo/mode';
 import { openSession } from '../api';
 import { wsClient, useWebSocket, getStoredWsUrl, isTauri } from '../ws';
 import { resolveCodexHierarchy } from '../provider';
+import { initConversationProgressListener } from './conversation-loader';
 
 /**
  * Store containing all active sessions
@@ -161,6 +162,7 @@ export async function initializeSessionListeners() {
 	} else {
 		await initTauriListeners();
 	}
+	await initConversationProgressListener();
 }
 
 // ── WebSocket mode ──────────────────────────────────────────────────

--- a/src/lib/ws.ts
+++ b/src/lib/ws.ts
@@ -8,8 +8,8 @@ class WsClient {
 	private ws: WebSocket | null = null;
 	private url: string = '';
 	private _connected = false;
-	private pendingResolve: ((value: any) => void) | null = null;
-	private pendingReject: ((reason: any) => void) | null = null;
+	private nextRequestId = 0;
+	private pending = new Map<number, { resolve: (value: any) => void; reject: (reason: any) => void }>();
 	private listeners = new Map<string, Set<EventCallback>>();
 	private reconnectTimer: ReturnType<typeof setTimeout> | null = null;
 
@@ -69,9 +69,14 @@ class WsClient {
 			throw new Error('WebSocket not connected');
 		}
 		return new Promise((resolve, reject) => {
-			this.pendingResolve = resolve as (value: any) => void;
-			this.pendingReject = reject;
-			this.ws!.send(JSON.stringify({ type, ...data }));
+			const requestId = ++this.nextRequestId;
+			this.pending.set(requestId, { resolve, reject });
+			try {
+				this.ws!.send(JSON.stringify({ type, ...data, requestId }));
+			} catch (error) {
+				this.pending.delete(requestId);
+				reject(error);
+			}
 		});
 	}
 
@@ -100,18 +105,18 @@ class WsClient {
 				return;
 			}
 			if (msg.type === 'conversationProgress') {
-				this.emit('conversationProgress', msg.data);
+				if (msg.data.requestId == null || this.pending.has(msg.data.requestId)) {
+					this.emit('conversationProgress', msg.data);
+				}
 				return;
 			}
 
-			// Request-response: resolve or reject the pending promise
-			if (msg.type === 'error') {
-				this.pendingReject?.(new Error(msg.message));
-			} else {
-				this.pendingResolve?.(msg.data ?? msg);
-			}
-			this.pendingResolve = null;
-			this.pendingReject = null;
+			// Correlate responses: background conversations can finish out of order.
+			const pending = this.pending.get(msg.requestId);
+			if (!pending) return;
+			this.pending.delete(msg.requestId);
+			if (msg.type === 'error') pending.reject(new Error(msg.message));
+			else pending.resolve(msg.data ?? msg);
 		} catch (e) {
 			console.error('[ws] Failed to parse message:', e);
 		}
@@ -128,9 +133,8 @@ class WsClient {
 	}
 
 	private rejectPending(reason: string) {
-		this.pendingReject?.(new Error(reason));
-		this.pendingResolve = null;
-		this.pendingReject = null;
+		for (const request of this.pending.values()) request.reject(new Error(reason));
+		this.pending.clear();
 	}
 
 	private scheduleReconnect() {

--- a/src/lib/ws.ts
+++ b/src/lib/ws.ts
@@ -99,6 +99,10 @@ class WsClient {
 				this.emit('notification', msg.data);
 				return;
 			}
+			if (msg.type === 'conversationProgress') {
+				this.emit('conversationProgress', msg.data);
+				return;
+			}
 
 			// Request-response: resolve or reject the pending promise
 			if (msg.type === 'error') {

--- a/src/routes/(app)/+page.svelte
+++ b/src/routes/(app)/+page.svelte
@@ -12,6 +12,8 @@
 		visibleTopLevelSessionIds
 	} from '$lib/stores/sessions';
 	import { getConversation, stopSession, openSession } from '$lib/api';
+	import { toolsLoadedFor, withConversationLoader } from '$lib/stores/conversation-loader';
+	import { get } from 'svelte/store';
 	import { isDemoMode, toggleDemoMode } from '$lib/demo';
 	import { PM_ORCHESTRATION_ENABLED } from '$lib/feature-flags';
 	import { isTauri } from '$lib/ws';
@@ -327,12 +329,13 @@
 		const sessionId = expandedId;
 		const requestId = ++conversationRequestId;
 		currentConversation.set(null);
+		toolsLoadedFor.set(null);
 		if (sessionId) {
-			getConversation(sessionId)
+			withConversationLoader(sessionId, 'conversation', () => getConversation(sessionId, false))
 				.then((conv) => {
-					if (requestId === conversationRequestId && conv.sessionId === sessionId) {
-						currentConversation.set(conv);
-					}
+					if (requestId !== conversationRequestId || conv.sessionId !== sessionId) return;
+					if (get(toolsLoadedFor) === sessionId) return;
+					currentConversation.set(conv);
 				})
 				.catch((error) => {
 					console.error('Failed to fetch conversation:', error);


### PR DESCRIPTION
History and Cost repeatedly deserialize and rewrite the entire Codex archive cache, while opening large conversations sends tool dumps before the user asks to see them. Reuse an in-process archive cache, return lightweight listing snapshots, skip unchanged disk writes, and load tools explicitly with byte progress.

This extracts the two archive commits from `fix/codex-archive-perf` onto current main without release/version changes or Cursor/Pi support. Conversation discovery still walks for resumed fragments missing from cached paths, and CLI view retains tools.

Review fixes:
- Correlate WebSocket responses by request ID so background conversation loads cannot settle unrelated requests. Reject superseded loads and keep progress local to the requesting connection.
- Ignore tool responses after their overlay is destroyed.
- Verify unchanged-cache modification time and reload persisted token streams in tests; omit unrelated toast styling.

Validation:
- Svelte check: 0 errors/warnings; production frontend build passed.
- Default Rust tests: 314 passed + 3 parser integration tests; 3 ignored tests across suites.
- CLI-only Rust tests: 300 passed + 3 parser integration tests; 3 ignored tests across suites.
- WebSocket regression tests: 3 passed; added to CI.

Native UI, packaging, signing and notarization were not exercised. Aborting a superseded async load discards its result; an already-started blocking file read can still finish in the background.
