### PR TITLE
fix: preserve Codex conversations across filtering and polling

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,6 +35,9 @@ jobs:
       - name: WebSocket request regression tests
         run: node --test scripts/test-ws.mjs
 
+      - name: Conversation selection regression tests
+        run: node --conditions=browser --test scripts/test-conversation-selection.mjs
+
       - name: Rust check
         run: cargo check --manifest-path src-tauri/Cargo.toml
 

--- a/scripts/test-conversation-selection.mjs
+++ b/scripts/test-conversation-selection.mjs
@@ -1,0 +1,61 @@
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { test } from 'node:test';
+import { compileModule } from 'svelte/compiler';
+import { flushSync } from 'svelte';
+
+// Execute the actual page's reactive loader with deferred backend responses.
+const page = readFileSync(new URL('../src/routes/(app)/+page.svelte', import.meta.url), 'utf8');
+const start = page.indexOf('\tlet conversationTarget');
+const end = page.indexOf('\n\tfunction handleExpand', start);
+const loader = page.slice(start, end);
+const source = `
+import { untrack } from 'svelte';
+export function harness() {
+ let sessions = $state([{id:'same',provider:'codex'}]);
+ let expandedId = $state('codex:same');
+ const sessionKeyOf = s => s.provider + ':' + s.id;
+ const providerSessionKey = (provider,id) => provider + ':' + id;
+ const providerOf = s => s.provider;
+ let expandedSession = $derived(sessions.find(s => sessionKeyOf(s) === expandedId) || null);
+ let value = null;
+ const currentConversation = {set(v) {value = v;}};
+ const toolsLoadedFor = {value:null,set(v) {this.value=v;}};
+ const get = s => s.value;
+ const requests = [];
+ const getConversation = (id,provider) => new Promise(resolve => requests.push({id,provider,resolve}));
+ const withConversationLoader = (_id,_provider,_kind,task) => task();
+ const dispose = $effect.root(() => {
+ ${loader}
+ });
+ return {requests,dispose,value:()=>value,poll:()=>{sessions=sessions.map(s=>({...s}));},select(provider){sessions=[{id:'same',provider}];expandedId=provider+':same';},close(){expandedId=null;}};
+}`;
+let code = compileModule(source, { filename: 'conversation-selection.svelte.js', generate: 'client' }).js.code;
+code = code.replace(/from '([^']+)'/g, (_, spec) => `from '${import.meta.resolve(spec)}'`);
+const { harness } = await import('data:text/javascript;base64,' + Buffer.from(code).toString('base64'));
+const settle = async () => { await Promise.resolve(); await Promise.resolve(); flushSync(); };
+
+test('poll updates neither restart an in-flight load nor erase loaded messages', async () => {
+ const h=harness();
+ try {
+  flushSync(); assert.equal(h.requests.length,1);
+  for(let i=0;i<3;i++){h.poll();flushSync();}
+  assert.equal(h.requests.length,1);
+  const response={sessionId:'same',provider:'codex',messages:[{content:'hello'}]};
+  h.requests[0].resolve(response);await settle();
+  assert.equal(h.value(),response);
+  h.poll();flushSync();assert.equal(h.value(),response);assert.equal(h.requests.length,1);
+ } finally {h.dispose();}
+});
+
+test('provider switch rejects stale replies and reopening loads again', async () => {
+ const h=harness();
+ try {
+  flushSync();h.select('cursor');flushSync();assert.equal(h.requests.length,2);
+  h.requests[0].resolve({sessionId:'same',provider:'codex',messages:[]});await settle();assert.equal(h.value(),null);
+  const response={sessionId:'same',provider:'cursor',messages:[{content:'cursor'}]};
+  h.requests[1].resolve(response);await settle();assert.equal(h.value(),response);
+  h.close();flushSync();assert.equal(h.value(),null);
+  h.select('cursor');flushSync();assert.equal(h.requests.length,3);
+ } finally {h.dispose();}
+});

--- a/src-tauri/src/session/codex.rs
+++ b/src-tauri/src/session/codex.rs
@@ -876,7 +876,21 @@ fn monitor_record_is_relevant(header: &RolloutEventHeader) -> bool {
 }
 
 fn apply_rollout_line(summary: &mut CodexRolloutSummary, line: &[u8], capture_tool_messages: bool) {
-    let Ok(header) = serde_json::from_slice::<RolloutEventHeader>(line) else {
+    // The monitor scanner populates payload_type separately; its serde-skipped
+    // field cannot classify a response_item in the full conversation reader.
+    #[derive(Deserialize)]
+    struct PayloadHeader {
+        #[serde(rename = "type")]
+        kind: Option<String>,
+    }
+    #[derive(Deserialize)]
+    struct ConversationHeader {
+        timestamp: Option<String>,
+        #[serde(rename = "type")]
+        event_type: Option<String>,
+        payload: Option<PayloadHeader>,
+    }
+    let Ok(header) = serde_json::from_slice::<ConversationHeader>(line) else {
         return;
     };
     if let Some(timestamp) = header.timestamp.as_deref() {
@@ -888,7 +902,8 @@ fn apply_rollout_line(summary: &mut CodexRolloutSummary, line: &[u8], capture_to
         // Message response items are user-visible even when tool records are
         // filtered out. Tool-shaped response items only need the full path.
         Some("response_item") => {
-            capture_tool_messages || header.payload_type.as_deref() == Some("message")
+            capture_tool_messages
+                || header.payload.as_ref().and_then(|p| p.kind.as_deref()) == Some("message")
         }
         _ => false,
     };
@@ -3161,6 +3176,38 @@ mod tests {
         let without_tools = find_codex_conversation_under(temp.path(), "thread-id", false).unwrap();
         assert_eq!(without_tools.len(), 1);
         assert_eq!(without_tools[0].content, "hello");
+    }
+
+    #[test]
+    fn hidden_tools_preserves_response_item_only_conversation() {
+        let temp = TempDir::new().unwrap();
+        let day = temp.path().join("2026/07/13");
+        fs::create_dir_all(&day).unwrap();
+        let path = day.join("rollout-2026-07-13T00-00-00-thread-id.jsonl");
+        let lines = vec![
+            event("2026-07-13T00:00:00Z", "session_meta", serde_json::json!({"id":"thread-id","cwd":"/tmp"})),
+            event("2026-07-13T00:00:01Z", "response_item", serde_json::json!({"type":"message","role":"user","content":[{"type":"input_text","text":"question"}]})),
+            // serde's map order puts payload before type: both orders must work.
+            serde_json::json!({"type":"response_item","timestamp":"2026-07-13T00:00:02Z","payload":{"type":"message","role":"assistant","content":[{"type":"output_text","text":"answer"}]}}).to_string(),
+            event("2026-07-13T00:00:03Z", "response_item", serde_json::json!({"type":"function_call_output","call_id":"tool","output":"hidden output"})),
+        ];
+        write_lines(&path, &lines, true);
+        for _ in 0..2 {
+            let messages = find_codex_conversation_under(temp.path(), "thread-id", false).unwrap();
+            assert_eq!(
+                messages
+                    .iter()
+                    .map(|m| m.content.as_str())
+                    .collect::<Vec<_>>(),
+                vec!["question", "answer"]
+            );
+        }
+        assert_eq!(
+            find_codex_conversation_under(temp.path(), "thread-id", true)
+                .unwrap()
+                .len(),
+            3
+        );
     }
 
     #[test]

--- a/src/routes/(app)/+page.svelte
+++ b/src/routes/(app)/+page.svelte
@@ -2,7 +2,7 @@
 	import { fade } from 'svelte/transition';
 	import { flip } from 'svelte/animate';
 	import { fadeIn, flyIn } from '$lib/transitions';
-	import { onMount } from 'svelte';
+	import { onMount, untrack } from 'svelte';
 	import { browser } from '$app/environment';
 	import {
 		sortedSessions,
@@ -324,12 +324,15 @@
 		}
 	});
 
+	// Polling replaces session objects; only a provider-qualified selection change
+	// should clear/reload the conversation. Read the current object untracked.
+	let conversationTarget = $derived(expandedSession ? sessionKeyOf(expandedSession) : null);
 	let conversationRequestId = 0;
 	$effect(() => {
-		const sessionId = expandedId;
+		const sessionId = conversationTarget;
 		const requestId = ++conversationRequestId;
 		currentConversation.set(null);
-		const selected = expandedSession;
+		const selected = untrack(() => expandedSession);
 		if (sessionId && selected) {
 			const selectedKey = sessionKeyOf(selected);
 			toolsLoadedFor.set(null);


### PR DESCRIPTION
Codex conversations stored only as response_item records appeared empty when tools were hidden because the full reader used a serde-skipped payload type. Parse the nested payload header so user and assistant messages remain visible while tool records stay hidden.

Monitor polling also replaced the selected session object and repeatedly cleared/restarted conversation loading. Depend on the provider-qualified selection key instead; reopening refreshes content, and stale responses remain rejected after provider switches.

Validation: CLI Rust suite 361 passed plus 3 parser integration tests; two Svelte runtime regression tests cover polling during/after loading, provider changes, stale replies and reopening. Svelte check and release app build passed. The user verified the relaunched app and confirmed the issue is resolved.
