### PR TITLE
feat: add OpenCode monitoring preview and reliable native rendering

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,7 +33,7 @@ jobs:
         run: npm run check
 
       - name: WebSocket request regression tests
-        run: node --test scripts/test-ws.mjs scripts/test-hidden-transitions.mjs scripts/test-opencode-provider.mjs scripts/test-integration-settings.mjs
+        run: node --test scripts/test-ws.mjs scripts/test-hidden-transitions.mjs scripts/test-opencode-provider.mjs scripts/test-opencode-connection.mjs scripts/test-integration-settings.mjs
 
       - name: Conversation selection regression tests
         run: node --conditions=browser --test scripts/test-conversation-selection.mjs

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,7 +33,7 @@ jobs:
         run: npm run check
 
       - name: WebSocket request regression tests
-        run: node --test scripts/test-ws.mjs
+        run: node --test scripts/test-ws.mjs scripts/test-hidden-transitions.mjs scripts/test-opencode-provider.mjs
 
       - name: Conversation selection regression tests
         run: node --conditions=browser --test scripts/test-conversation-selection.mjs

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,7 +33,7 @@ jobs:
         run: npm run check
 
       - name: WebSocket request regression tests
-        run: node --test scripts/test-ws.mjs scripts/test-hidden-transitions.mjs scripts/test-opencode-provider.mjs
+        run: node --test scripts/test-ws.mjs scripts/test-hidden-transitions.mjs scripts/test-opencode-provider.mjs scripts/test-integration-settings.mjs
 
       - name: Conversation selection regression tests
         run: node --conditions=browser --test scripts/test-conversation-selection.mjs

--- a/docs/opencode-preview-acceptance-2026-09-12.md
+++ b/docs/opencode-preview-acceptance-2026-09-12.md
@@ -248,15 +248,29 @@ Observed with native Computer Use, not browser simulation:
 | Integration | Final rebuilt bundle: visible form, aligned right inset, URL, Connecting then AX `Connected · 3 sessions`; settings apply only to this isolated app |
 | OpenCode-only / cross-directory status | Final bundle screenshots: OpenCode filter, 2 roots, Working 1 / Waiting 1; Chinese root READY, old English root WORKING; child is grouped under English root |
 | English conversation | Final bundle screenshot and AX: 24 chronological messages, real visible English and Chinese glyphs, `/fixture/a`, correct Working header; no send/stop/rename/terminal controls |
-| Chinese conversation / live refresh | Earlier same-source UI bundle, binary `6fc6b89c2f7b2493a1de6190d675948898df9c2df0ee9848b8b07410d0ad4e37`: visible `/fixture/中文`, 24→26 messages, new 25/26 entries and revision 1; final build afterward included only a backend scoped legacy-collision guard change |
-| Initial HTTP 503 / Retry / recovery | Earlier bundle screenshot: `Could not load conversation`, `OpenCode HTTP 503`, RETRY; Retry clicked while 503 persisted and error returned correctly. After clearing failure, polling recovered. A separate attempted click after auto-recovery had a stale AX index and is not counted as successful Retry evidence |
-| Tooling limits | An earlier coordinate click failed `noWindowsAvailable`; native Raise + keyboard filter selection recovered. A later Mac lock stopped interaction. After unlocking became possible, final bundle was relaunched and screenshots above succeeded. Mac locked again before final Ready/live-update, hide/show and disconnect/reconnect steps; those are not screenshot passes |
+| Ready / live refresh / hide-show | After user unlock, final binary's English overlay visibly showed READY, 26 messages and `/fixture/a · live revision 1` (earlier 24 / revision 0). Invoked native Hide then Raise; the restored 900×600 screenshot visibly retained messages 22–26 and readable English/Chinese glyphs |
+| Disconnect / cleanup | Final binary Settings DISCONNECT yielded visible `Not connected`; monitor screenshot showed SYSTEM STATUS 0 / NO OPENCODE SESSIONS. Two HTTP metric snapshots across subsequent UI actions both remained at 3,377 requests / active 0, confirming polling stopped while disconnected |
+| Reconnect / identity | Changed fixture to revision 2 while disconnected, explicitly re-entered the same URL and CONNECTed. AX Connecting → screenshot `Connected · 3 sessions`; monitor restored two roots with Working 1 / Waiting 1. Reopened Chinese root: screenshot showed READY, 26 messages and `/fixture/中文 · live revision 2`, not prior English-directory content or cached revision 1 |
+| Global 503 / initial error / Retry | Final binary: global fixture 503 retained both roots, marked Connecting and exposed `OpenCode HTTP 503`. Opening Chinese root showed 0 messages, `Could not load conversation`, `OpenCode HTTP 503` and RETRY in a full screenshot. Clicked Retry while 503 persisted; fresh error returned. Integration form also visibly showed HTTP 503 |
+| Global recovery | Cleared global error and advanced revision 3. Settings screenshot restored `Connected · 3 sessions`; monitor returned to Working 1 / Waiting 1 with Chinese READY. Reopened conversation screenshot showed 26 chronological messages, `/fixture/中文 · live revision 3` and no error. This repeats recovery on the final binary, not just the earlier UI bundle |
+| Tooling limits | Earlier `noWindowsAvailable` and stale AX indexes were recovered by selecting the exact QA app, Raise and fresh/full AX reads. Tiny hidden-window thumbnail captures are not used as legibility evidence; the restored full-size screenshots are. Mac locks interrupted earlier attempts; user unlock enabled all required steps above. A later lock interrupted optional compact-layout/extra child checks after required recovery evidence was complete |
 
 Images were returned inline by native Computer Use in this task, not exported as
 PNG files. AX text is identified separately; HTTP fixture state is not pixel
-evidence. In particular, setting `busy:false,fresh:true,revision:1,messages:26`
-after the final English screenshot succeeded at the fixture/data layer but the
-next screenshot was blocked by the locked Mac. Do not infer its visual result.
+evidence. The previously blocked `busy:false,fresh:true,revision:1,messages:26`
+visual check was actually completed after user unlock, as recorded above.
+Opening Settings can show healthy status before the independent monitor snapshot
+has refreshed; the monitor subsequently recovered without manual state changes.
+One click used an AX card index invalidated by that status movement; a fresh full
+tree and the successful reopen are the evidence, not the failed click.
+
+After native acceptance, the synthetic fixture's final metrics were 3,803 requests,
+active 0, peak 2 (independent discovery + conversation). The task-owned fixture
+on port 64647 and earlier isolated real server on 64648 were stopped. No user
+provider server was stopped. The QA app may remain open/offline after the later
+Mac lock; this is not a release install or persistent connection configuration.
+Post-cleanup `lsof -nP -iTCP:64647 -iTCP:64648` returned no entries (exit 1,
+the no-matches result), including a permitted system-level check.
 
 Actual installed OpenCode **1.18.20** was started on loopback port 64648 with
 fresh isolated XDG config/data/state/cache directories. Verified healthy/version,
@@ -267,23 +281,26 @@ No user prompts, real model response or paid model call was generated. Current
 nonempty conversation and error acceptance relies on the committed HTTP fixture,
 not the old document's OpenCode 1.18.29/model-response claim.
 
-## Remaining gates / verdict
+## Verdict / user decision
 
-**Not yet unconditional merge-ready:** implementation and automated/performance
-gates passed, but the Mac lock prevents completing the requested native sequence.
-After unlocking, resume only this QA bundle and fixture:
+**The local candidate is merge-ready for the agreed development-preview scope.**
+Implementation, full/targeted automated checks, reproducible boundedness/performance
+fixtures and required native/debug checks have passed. No further source blocker
+was found. This acceptance follow-up changes documentation only; implementation
+commit `0f9509e8e66c3a56646f02d79c8f3e7067543af7` and the native binary hash above
+are unchanged. Disconnect was directly verified before reconnect/outage/recovery;
+after the later Mac lock, test-server process cleanup was used, not another claim
+of a native Disconnect click.
 
-1. Observe final English root Ready and revision 1 / 26 messages; hide/show the
-   overlay and verify visible content (automated transition policy already passes).
-2. Settings → Integration → DISCONNECT: Not connected; OpenCode-only monitor
-   becomes empty. Reconnect same URL: Connecting → Connected, both directories
-   and their scoped conversations return without old data.
-3. Exercise global 503 and recovery in Settings/monitor, then disconnect cleanly;
-   fixture request activity must stop after the bounded in-flight timeout.
+**Remote PR #127 is not yet the verified candidate.** The final read-only GitHub
+check still reports OPEN / non-draft / CLEAN at `a1fe4c1`, base `d3fe23e`, with
+the September 8 CI result. User approval is required before pushing this reviewed
+candidate to `codex/opencode-provider` and updating PR evidence. Fresh remote CI
+must then pass on the new head; leave merge to the user. No push, PR mutation or
+merge was performed during this task.
 
-No further source blocker was found in this audit. These remaining observations
-must be recorded before changing this verdict; a green prior remote CI or current
-data-only fixture response is not a substitute. Then request user approval to
-push the reviewed candidate to PR #127 and update its evidence, rerun remote CI,
-and leave merge to the user. Signed distribution, notarization, release deployment
-and unsupported capabilities are explicitly not accepted or promised here.
+Limits remain explicit: benchmarks are debug loopback fixtures on a shared Mac,
+not a production latency guarantee; current real OpenCode checks do not include
+a model-generated reply. Native evidence includes full-size screenshots and AX,
+not an exported screenshot archive. Distribution signing, notarization, release
+deployment and unsupported capabilities are not accepted or promised here.

--- a/docs/opencode-preview-acceptance-2026-09-12.md
+++ b/docs/opencode-preview-acceptance-2026-09-12.md
@@ -1,0 +1,289 @@
+# OpenCode preview candidate acceptance — 2026-09-12
+
+## Revision and authority
+
+- Candidate: `codex/opencode-merge-ready-20260912`, based on
+  `a1fe4c1a98a8e56be7581e3f29790af8a7ca8105` (PR #127's five commits).
+  The commit containing this record identifies the reviewed source.
+- Fresh remote checks: main `d3fe23e56bcce587030087d342d2aba477ec2f10`;
+  [PR #127](https://github.com/minchenlee/c9watch/pull/127) still OPEN,
+  non-draft, CLEAN, head `a1fe4c1`. Its last CI check succeeded on September 8,
+  [run 34182521115](https://github.com/minchenlee/c9watch/actions/runs/34182521115).
+  That CI result does **not** cover this unpushed candidate.
+- Sole Maker: `opencode-maker-20260912`, shared task `OPENCODE-PREVIEW-127`.
+  Worktree `/private/tmp/c9watch-opencode-ready`. No delegated agents.
+- Main checkout and `/private/tmp/c9watch-messaging-ready` were not edited.
+  No messaging-worker commits were imported. No push, PR update or merge.
+
+## Review outcome and changes
+
+Reviewed current PR body/comments, all five commits and the diff against current
+main, not the historical verification paragraph. Prior providerless fallback
+and local-provider polling comments were already fixed in the PR. The remaining
+merge blockers addressed here were:
+
+1. Same OpenCode ID in different directories previously shared one local key.
+   IDs and parent references now include a URL-encoded directory while retaining
+   provider qualification. Detail/children responses are validated against that
+   identity; full CLI references can still read beyond recent discovery.
+2. Per-page limits alone did not bound a whole conversation or discovery fanout.
+   Added aggregate byte/time/page/part/session/directory limits, health checks,
+   stricter malformed-message handling and explicit errors rather than truncation.
+3. Concurrent retry/refresh/disconnect could leave unnecessary HTTP work or stale
+   data. Added a fail-fast conversation/children gate, one-entry short-lived
+   connection-scoped cache, cancellation and generation checks. Settings polling
+   is completion-driven and ignores stale completions.
+4. Synchronous native/WS discovery enrichment and subagent transcript scans could
+   occupy Tokio async workers. Added bounded blocking dispatch at those entry
+   points; subagent scan admission no longer queues unlimited waiters. Existing
+   detector/enrichment/scanner responsibilities and background poll thread remain.
+
+Other provider files in the original PR contain the required enum/default fields
+and label exhaustiveness updates, not messaging changes. This candidate changes
+no Codex/Claude messaging, widget or unrelated shared snapshot behavior. OpenCode
+send, stop, rename, terminal, permission/question and other unspecified controls
+remain unavailable; open/stop/rename capability flags are false.
+
+## Automated verification
+
+Environment: Apple M2 / Mac14,2, 16 GiB RAM, macOS 26.1 (25B78),
+Rust 1.95.0, Node 26.8.1. Commands run from the candidate worktree unless stated.
+Rust runs used these resource-saving profile settings, with unchanged optimization
+level (debug/unoptimized):
+
+```sh
+export CARGO_PROFILE_DEV_DEBUG=0 CARGO_PROFILE_TEST_DEBUG=0 CARGO_INCREMENTAL=0
+npm ci --ignore-scripts --no-audit --no-fund
+cargo test --manifest-path src-tauri/Cargo.toml --locked --quiet
+cargo test --manifest-path src-tauri/Cargo.toml --locked --no-default-features --features cli --quiet
+npm run check
+npm run build
+node --test scripts/test-ws.mjs scripts/test-hidden-transitions.mjs scripts/test-opencode-provider.mjs scripts/test-opencode-connection.mjs scripts/test-integration-settings.mjs
+node --conditions=browser --test scripts/test-conversation-selection.mjs
+node scripts/test-subagent-polling.mjs
+node scripts/test-subscription-polling.mjs
+node scripts/test-usage-preferences.mjs
+git diff --check
+```
+
+Results: dependency install passed; final default Rust **443 unit + 3 integration
+passed** (9 unit / 1 integration ignored), CLI **409 unit + 3 integration passed**
+(6 unit / 1 integration ignored), doc tests completed; Svelte
+**0 errors / 0 warnings**, frontend production build passed; Node **16 + 6 passed**;
+all three polling/preference scripts PASS; diff check clean. Explicit fixture
+benchmarks and global-service stress are ignored in normal CI and run separately
+below. Remaining normal ignored tests are pre-existing environment/slow tests,
+not silently counted as passes. Rust emits existing dead-code and CLI `cfg(mobile)`
+warnings. Expected fixture 503/stale-error messages in Node output are assertions'
+inputs, not failed tests. CI now includes the new connection polling regression.
+
+Failure coverage is executable, not based only on source inspection:
+
+| Contract/failure | Evidence |
+| --- | --- |
+| Same ID across directories | HTTP fixture → real snapshot → enrichment yields distinct keys, Working vs idle; detail/conversation reads carry the right directory; frontend parent/child grouping stays separate |
+| Provider collision / unsupported actions | Rust providerless probing/collision and rename guards; frontend identical-ID OpenCode/Claude isolation and false action capabilities |
+| Old-but-busy / retry retention, stale-idle / archived expiry | Original snapshot regression plus new replacement/deletion checks; old root visible natively while expired idle fixture is absent |
+| Detail / children / deleted session | Correct scoped parent-child responses; 404, archived detail and wrong-directory detail explicitly rejected |
+| Initial error + Retry / stale completion | Actual frontend selection state tests; serial retries, provider switch, close, late errors and reopen covered |
+| 401 / 403 / 404 / 500 / 503 and recovery | Loopback health/snapshot errors preserve metadata as Connecting, omit response-body secrets, then restore healthy snapshot |
+| Malformed JSON / schema / message | Invalid health JSON, unhealthy health, malformed message fields and non-string text rejected; existing message format tests retained |
+| Cursor repetition / unique infinite sequence | A→B→A fails after 3 requests; unique cursors stop at 128 pages; empty/oversized cursor guards in loader |
+| Page / total / count limits | Chunked >8 MiB shrinks page size; single >8 MiB rejected; 32 MiB aggregate fails on seventh 5 MiB page; server ignoring requested row count rejected; >10,000 parts rejected; 513 sessions / 33 directories rejected |
+| Timeout / concurrent disconnect | Shared 40 ms deadline against 150 ms fixture; cancelled response rejected and no next request; old generation cannot replace newer snapshot |
+| Cache / backpressure | 100 same-key hits produce only original detail+page HTTP requests; expiry reloads; cancelled connection cannot hit cache; 16-way public conversation stress below |
+
+## Performance: comparative transport loader
+
+`src-tauri/src/session/opencode_perf.rs` runs the same loader harness on PR head
+and candidate: pre-serialized loopback HTTP pages, cold client construction,
+ten uncached repeats and full response serialization. Every repeat fetches every
+page; this is **not** a warmed-result cache benchmark. Small: 24 messages / 2
+pages / 5,321 wire bytes. Large: 1,200 messages / 60 pages / 9,944,553 wire bytes,
+9,939,651 serialized output bytes. Chronological first/last entries are asserted.
+
+```sh
+cargo test --manifest-path src-tauri/Cargo.toml --locked --lib benchmark_opencode_conversation -- --ignored --nocapture --test-threads=1
+```
+
+For baseline reproduction use a separate detached worktree at `a1fe4c1`, copy
+the identical `opencode_perf.rs` next to `opencode.rs`, and add only this test
+module to the latter (no loader changes):
+
+```rust
+#[cfg(test)]
+#[path = "opencode_perf.rs"]
+mod perf;
+```
+
+The actual baseline was `/private/tmp/c9watch-opencode-perf-baseline`, with a
+test-only absolute path to that identical candidate harness. Builds shared
+dependencies sequentially, never concurrently. Copied test executables were
+then measured in order **baseline, candidate, candidate, baseline, baseline,
+candidate**, without compilation during measurement:
+
+```sh
+for bench in baseline candidate candidate baseline baseline candidate; do
+  /usr/bin/time -l "src-tauri/target/opencode-${bench}-bench" benchmark_opencode_conversation --ignored --nocapture --test-threads=1
+done
+```
+
+All times milliseconds; p95 is the maximum of ten repeat samples, not a claim
+about production population percentiles. Peak RSS includes both synthetic HTTP
+server and loader, not whole GUI app memory.
+
+| Run | Small cold / repeat median / p95 | Large cold / repeat median / p95 | Peak RSS bytes |
+| --- | --- | --- | ---: |
+| Baseline 1 | 7.156 / 1.380 / 1.701 | 223.651 / 226.602 / 240.890 | 170344448 |
+| Candidate 1 | 4.786 / 1.259 / 1.550 | 371.115 / 242.019 / 258.897 | 170983424 |
+| Candidate 2 | 2.001 / 1.028 / 1.508 | 232.826 / 236.084 / 241.614 | 170721280 |
+| Baseline 2 | 2.010 / 0.946 / 1.104 | 241.213 / 233.034 / 246.822 | 158892032 |
+| Baseline 3 | 1.769 / 1.024 / 1.745 | 223.830 / 223.493 / 234.416 | 170098688 |
+| Candidate 3 | 1.690 / 1.001 / 1.174 | 229.329 / 225.833 / 235.442 | 170426368 |
+
+Median of the three large repeat medians: baseline **226.602 ms**, candidate
+**236.084 ms** (+4.2%). Maximum RSS differs by 638,976 bytes (+0.38%). Retired
+instructions in these runs were approximately 38.59–38.64 billion baseline vs
+38.66–38.73 billion candidate. These fixtures show no sustained substantial
+loader regression, but do **not** establish a release performance SLA.
+
+Variance is not hidden: earlier baseline/candidate large medians were
+229.329/222.093 ms; a later candidate run during other machine activity measured
+309.397 ms median / 834.461 ms p95, and the first alternating candidate cold load
+was 371.115 ms. A standalone recheck measured 230.886 ms median / 259.288 ms p95,
+RSS 170344448. The machine was shared, not a controlled performance lab.
+The first sandboxed `/usr/bin/time -l` wrapper returned exit 1 because macOS
+`sysctl kern.clockrate` was denied despite a passing benchmark; subsequent
+permitted counter runs exited 0 and supplied the RSS figures above.
+
+## Production reader, scheduler and concurrency
+
+```sh
+cargo test --manifest-path src-tauri/Cargo.toml --locked --lib benchmark_opencode_reader_cache_and_refresh -- --ignored --nocapture --test-threads=1
+cargo test --manifest-path src-tauri/Cargo.toml --locked --lib benchmark_transcript_scheduler -- --ignored --nocapture --test-threads=1
+cargo test --manifest-path src-tauri/Cargo.toml --locked --lib concurrent_conversation_entry -- --ignored --nocapture --test-threads=1
+```
+
+Production-reader fixture (separate workload from comparator) includes detail
+validation, fresh server-side JSON serialization on every request, 1 ms accept
+polling, page reads, cache population/copy and output serialization. Small cold
+**7.782 ms**, refresh median **3.874 ms**, p95 **6.008 ms**, cache hit median
+**0.142 ms**. Large cold **581.132 ms**, refresh median **653.389 ms**, p95
+**766.131 ms**, cache hit median **252.292 ms**. Eleven full loads plus eleven
+cache hits used **33 / 671 HTTP requests** for small/large; each cache hit made
+**zero HTTP requests**. Large cached results still incur copying/serialization;
+this is not a claim that caching eliminates CPU cost. Both workloads complete
+well within the polling interval; polling is scheduled after completion anyway.
+
+Scheduler fixture writes **46,526,670 bytes / 20,000 synthetic transcript rows**
+and runs the real transcript parser and subagent scanner (both counts asserted
+20,000) on a single-thread Tokio runtime with a 2 ms heartbeat. Measured inline
+control: **1057.182 ms** scan, **1057.284 ms** maximum heartbeat gap (3 ticks).
+Bounded blocking dispatch: **994.194 ms** scan, **3.483 ms** maximum heartbeat
+gap (297 ticks). This demonstrates that the added dispatch boundary prevents
+the same synchronous scan from starving that async worker; it is not a claim
+about all background work in the application. A final rerun measured inline
+**1230.990 ms / 1231.735 ms** scan/gap and blocking **1205.680 ms / 3.782 ms**
+(358 ticks), confirming the scheduler boundary despite slower overall work.
+Cancellation/admission regression
+also verifies that an aborted async caller does not release its running job's
+permit and that the next scan succeeds after completion.
+
+Public conversation entry stress: **16 callers, 1 accepted, 15 immediately
+rejected, peak HTTP concurrency 1, reconnect recovery OK**. The fixture joins
+all request threads and asserts active requests return to zero. Discovery has
+its own dedicated serial thread, so discovery plus conversation can overlap
+(native fixture observed peak 2); they do not serialize unrelated providers.
+
+Resource limits are explicit: 8 MiB/page, 32 MiB/conversation, 128 pages,
+10,000 rendered parts, 400 DOM messages, one one-second cached conversation;
+snapshot 512 sessions / 32 directories / 16 MiB / 10 seconds. Requests time out
+within three seconds or the shorter remaining operation deadline. An in-flight
+request is not forcibly interrupted at the socket level by disconnect, but is
+bounded by that timeout and cannot publish or continue paging afterward.
+HTTP response ownership closes/drops body streams on every exit; idle reuse is
+limited to one socket per host / five seconds. No persistent SSE connection.
+
+## Native/debug and real-server evidence
+
+Built with `npm run build` followed by:
+
+```sh
+CARGO_PROFILE_DEV_DEBUG=0 CARGO_PROFILE_TEST_DEBUG=0 CARGO_INCREMENTAL=0 npm run tauri build -- --debug --bundles app --config scripts/opencode-qa.conf.json
+```
+
+The QA config deliberately skips the duplicate frontend build; run the preceding
+`npm run build` first. Launch the exact output, not `/Applications/c9watch.app`:
+`src-tauri/target/debug/bundle/macos/c9watch OpenCode Ready QA.app`, bundle ID
+`com.minchenlee.c9watch.opencodereadyqa`. Final production-source binary SHA-256:
+`1924e61eefe2245d8bce486e0cf01512f10e2db9e04d44a3b21ca9e0cb2ba886`.
+Later additions are test-only benchmarks and this record, not production changes.
+This bundle is development/ad-hoc signed only; notarization was explicitly skipped.
+The local root `target` symlink points to ignored `src-tauri/target` for reused
+build metadata; it and benchmark executables/logs are generated artifacts and
+are excluded from the candidate commit.
+
+Run `python3 scripts/opencode-preview-fixture.py --port 64647`. In native Settings
+→ Integration, connect `http://127.0.0.1:64647`; choose OpenCode filter. Controls:
+
+```sh
+curl -fsS -X POST http://127.0.0.1:64647/__fixture -H 'Content-Type: application/json' -d '{"messageError":503}'
+curl -fsS -X POST http://127.0.0.1:64647/__fixture -H 'Content-Type: application/json' -d '{"messageError":0,"revision":1,"messages":26}'
+curl -fsS -X POST http://127.0.0.1:64647/__fixture -H 'Content-Type: application/json' -d '{"busy":false,"fresh":true}'
+curl -fsS -X POST http://127.0.0.1:64647/__fixture -H 'Content-Type: application/json' -d '{"error":503}'
+curl -fsS -X POST http://127.0.0.1:64647/__fixture -H 'Content-Type: application/json' -d '{"error":0}'
+curl -fsS http://127.0.0.1:64647/__metrics
+```
+
+`auth:true` requires fixture-only Basic credentials `opencode:fixture`;
+`deleted:true` empties discovery; `delay` sets seconds per request.
+`fresh:false,busy:true` exercises old-but-busy retention; setting busy false with
+fresh false expires that old root. The expired idle fixture never appears.
+Every OpenCode-shaped route is read-only; only `/__fixture` changes test state.
+
+Observed with native Computer Use, not browser simulation:
+
+| Evidence | Observation and provenance |
+| --- | --- |
+| Integration | Final rebuilt bundle: visible form, aligned right inset, URL, Connecting then AX `Connected · 3 sessions`; settings apply only to this isolated app |
+| OpenCode-only / cross-directory status | Final bundle screenshots: OpenCode filter, 2 roots, Working 1 / Waiting 1; Chinese root READY, old English root WORKING; child is grouped under English root |
+| English conversation | Final bundle screenshot and AX: 24 chronological messages, real visible English and Chinese glyphs, `/fixture/a`, correct Working header; no send/stop/rename/terminal controls |
+| Chinese conversation / live refresh | Earlier same-source UI bundle, binary `6fc6b89c2f7b2493a1de6190d675948898df9c2df0ee9848b8b07410d0ad4e37`: visible `/fixture/中文`, 24→26 messages, new 25/26 entries and revision 1; final build afterward included only a backend scoped legacy-collision guard change |
+| Initial HTTP 503 / Retry / recovery | Earlier bundle screenshot: `Could not load conversation`, `OpenCode HTTP 503`, RETRY; Retry clicked while 503 persisted and error returned correctly. After clearing failure, polling recovered. A separate attempted click after auto-recovery had a stale AX index and is not counted as successful Retry evidence |
+| Tooling limits | An earlier coordinate click failed `noWindowsAvailable`; native Raise + keyboard filter selection recovered. A later Mac lock stopped interaction. After unlocking became possible, final bundle was relaunched and screenshots above succeeded. Mac locked again before final Ready/live-update, hide/show and disconnect/reconnect steps; those are not screenshot passes |
+
+Images were returned inline by native Computer Use in this task, not exported as
+PNG files. AX text is identified separately; HTTP fixture state is not pixel
+evidence. In particular, setting `busy:false,fresh:true,revision:1,messages:26`
+after the final English screenshot succeeded at the fixture/data layer but the
+next screenshot was blocked by the locked Mac. Do not infer its visual result.
+
+Actual installed OpenCode **1.18.20** was started on loopback port 64648 with
+fresh isolated XDG config/data/state/cache directories. Verified healthy/version,
+empty `/session?limit=513`, directory status `{}`, and `/doc` contracts for
+health/list/detail/children/messages (`limit`/`before`/directory). Official
+[server API documentation](https://opencode.ai/docs/server/) was also checked.
+No user prompts, real model response or paid model call was generated. Current
+nonempty conversation and error acceptance relies on the committed HTTP fixture,
+not the old document's OpenCode 1.18.29/model-response claim.
+
+## Remaining gates / verdict
+
+**Not yet unconditional merge-ready:** implementation and automated/performance
+gates passed, but the Mac lock prevents completing the requested native sequence.
+After unlocking, resume only this QA bundle and fixture:
+
+1. Observe final English root Ready and revision 1 / 26 messages; hide/show the
+   overlay and verify visible content (automated transition policy already passes).
+2. Settings → Integration → DISCONNECT: Not connected; OpenCode-only monitor
+   becomes empty. Reconnect same URL: Connecting → Connected, both directories
+   and their scoped conversations return without old data.
+3. Exercise global 503 and recovery in Settings/monitor, then disconnect cleanly;
+   fixture request activity must stop after the bounded in-flight timeout.
+
+No further source blocker was found in this audit. These remaining observations
+must be recorded before changing this verdict; a green prior remote CI or current
+data-only fixture response is not a substitute. Then request user approval to
+push the reviewed candidate to PR #127 and update its evidence, rerun remote CI,
+and leave merge to the user. Signed distribution, notarization, release deployment
+and unsupported capabilities are explicitly not accepted or promised here.

--- a/docs/opencode-preview.md
+++ b/docs/opencode-preview.md
@@ -1,0 +1,97 @@
+# OpenCode monitoring preview
+
+This preview connects to one explicitly configured OpenCode HTTP server. It
+adds session cards, the OpenCode filter/badge, parent/child grouping, and
+on-demand text/tool-result conversation reads. It does not discover running
+servers or inspect OpenCode's local databases/transcripts.
+
+## Try it
+
+1. Start a terminal session with a known port: `opencode --port 4096`.
+2. In c9watch Settings → OpenCode, enter `http://127.0.0.1:4096` and click
+   **CONNECT**. If the server requires Basic authentication, enter its username
+   (normally `opencode`) and password.
+3. Select the **OpenCode** provider filter and open a session card to read its
+   conversation.
+
+Connection settings and credentials stay in process memory until c9watch quits.
+The desktop's connection status shows authentication, HTTP, malformed-response,
+and connection errors. Disconnect clears this provider's cached sessions.
+
+Full `opencode:ses_…` CLI references are read directly, including sessions no
+longer present in the monitor's recent-session window.
+
+For startup configuration or CLI use, set `C9WATCH_OPENCODE_URL`, optionally
+`C9WATCH_OPENCODE_USERNAME` and `C9WATCH_OPENCODE_PASSWORD`, in the environment
+that launches c9watch. CLI session references use `opencode:<session-id>`.
+
+The endpoint must be the server used by the intended OpenCode client. Starting
+`opencode serve` separately starts another server; it does not attach to an
+existing TUI. Desktop/IDE endpoint discovery is not implemented.
+
+## Behavior and limits
+
+- Background HTTP snapshots refresh every two seconds after the previous
+  request finishes. Each request has a three-second timeout and an 8 MiB
+  response limit. Redirects are rejected. GUI detection reads the cache without
+  waiting on network I/O; one-shot CLI detection waits for a bounded snapshot.
+- Unarchived busy/retrying sessions and idle sessions updated within 30 minutes
+  appear in the monitor. Deleted/archived/expired sessions disappear on the next
+  successful snapshot. These are recent server sessions, not proof that a TUI
+  process is still open.
+- Status tables are fetched separately for each session directory, matching
+  OpenCode's directory-scoped status state.
+- `busy` maps to Working; `idle` (including absent entries in the sparse status
+  map) maps to WaitingForInput. `retry` and unknown statuses map to Connecting.
+- Offline sessions retain their last metadata but become Connecting with the
+  actual connection error. Recovery replaces the snapshot and clears the error.
+- This preview polls HTTP; SSE, permission/question lifecycle mapping,
+  persisted connection settings, history search, usage/cost totals, images,
+  prompt sending, opening terminals, stop, and rename are not implemented.
+  Permission waits may still show the server's busy status.
+- OpenCode sessions advertise no open/stop/rename capabilities and use PID 0.
+  Provider-scoped identity keeps them separate from Claude/Codex/Cursor/Pi.
+
+Conversation reads use `limit` / `before` pagination and `X-Next-Cursor`.
+Pages are reassembled in chronological order and tool filtering occurs per
+page. Oversized pages are retried with smaller page sizes. The 8 MiB limit
+applies to each page; a single message larger than that returns an explicit
+error. Repeated cursors and loads exceeding one minute are rejected. Initial
+conversation errors appear in the panel with a Retry action.
+
+## Native rendering
+
+Native Tauri fade/fly/scale/slide transitions complete immediately. WebKit can
+suspend its animation timeline when a window becomes hidden, even after an
+intro starts, leaving content at opacity zero while accessibility updates
+continue. The message bubble's duplicate CSS fade is removed. Browser
+transitions retain motion when visible and respect reduced motion.
+
+OpenCode uses the existing pink accent (`#FF69B4`) in badges and filter markers.
+
+## Verification
+
+Development testing used the official OpenCode 1.18.29 npm binary with isolated
+XDG directories and a loopback server. Session/status reads, a real model reply,
+and a 23-message conversation across multiple pages were checked. Synthetic
+HTTP tests cover directory-scoped status, stale/busy retention, authentication,
+HTTP errors/recovery, pagination above 8 MiB total, cursor loops, and filtering.
+Full provider-qualified CLI IDs can be read even when absent from discovery.
+
+Native QA of the development bundle exercised Working/Ready across directories,
+HTTP 503 with Retry, recovery, live conversation updates, and visible English /
+Chinese conversation content after the animation repair. The PR branch is based
+on current main and places the connection form in Settings → OpenCode, alongside
+Notifications, Usage, and About. The independent PR bundle builds and launches with current main. Its Settings
+navigation still needs visual revalidation: Computer Use repeatedly rejected
+clicks as an app-change conflict after refreshing the accessibility state.
+It contains no temporary render diagnostics or messaging bridge.
+
+Automated checks include provider isolation, initial-error retry and stale
+responses, bounded live conversation windows, and native/browser transition
+policy. This is a development preview, not a signed release. Permission/question
+mapping and other unsupported capabilities listed above remain out of scope.
+
+On the isolated PR branch, default Rust tests passed (434 passed, 6 ignored),
+including doc-test completion; CLI-only tests also passed. Frontend check/build
+and provider, conversation, transition, WebSocket, and existing polling checks passed.

--- a/docs/opencode-preview.md
+++ b/docs/opencode-preview.md
@@ -19,7 +19,11 @@ The desktop's connection status shows authentication, HTTP, malformed-response,
 and connection errors. Disconnect clears this provider's cached sessions.
 
 Full `opencode:ses_…` CLI references are read directly, including sessions no
-longer present in the monitor's recent-session window.
+longer present in the monitor's recent-session window. Prefer the complete
+directory-qualified identity from discovery, for example
+`opencode:ses_…?directory=%2Fmy%2Fproject` (quote this argument in a shell).
+The local identity includes the directory; the HTTP path uses the original ID
+and sends `directory` as a query parameter. Known ambiguous bare IDs are rejected.
 
 For startup configuration or CLI use, set `C9WATCH_OPENCODE_URL`, optionally
 `C9WATCH_OPENCODE_USERNAME` and `C9WATCH_OPENCODE_PASSWORD`, in the environment
@@ -32,9 +36,12 @@ existing TUI. Desktop/IDE endpoint discovery is not implemented.
 ## Behavior and limits
 
 - Background HTTP snapshots refresh every two seconds after the previous
-  request finishes. Each request has a three-second timeout and an 8 MiB
-  response limit. Redirects are rejected. GUI detection reads the cache without
-  waiting on network I/O; one-shot CLI detection waits for a bounded snapshot.
+  operation finishes on a dedicated thread. Each request has a three-second
+  timeout and an 8 MiB response limit. The complete snapshot has a ten-second /
+  16 MiB budget, at most 512 sessions and 32 directories. Overflow is an error,
+  not an apparently complete partial list. Redirects are rejected. GUI detection
+  reads the cache without waiting on network I/O; one-shot CLI detection waits
+  for a bounded snapshot. Health is checked before discovery/status reads.
 - Unarchived busy/retrying sessions and idle sessions updated within 30 minutes
   appear in the monitor. Deleted/archived/expired sessions disappear on the next
   successful snapshot. These are recent server sessions, not proof that a TUI
@@ -50,18 +57,42 @@ existing TUI. Desktop/IDE endpoint discovery is not implemented.
   prompt sending, opening terminals, stop, and rename are not implemented.
   Permission waits may still show the server's busy status.
 - OpenCode sessions advertise no open/stop/rename capabilities and use PID 0.
-  Provider-scoped identity keeps them separate from Claude/Codex/Cursor/Pi.
+  Provider- and directory-qualified identity keeps them separate from each
+  other and from Claude/Codex/Cursor/Pi. Detail reads validate the returned ID,
+  directory and archive state. On-demand read-only children requests validate
+  parent/directory and share the conversation admission gate; ordinary discovery
+  groups the list's parent IDs without an extra request for each parent.
 
 Conversation reads use `limit` / `before` pagination and `X-Next-Cursor`.
 Pages are reassembled in chronological order and tool filtering occurs per
 page. Oversized pages are retried with smaller page sizes. The 8 MiB limit
 applies to each page; a single message larger than that returns an explicit
-error. Repeated cursors and loads exceeding one minute are rejected. Initial
+error. Each load additionally has a 32 MiB total wire budget (including detail
+and oversized retries), 128-page bound, 10,000 rendered-part bound and a
+one-minute deadline. Ignored page limits, malformed messages, repeated/empty
+cursors and cursors longer than 4096 bytes are rejected. Initial
 conversation errors appear in the panel with a Retry action. Only OpenCode
 previews refresh on a two-second timer; local providers load on selection or
 manual retry without periodically reparsing unchanged transcripts. Legacy
 ID-only conversation lookup includes OpenCode and still rejects cross-provider
-ID collisions.
+ID collisions. The DOM window is capped at 400 messages (200-message batches).
+
+One conversation/children HTTP operation is admitted at a time; overlapping
+loads fail immediately with a retryable error instead of waiting in a queue.
+The last successful conversation alone is cached for one second, scoped by
+connection, session and tool visibility. Errors do not enter the cache.
+Disconnect/reconnect invalidates cache generations and cancels old operations;
+an already-running HTTP request can take up to its remaining three-second
+timeout to close, but cannot publish stale results or start another page.
+Responses are dropped on success/error/cancellation; each client retains at
+most one idle socket per host for five seconds. No SSE/socket subscription is
+opened. Settings status polling and preview polling each await completion
+before scheduling another poll.
+
+Synchronous discovery/enrichment, subagent scans and subagent transcript reads
+run in the blocking pool behind separate one-job, fail-fast admission gates.
+Permits stay with the job even if its async caller is cancelled. This preserves
+the existing scanner ownership and keeps disk/JSON work off Tokio async workers.
 
 ## Native rendering
 
@@ -75,27 +106,11 @@ OpenCode uses the existing pink accent (`#FF69B4`) in badges and filter markers.
 
 ## Verification
 
-Development testing used the official OpenCode 1.18.29 npm binary with isolated
-XDG directories and a loopback server. Session/status reads, a real model reply,
-and a 23-message conversation across multiple pages were checked. Synthetic
-HTTP tests cover directory-scoped status, stale/busy retention, authentication,
-HTTP errors/recovery, pagination above 8 MiB total, cursor loops, and filtering.
-Full provider-qualified CLI IDs can be read even when absent from discovery.
-
-Native QA of the development bundle exercised Working/Ready across directories,
-HTTP 503 with Retry, recovery, live conversation updates, and visible English /
-Chinese conversation content after the animation repair. The PR branch is based
-on current main and places provider integrations in Settings → Integration:
-Claude Code, Codex, Cursor, and Pi use local automatic detection, while OpenCode
-keeps its explicit HTTP connection form. Computer Use verified the renamed
-navigation item and the rendered Integration page in the independent PR bundle.
-It contains no temporary render diagnostics or messaging bridge.
-
-Automated checks include provider isolation, initial-error retry and stale
-responses, bounded live conversation windows, and native/browser transition
-policy. This is a development preview, not a signed release. Permission/question
-mapping and other unsupported capabilities listed above remain out of scope.
-
-On the isolated PR branch, default Rust tests passed (434 passed, 6 ignored),
-including doc-test completion; CLI-only tests also passed. Frontend check/build
-and provider, conversation, transition, WebSocket, and existing polling checks passed.
+See [the dated candidate acceptance record](opencode-preview-acceptance-2026-09-12.md)
+for exact revisions, commands, measured performance, observed native rendering
+and remaining gates. Historical PR text is not current acceptance evidence.
+Current compatibility checks used an isolated OpenCode **1.18.20** server for
+health, empty discovery, status and `/doc` schema reads. No real model request
+was made during this audit; nonempty conversations and failure modes use the
+committed loopback fixture. This is a development preview, not a distribution-
+signed, notarized or deployed release.

--- a/docs/opencode-preview.md
+++ b/docs/opencode-preview.md
@@ -57,7 +57,11 @@ Pages are reassembled in chronological order and tool filtering occurs per
 page. Oversized pages are retried with smaller page sizes. The 8 MiB limit
 applies to each page; a single message larger than that returns an explicit
 error. Repeated cursors and loads exceeding one minute are rejected. Initial
-conversation errors appear in the panel with a Retry action.
+conversation errors appear in the panel with a Retry action. Only OpenCode
+previews refresh on a two-second timer; local providers load on selection or
+manual retry without periodically reparsing unchanged transcripts. Legacy
+ID-only conversation lookup includes OpenCode and still rejects cross-provider
+ID collisions.
 
 ## Native rendering
 

--- a/docs/opencode-preview.md
+++ b/docs/opencode-preview.md
@@ -8,7 +8,7 @@ servers or inspect OpenCode's local databases/transcripts.
 ## Try it
 
 1. Start a terminal session with a known port: `opencode --port 4096`.
-2. In c9watch Settings → OpenCode, enter `http://127.0.0.1:4096` and click
+2. In c9watch Settings → Integration → OpenCode, enter `http://127.0.0.1:4096` and click
    **CONNECT**. If the server requires Basic authentication, enter its username
    (normally `opencode`) and password.
 3. Select the **OpenCode** provider filter and open a session card to read its
@@ -85,10 +85,10 @@ Full provider-qualified CLI IDs can be read even when absent from discovery.
 Native QA of the development bundle exercised Working/Ready across directories,
 HTTP 503 with Retry, recovery, live conversation updates, and visible English /
 Chinese conversation content after the animation repair. The PR branch is based
-on current main and places the connection form in Settings → OpenCode, alongside
-Notifications, Usage, and About. The independent PR bundle builds and launches with current main. Its Settings
-navigation still needs visual revalidation: Computer Use repeatedly rejected
-clicks as an app-change conflict after refreshing the accessibility state.
+on current main and places provider integrations in Settings → Integration:
+Claude Code, Codex, Cursor, and Pi use local automatic detection, while OpenCode
+keeps its explicit HTTP connection form. Computer Use verified the renamed
+navigation item and the rendered Integration page in the independent PR bundle.
 It contains no temporary render diagnostics or messaging bridge.
 
 Automated checks include provider isolation, initial-error retry and stale

--- a/scripts/opencode-preview-fixture.py
+++ b/scripts/opencode-preview-fixture.py
@@ -1,0 +1,151 @@
+#!/usr/bin/env python3
+"""Local read-only OpenCode fixture for repeatable native QA (no real model/API).
+
+Run: python3 scripts/opencode-preview-fixture.py --port 64647
+Control: curl -X POST http://127.0.0.1:64647/__fixture -H 'Content-Type: application/json'
+         -d '{"messageError":503}'
+Ready without expiring the old root: {"busy":false,"fresh":true}
+Reset errors / update text: {"messageError":0,"revision":1}
+Only /__fixture accepts writes; every OpenCode-shaped endpoint is GET-only.
+"""
+import argparse
+import base64
+import json
+import threading
+import time
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from urllib.parse import parse_qs, urlparse
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--port", type=int, default=64647)
+    args = parser.parse_args()
+    state = {"error": 0, "messageError": 0, "revision": 0, "busy": True,
+             "deleted": False, "delay": 0, "messages": 24, "auth": False, "fresh": False}
+    metrics = {"requests": 0, "active": 0, "peak": 0, "paths": {}}
+    lock = threading.Lock()
+
+    def sessions():
+        def row(sid, directory, title, parent=None, updated=None):
+            return {"id": sid, "directory": directory, "title": title, "parentID": parent,
+                    "time": {"created": 1000, "updated": int(time.time() * 1000) if updated is None else updated}}
+        if state["deleted"]:
+            return []
+        return [row("ses_root", "/fixture/a", "OpenCode English preview", updated=None if state["fresh"] else 0),
+                row("ses_root", "/fixture/中文", "OpenCode 中文預覽"),
+                row("ses_child", "/fixture/a", "Read-only child", "ses_root"),
+                row("ses_expired", "/fixture/a", "Expired idle (must not appear)", updated=0)]
+
+    class Handler(BaseHTTPRequestHandler):
+        protocol_version = "HTTP/1.1"
+
+        def log_message(self, *_args):
+            pass
+
+        def reply(self, value, code=200, headers=None):
+            body = json.dumps(value, ensure_ascii=False).encode()
+            self.send_response(code)
+            self.send_header("Content-Type", "application/json")
+            self.send_header("Content-Length", str(len(body)))
+            for key, value in (headers or {}).items():
+                self.send_header(key, value)
+            self.end_headers()
+            try:
+                self.wfile.write(body)
+            except (BrokenPipeError, ConnectionResetError):
+                pass
+
+        def do_POST(self):
+            if self.path != "/__fixture":
+                self.reply({"error": "read-only fixture"}, 405)
+                return
+            if int(self.headers.get("Content-Length", 0)) > 4096:
+                self.reply({"error": "control too large"}, 413)
+                return
+            update = json.loads(self.rfile.read(int(self.headers.get("Content-Length", 0))))
+            with lock:
+                for key, value in update.items():
+                    if key in state:
+                        state[key] = value
+                result = dict(state)
+            self.reply(result)
+
+        def do_GET(self):
+            parsed = urlparse(self.path)
+            query = parse_qs(parsed.query)
+            path = parsed.path
+            if path == "/__metrics":
+                with lock:
+                    result = {**metrics, "state": dict(state)}
+                self.reply(result)
+                return
+            with lock:
+                metrics["requests"] += 1
+                metrics["active"] += 1
+                metrics["peak"] = max(metrics["peak"], metrics["active"])
+                metrics["paths"][path] = metrics["paths"].get(path, 0) + 1
+                current = dict(state)
+            try:
+                time.sleep(current["delay"])
+                if current["auth"] and self.headers.get("Authorization") != "Basic " + base64.b64encode(b"opencode:fixture").decode():
+                    self.reply({"error": "fixture authentication required"}, 401)
+                    return
+                if current["error"]:
+                    self.reply({"error": "fixture outage"}, current["error"])
+                    return
+                if path == "/global/health":
+                    self.reply({"healthy": True, "version": "fixture-2026-09-12"})
+                    return
+                if path == "/session":
+                    self.reply(sessions())
+                    return
+                directory = query.get("directory", ["/fixture/a"])[0]
+                if path == "/session/status":
+                    self.reply({"ses_root": {"type": "busy"}} if current["busy"] and directory == "/fixture/a" else {})
+                    return
+                segments = path.strip("/").split("/")
+                if len(segments) < 2 or segments[0] != "session":
+                    self.reply({"error": "unknown fixture route"}, 404)
+                    return
+                sid = segments[1]
+                detail = next((s for s in sessions() if s["id"] == sid and s["directory"] == directory), None)
+                if not detail:
+                    self.reply({"error": "not found"}, 404)
+                    return
+                if len(segments) == 2:
+                    self.reply(detail)
+                elif segments[2] == "children":
+                    self.reply([s for s in sessions() if s["directory"] == directory and s["parentID"] == sid])
+                elif segments[2] == "message":
+                    if current["messageError"]:
+                        self.reply({"error": "fixture conversation outage"}, current["messageError"])
+                        return
+                    count = current["messages"]
+                    before = min(count, int(query.get("before", [str(count)])[0]))
+                    limit = int(query.get("limit", ["20"])[0])
+                    start = max(0, before - limit)
+                    rows = [{"info": {"id": f"msg_{i}", "role": "user" if i % 2 == 0 else "assistant",
+                                      "time": {"created": 1000 + i}},
+                             "parts": [{"type": "text", "text": f"{i + 1}. English preview / 中文內容 · {directory} · live revision {current['revision']}"}]}
+                            for i in range(start, before)]
+                    self.reply(rows, headers={"X-Next-Cursor": str(start)} if start else None)
+                else:
+                    self.reply({"error": "unsupported"}, 404)
+            finally:
+                with lock:
+                    metrics["active"] -= 1
+
+    server = ThreadingHTTPServer(("127.0.0.1", args.port), Handler)
+    server.daemon_threads = True
+    print(json.dumps({"url": f"http://127.0.0.1:{server.server_port}", "fixture": True}), flush=True)
+    try:
+        server.serve_forever()
+    except KeyboardInterrupt:
+        pass
+    finally:
+        server.server_close()
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/opencode-qa.conf.json
+++ b/scripts/opencode-qa.conf.json
@@ -1,0 +1,6 @@
+{
+  "productName": "c9watch OpenCode Ready QA",
+  "identifier": "com.minchenlee.c9watch.opencodereadyqa",
+  "build": {"beforeBuildCommand": ""},
+  "bundle": {"createUpdaterArtifacts": false}
+}

--- a/scripts/test-conversation-selection.mjs
+++ b/scripts/test-conversation-selection.mjs
@@ -12,9 +12,9 @@ const end = page.indexOf('\n\tfunction handleExpand', start);
 const loader = page.slice(start, end);
 const source = `
 import { untrack } from 'svelte';
-export function harness() {
- let sessions = $state([{id:'same',provider:'codex'}]);
- let expandedId = $state('codex:same');
+export function harness(initialProvider = 'codex') {
+ let sessions = $state([{id:'same',provider:initialProvider}]);
+ let expandedId = $state(initialProvider + ':same');
  const sessionKeyOf = s => s.provider + ':' + s.id;
  const providerSessionKey = (provider,id) => provider + ':' + id;
  const providerOf = s => s.provider;
@@ -41,14 +41,14 @@ const { harness } = await import('data:text/javascript;base64,' + Buffer.from(co
 const settle = async () => { await Promise.resolve(); await Promise.resolve(); flushSync(); };
 
 test('initial failure is visible, retry succeeds, and stale errors are ignored', async () => {
- const h=harness();
+ const h=harness('opencode');
  try {
   flushSync(); h.requests[0].reject(new Error('OpenCode HTTP 503')); await settle();
   assert.match(h.error(), /503/); assert.equal(h.value(),null);
   h.retry(); flushSync(); assert.equal(h.error(),null); assert.equal(h.requests.length,2);
-  const response={sessionId:'same',provider:'codex',messages:[{content:'recovered'}]};
+  const response={sessionId:'same',provider:'opencode',messages:[{content:'recovered'}]};
   h.requests[1].resolve(response); await settle(); assert.equal(h.value(),response);
-  h.refresh(); h.select('opencode'); flushSync();
+  h.refresh(); h.select('codex'); flushSync();
   h.requests[2].reject(new Error('stale error')); await settle(); assert.equal(h.error(),null);
  } finally {h.dispose();}
 });
@@ -79,13 +79,13 @@ test('provider switch rejects stale replies and reopening loads again', async ()
 });
 
  test('open preview refreshes serially and discards a response after close', async () => {
- const h=harness();
+ const h=harness('opencode');
  try {
   flushSync(); h.refresh(); assert.equal(h.requests.length,1);
-  h.requests[0].resolve({sessionId:'same',provider:'codex',messages:[{content:'old'}]});await settle();
+  h.requests[0].resolve({sessionId:'same',provider:'opencode',messages:[{content:'old'}]});await settle();
   h.refresh();assert.equal(h.requests.length,2);
   h.refresh();assert.equal(h.requests.length,2);
-  const updated={sessionId:'same',provider:'codex',messages:[{content:'old'},{content:'reply'}]};
+  const updated={sessionId:'same',provider:'opencode',messages:[{content:'old'},{content:'reply'}]};
   h.requests[1].resolve(updated);await settle();assert.equal(h.value(),updated);
   h.refresh();assert.equal(h.requests.length,3);
   h.close();flushSync();h.requests[2].resolve(updated);await settle();
@@ -102,4 +102,22 @@ test('following new replies advances the visible tail without unbounded renderin
  const messages=Array.from({length:3},(_,i)=>({content:String(i)}));
  sw.followLatest(3);assert.equal(sw.sliceMessages(messages).at(-1).content,'2');
  sw.followLatest(1000);assert.equal(sw.endIndex,1000);assert.ok(sw.endIndex-sw.startIndex<=MAX_VISIBLE);
+});
+
+
+test('local providers load once and allow manual retry without scheduling full reparses', async () => {
+ for (const provider of ['claudeCode', 'codex', 'cursor', 'pi']) {
+  const h = harness(provider);
+  try {
+   flushSync();
+   h.requests[0].reject(new Error('temporary read failure')); await settle();
+   h.refresh(); assert.equal(h.requests.length, 1, provider);
+   h.retry(); flushSync(); assert.equal(h.requests.length, 2, provider);
+   const response = {sessionId:'same', provider, messages:[{content:'loaded'}]};
+   h.requests[1].resolve(response); await settle();
+   for (let i = 0; i < 3; i++) { h.poll(); flushSync(); h.refresh(); }
+   assert.equal(h.requests.length, 2, provider);
+   assert.equal(h.value(), response);
+  } finally { h.dispose(); }
+ }
 });

--- a/scripts/test-conversation-selection.mjs
+++ b/scripts/test-conversation-selection.mjs
@@ -3,6 +3,7 @@ import { readFileSync } from 'node:fs';
 import { test } from 'node:test';
 import { compileModule } from 'svelte/compiler';
 import { flushSync } from 'svelte';
+import ts from 'typescript';
 
 // Execute the actual page's reactive loader with deferred backend responses.
 const page = readFileSync(new URL('../src/routes/(app)/+page.svelte', import.meta.url), 'utf8');
@@ -22,18 +23,35 @@ export function harness() {
  const currentConversation = {set(v) {value = v;}};
  const toolsLoadedFor = {value:null,set(v) {this.value=v;}};
  const get = s => s.value;
+ const timers = new Map(); let timerId = 0;
+ const setTimeout = fn => {timers.set(++timerId,fn);return timerId;};
+ const clearTimeout = id => timers.delete(id);
  const requests = [];
- const getConversation = (id,provider) => new Promise(resolve => requests.push({id,provider,resolve}));
+ const getConversation = (id,provider) => new Promise((resolve,reject) => requests.push({id,provider,resolve,reject}));
  const withConversationLoader = (_id,_provider,_kind,task) => task();
+ ${loader.slice(0, loader.indexOf("\t$effect(() => {"))}
  const dispose = $effect.root(() => {
- ${loader}
+ ${loader.slice(loader.indexOf("\t$effect(() => {"))}
  });
- return {requests,dispose,value:()=>value,poll:()=>{sessions=sessions.map(s=>({...s}));},select(provider){sessions=[{id:'same',provider}];expandedId=provider+':same';},close(){expandedId=null;}};
+ return {requests,dispose,error:()=>conversationError,retry:()=>retryConversation(),refresh(){const work=[...timers.values()];timers.clear();work.forEach(fn=>fn());},value:()=>value,poll:()=>{sessions=sessions.map(s=>({...s}));},select(provider){sessions=[{id:'same',provider}];expandedId=provider+':same';},close(){expandedId=null;}};
 }`;
-let code = compileModule(source, { filename: 'conversation-selection.svelte.js', generate: 'client' }).js.code;
+let code = compileModule(ts.transpileModule(source, {compilerOptions:{target:ts.ScriptTarget.ES2022,module:ts.ModuleKind.ES2022}}).outputText, { filename: 'conversation-selection.svelte.js', generate: 'client' }).js.code;
 code = code.replace(/from '([^']+)'/g, (_, spec) => `from '${import.meta.resolve(spec)}'`);
 const { harness } = await import('data:text/javascript;base64,' + Buffer.from(code).toString('base64'));
 const settle = async () => { await Promise.resolve(); await Promise.resolve(); flushSync(); };
+
+test('initial failure is visible, retry succeeds, and stale errors are ignored', async () => {
+ const h=harness();
+ try {
+  flushSync(); h.requests[0].reject(new Error('OpenCode HTTP 503')); await settle();
+  assert.match(h.error(), /503/); assert.equal(h.value(),null);
+  h.retry(); flushSync(); assert.equal(h.error(),null); assert.equal(h.requests.length,2);
+  const response={sessionId:'same',provider:'codex',messages:[{content:'recovered'}]};
+  h.requests[1].resolve(response); await settle(); assert.equal(h.value(),response);
+  h.refresh(); h.select('opencode'); flushSync();
+  h.requests[2].reject(new Error('stale error')); await settle(); assert.equal(h.error(),null);
+ } finally {h.dispose();}
+});
 
 test('poll updates neither restart an in-flight load nor erase loaded messages', async () => {
  const h=harness();
@@ -58,4 +76,30 @@ test('provider switch rejects stale replies and reopening loads again', async ()
   h.close();flushSync();assert.equal(h.value(),null);
   h.select('cursor');flushSync();assert.equal(h.requests.length,3);
  } finally {h.dispose();}
+});
+
+ test('open preview refreshes serially and discards a response after close', async () => {
+ const h=harness();
+ try {
+  flushSync(); h.refresh(); assert.equal(h.requests.length,1);
+  h.requests[0].resolve({sessionId:'same',provider:'codex',messages:[{content:'old'}]});await settle();
+  h.refresh();assert.equal(h.requests.length,2);
+  h.refresh();assert.equal(h.requests.length,2);
+  const updated={sessionId:'same',provider:'codex',messages:[{content:'old'},{content:'reply'}]};
+  h.requests[1].resolve(updated);await settle();assert.equal(h.value(),updated);
+  h.refresh();assert.equal(h.requests.length,3);
+  h.close();flushSync();h.requests[2].resolve(updated);await settle();
+  assert.equal(h.value(),null);h.refresh();assert.equal(h.requests.length,3);
+ } finally {h.dispose();}
+});
+
+const slidingSource = readFileSync(new URL('../src/lib/slidingWindow.svelte.ts', import.meta.url), 'utf8');
+let slidingCode = compileModule(ts.transpileModule(slidingSource, {compilerOptions:{target:ts.ScriptTarget.ES2022,module:ts.ModuleKind.ES2022}}).outputText, {filename:'sliding-window.svelte.js',generate:'client'}).js.code;
+slidingCode = slidingCode.replace(/from '([^']+)'/g, (_, spec) => `from '${import.meta.resolve(spec)}'`);
+const {createSlidingWindow, MAX_VISIBLE} = await import('data:text/javascript;base64,'+Buffer.from(slidingCode).toString('base64'));
+test('following new replies advances the visible tail without unbounded rendering', () => {
+ const sw=createSlidingWindow();sw.reset(2);
+ const messages=Array.from({length:3},(_,i)=>({content:String(i)}));
+ sw.followLatest(3);assert.equal(sw.sliceMessages(messages).at(-1).content,'2');
+ sw.followLatest(1000);assert.equal(sw.endIndex,1000);assert.ok(sw.endIndex-sw.startIndex<=MAX_VISIBLE);
 });

--- a/scripts/test-hidden-transitions.mjs
+++ b/scripts/test-hidden-transitions.mjs
@@ -1,0 +1,57 @@
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { test } from 'node:test';
+import ts from 'typescript';
+
+const source = readFileSync(new URL('../src/lib/transitions.ts', import.meta.url), 'utf8');
+const wsCode = ts.transpileModule(readFileSync(new URL('../src/lib/ws.ts', import.meta.url), 'utf8'), { compilerOptions: { target: ts.ScriptTarget.ES2022, module: ts.ModuleKind.ES2022 } }).outputText;
+const wsUrl = 'data:text/javascript;base64,' + Buffer.from(wsCode).toString('base64');
+const code = ts.transpileModule(source, {
+  compilerOptions: { target: ts.ScriptTarget.ES2022, module: ts.ModuleKind.ES2022 }
+}).outputText.replace("'./ws'", JSON.stringify(wsUrl)).replaceAll("'svelte/transition'", JSON.stringify(import.meta.resolve('svelte/transition')))
+  .replaceAll("'svelte/easing'", JSON.stringify(import.meta.resolve('svelte/easing')));
+const transitions = await import('data:text/javascript;base64,' + Buffer.from(code).toString('base64'));
+
+test('hidden intros and outros bypass delayed keyframes, including explicit delays', () => {
+  const node = { ownerDocument: { visibilityState: 'hidden' } };
+  for (const name of ['fade', 'fadeIn', 'flyIn', 'flyInX', 'scale', 'slide']) {
+    const config = transitions[name](node, { duration: 400, delay: 800, index: 10 });
+    assert.equal(config.duration, 0, name);
+    assert.equal(config.delay, 0, name);
+    assert.equal(config.css, undefined, name);
+  }
+});
+
+test('visible transitions retain motion and reevaluate visibility on every invocation', () => {
+  globalThis.getComputedStyle = () => ({ opacity: '1', transform: 'none' });
+  const node = { ownerDocument: { visibilityState: 'visible' } };
+  assert.equal(transitions.fadeIn(node).duration, 320);
+  assert.equal(transitions.flyIn(node, { index: 2 }).delay, 120);
+  node.ownerDocument.visibilityState = 'hidden';
+  assert.equal(transitions.fadeIn(node).duration, 0);
+  node.ownerDocument.visibilityState = 'visible';
+  assert.equal(transitions.fadeIn(node).duration, 320);
+  delete globalThis.getComputedStyle;
+});
+
+test('reduced motion also bypasses supplied delays', () => {
+  globalThis.window = { matchMedia: () => ({ matches: true }) };
+  try {
+    assert.deepEqual(transitions.fade({ ownerDocument: { visibilityState: 'visible' } }, { delay: 500 }), { duration: 0, delay: 0 });
+  } finally { delete globalThis.window; }
+});
+
+
+test('native transitions never install a first frame that can freeze when hidden mid-intro', () => {
+  globalThis.window = { __TAURI_INTERNALS__: { invoke() {} } };
+  try {
+    for (const name of ['fade', 'fadeIn', 'flyIn', 'flyInX', 'scale', 'slide']) {
+      assert.deepEqual(transitions[name]({ ownerDocument: { visibilityState: 'visible' } }, { duration: 500, delay: 300 }), { duration: 0, delay: 0 });
+    }
+  } finally { delete globalThis.window; }
+});
+
+test('conversation bubbles do not add a second opacity animation outside the safe transition', () => {
+  const bubble = readFileSync(new URL('../src/lib/components/MessageBubble.svelte', import.meta.url), 'utf8');
+  assert.doesNotMatch(bubble, /animation\s*:\s*fade-in/);
+});

--- a/scripts/test-integration-settings.mjs
+++ b/scripts/test-integration-settings.mjs
@@ -1,0 +1,22 @@
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { test } from 'node:test';
+
+const settings = readFileSync(new URL('../src/lib/components/SettingsTab.svelte', import.meta.url), 'utf8');
+const integration = readFileSync(new URL('../src/lib/components/IntegrationSettings.svelte', import.meta.url), 'utf8');
+
+test('Settings exposes a shared Integration section instead of an OpenCode section', () => {
+  assert.match(settings, /IntegrationSettings/);
+  assert.match(settings, /activeSection === 'integration'/);
+  assert.doesNotMatch(settings, /activeSection === 'opencode'/);
+  assert.match(settings, />Integration<\/button>/);
+  assert.doesNotMatch(settings, />OpenCode<\/button>/);
+});
+
+test('Integration section groups local providers and the configurable OpenCode connection', () => {
+  for (const provider of ['Claude Code', 'Codex', 'Cursor', 'Pi']) assert.match(integration, new RegExp(provider));
+  assert.match(integration, /Local integrations/);
+  assert.match(integration, /Automatic detection/);
+  assert.match(integration, /<OpenCodeConnection \/>/);
+  assert.match(integration, /Remote integrations/);
+});

--- a/scripts/test-integration-settings.mjs
+++ b/scripts/test-integration-settings.mjs
@@ -22,8 +22,8 @@ test('Integration section groups local providers and the configurable OpenCode c
   assert.match(integration, /Remote integrations/);
 });
 
-test('Settings content uses the available width without right padding', () => {
+test('Settings content uses the available width and aligns with the tab bar', () => {
   assert.match(appPage, /<main class="grid-container history-main settings-main"/);
-  assert.match(appPage, /\.history-main\.settings-main\s*\{\s*padding-right:\s*0;/);
+  assert.match(appPage, /\.history-main\.settings-main\s*\{\s*padding-right:\s*var\(--space-md\);/);
   assert.match(settings, /\.settings-body \{[^}]*max-width:\s*none;[^}]*padding:\s*0 0 var\(--space-2xl\) var\(--space-lg\)/s);
 });

--- a/scripts/test-integration-settings.mjs
+++ b/scripts/test-integration-settings.mjs
@@ -4,6 +4,7 @@ import { test } from 'node:test';
 
 const settings = readFileSync(new URL('../src/lib/components/SettingsTab.svelte', import.meta.url), 'utf8');
 const integration = readFileSync(new URL('../src/lib/components/IntegrationSettings.svelte', import.meta.url), 'utf8');
+const appPage = readFileSync(new URL('../src/routes/(app)/+page.svelte', import.meta.url), 'utf8');
 
 test('Settings exposes a shared Integration section instead of an OpenCode section', () => {
   assert.match(settings, /IntegrationSettings/);
@@ -19,4 +20,10 @@ test('Integration section groups local providers and the configurable OpenCode c
   assert.match(integration, /Automatic detection/);
   assert.match(integration, /<OpenCodeConnection \/>/);
   assert.match(integration, /Remote integrations/);
+});
+
+test('Settings content uses the available width without right padding', () => {
+  assert.match(appPage, /<main class="grid-container history-main settings-main"/);
+  assert.match(appPage, /\.history-main\.settings-main\s*\{\s*padding-right:\s*0;/);
+  assert.match(settings, /\.settings-body \{[^}]*max-width:\s*none;[^}]*padding:\s*0 0 var\(--space-2xl\) var\(--space-lg\)/s);
 });

--- a/scripts/test-opencode-connection.mjs
+++ b/scripts/test-opencode-connection.mjs
@@ -1,0 +1,56 @@
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import vm from 'node:vm';
+import { test } from 'node:test';
+import ts from 'typescript';
+
+function harness() {
+  const requests = [], timers = new Map();
+  let mount, timerId = 0;
+  const exports = {};
+  const source = readFileSync(new URL('../src/lib/components/OpenCodeConnection.svelte', import.meta.url), 'utf8').split('<script lang="ts">')[1].split('</script>')[0];
+  const code = ts.transpileModule(source + '\nexports.connect=connect; exports.state=()=>({status,busy,error});', {
+    compilerOptions: { target: ts.ScriptTarget.ES2022, module: ts.ModuleKind.CommonJS }
+  }).outputText;
+  vm.runInNewContext(code, {
+    exports, $state: value => value,
+    require(name) {
+      if (name === 'svelte') return { onMount(fn) { mount = fn; } };
+      if (name === '@tauri-apps/api/core') return { invoke: (command, args) => new Promise((resolve, reject) => requests.push({ command, args, resolve, reject })) };
+      throw Error(name);
+    },
+    setTimeout(fn) { timers.set(++timerId, fn); return timerId; },
+    clearTimeout(id) { timers.delete(id); }
+  });
+  const dispose = mount();
+  return { ...exports, requests, dispose, timers, tick() { const callbacks = [...timers.values()]; timers.clear(); callbacks.forEach(fn => fn()); } };
+}
+const settle = async () => { await Promise.resolve(); await Promise.resolve(); };
+
+test('connection status polling remains serial and ignores completion after disposal', async () => {
+  const h = harness();
+  for (let i = 0; i < 100; i++) h.tick();
+  assert.equal(h.requests.length, 1);
+  h.requests[0].resolve({ url: '', connected: false }); await settle();
+  h.tick(); assert.equal(h.requests.length, 2);
+  h.dispose();
+  h.requests[1].resolve({ url: 'http://old/', connected: true }); await settle();
+  assert.equal(h.state().status.connected, false);
+  assert.equal(h.timers.size, 0);
+});
+
+test('disconnect invalidates an older status request and coalesces repeated clicks', async () => {
+  const h = harness();
+  try {
+    const action = h.connect(true);
+    h.connect(true);
+    assert.equal(h.requests.length, 2);
+    assert.equal(h.requests[1].args.url, '');
+    h.requests[1].resolve(); await settle();
+    assert.equal(h.requests.length, 3);
+    h.requests[2].resolve({ url: '', connected: false }); await action;
+    h.requests[0].resolve({ url: 'http://old/', connected: true }); await settle();
+    assert.equal(h.state().status.connected, false);
+    assert.equal(h.state().busy, false);
+  } finally { h.dispose(); }
+});

--- a/scripts/test-opencode-provider.mjs
+++ b/scripts/test-opencode-provider.mjs
@@ -1,0 +1,32 @@
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { test } from 'node:test';
+import ts from 'typescript';
+
+const code = ts.transpileModule(readFileSync(new URL('../src/lib/provider.ts', import.meta.url), 'utf8'), {
+  compilerOptions: { target: ts.ScriptTarget.ES2022, module: ts.ModuleKind.ES2022 }
+}).outputText;
+const provider = await import('data:text/javascript;base64,' + Buffer.from(code).toString('base64'));
+
+test('OpenCode selection stays separate from other providers with the same ID', () => {
+  const session = { id: 'same', provider: 'opencode', sessionKey: 'claudeCode:same' };
+  assert.equal(provider.sessionKeyOf(session), 'opencode:same');
+  assert.equal(provider.providerLabel(provider.providerOf(session)), 'OPENCODE');
+  assert.equal(provider.matchesProvider(session, 'opencode'), true);
+  assert.equal(provider.matchesProvider(session, 'claudeCode'), false);
+  for (const action of ['open', 'stop', 'rename']) assert.equal(provider.canSessionAction(session, action), false);
+  assert.equal(provider.canSessionAction(session, 'conversation'), true);
+});
+
+test('OpenCode descendants attach only to their own provider and orphans remain visible', () => {
+  const sessions = [
+    { id: 'root', provider: 'claudeCode', agentKind: 'root' },
+    { id: 'root', provider: 'opencode', agentKind: 'root' },
+    { id: 'child', provider: 'opencode', agentKind: 'subagent', parentThreadId: 'root' },
+    { id: 'orphan', provider: 'opencode', agentKind: 'subagent', parentThreadId: 'missing' }
+  ];
+  const hierarchy = provider.resolveCodexHierarchy(sessions);
+  assert.deepEqual(hierarchy.subagentsByParent.get('opencode:root'), [sessions[2]]);
+  assert.equal(hierarchy.subagentsByParent.has('claudeCode:root'), false);
+  assert.equal(hierarchy.topLevelIds.has('opencode:orphan'), true);
+});

--- a/scripts/test-opencode-provider.mjs
+++ b/scripts/test-opencode-provider.mjs
@@ -30,3 +30,17 @@ test('OpenCode descendants attach only to their own provider and orphans remain 
   assert.equal(hierarchy.subagentsByParent.has('claudeCode:root'), false);
   assert.equal(hierarchy.topLevelIds.has('opencode:orphan'), true);
 });
+
+test('directory-qualified OpenCode roots and children cannot collide', () => {
+  const sessions = ['/a', '/b'].flatMap(directory => {
+    const suffix = '?directory=' + encodeURIComponent(directory);
+    return [
+      { id: 'same' + suffix, provider: 'opencode', agentKind: 'root' },
+      { id: 'child' + suffix, provider: 'opencode', agentKind: 'subagent', parentThreadId: 'same' + suffix }
+    ];
+  });
+  const hierarchy = provider.resolveCodexHierarchy(sessions);
+  assert.equal(hierarchy.topLevelIds.size, 2);
+  assert.deepEqual(hierarchy.subagentsByParent.get('opencode:same?directory=%2Fa'), [sessions[1]]);
+  assert.deepEqual(hierarchy.subagentsByParent.get('opencode:same?directory=%2Fb'), [sessions[3]]);
+});

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -464,6 +464,7 @@ dependencies = [
  "qr2term",
  "rand 0.8.5",
  "regex",
+ "reqwest",
  "rusqlite",
  "rust-embed",
  "serde",
@@ -714,7 +715,7 @@ dependencies = [
  "bitflags 2.10.0",
  "core-foundation",
  "core-graphics-types",
- "foreign-types",
+ "foreign-types 0.5.0",
  "libc",
 ]
 
@@ -1236,12 +1237,21 @@ checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
 name = "foreign-types"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f6f339eb8adc052cd2ca78910fda869aefa38d22d5cb648e6485e4d3fc06f3b1"
+dependencies = [
+ "foreign-types-shared 0.1.1",
+]
+
+[[package]]
+name = "foreign-types"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d737d9aa519fb7b749cbc3b962edcf310a8dd1f4b67c91c4f83975dbdd17d965"
 dependencies = [
  "foreign-types-macros",
- "foreign-types-shared",
+ "foreign-types-shared 0.3.1",
 ]
 
 [[package]]
@@ -1254,6 +1264,12 @@ dependencies = [
  "quote",
  "syn 2.0.114",
 ]
+
+[[package]]
+name = "foreign-types-shared"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
 
 [[package]]
 name = "foreign-types-shared"
@@ -1287,6 +1303,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2dff15bf788c671c1934e366d07e30c1814a8ef514e1af724a602e8a2fbe1b10"
 dependencies = [
  "futures-core",
+ "futures-sink",
 ]
 
 [[package]]
@@ -1810,6 +1827,22 @@ dependencies = [
  "rustls-pki-types",
  "tokio",
  "tokio-rustls",
+ "tower-service",
+]
+
+[[package]]
+name = "hyper-tls"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70206fc6890eaca9fde8a0bf71caa2ddfc9fe045ac9e5c70df101a7dbde866e0"
+dependencies = [
+ "bytes",
+ "http-body-util",
+ "hyper",
+ "hyper-util",
+ "native-tls",
+ "tokio",
+ "tokio-native-tls",
  "tower-service",
 ]
 
@@ -2418,6 +2451,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "native-tls"
+version = "0.2.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "465500e14ea162429d264d44189adc38b199b62b1c21eea9f69e4b73cb03bbf2"
+dependencies = [
+ "libc",
+ "log",
+ "openssl",
+ "openssl-probe",
+ "openssl-sys",
+ "schannel",
+ "security-framework",
+ "security-framework-sys",
+ "tempfile",
+]
+
+[[package]]
 name = "ndk"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2770,10 +2820,47 @@ dependencies = [
 ]
 
 [[package]]
+name = "openssl"
+version = "0.10.81"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77823a27f0babb03091cb9ed9ef80af3b39dbc82f97e8fa530374b7dafd87a45"
+dependencies = [
+ "bitflags 2.10.0",
+ "cfg-if",
+ "foreign-types 0.3.2",
+ "libc",
+ "openssl-macros",
+ "openssl-sys",
+]
+
+[[package]]
+name = "openssl-macros"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.114",
+]
+
+[[package]]
 name = "openssl-probe"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
+
+[[package]]
+name = "openssl-sys"
+version = "0.9.117"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b47e7e6bb2c38cd930d25a23b40fa52e068c10e85f3e03a7f5ba5aaca5713695"
+dependencies = [
+ "cc",
+ "libc",
+ "pkg-config",
+ "vcpkg",
+]
 
 [[package]]
 name = "option-ext"
@@ -3465,6 +3552,7 @@ checksum = "04e9018c9d814e5f30cc16a0f03271aeab3571e609612d9fe78c1aa8d11c2f62"
 dependencies = [
  "base64 0.22.1",
  "bytes",
+ "futures-channel",
  "futures-core",
  "futures-util",
  "http",
@@ -3472,9 +3560,11 @@ dependencies = [
  "http-body-util",
  "hyper",
  "hyper-rustls",
+ "hyper-tls",
  "hyper-util",
  "js-sys",
  "log",
+ "native-tls",
  "percent-encoding",
  "pin-project-lite",
  "rustls",
@@ -3484,6 +3574,7 @@ dependencies = [
  "serde_json",
  "sync_wrapper",
  "tokio",
+ "tokio-native-tls",
  "tokio-rustls",
  "tokio-util",
  "tower",
@@ -4793,6 +4884,16 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.114",
+]
+
+[[package]]
+name = "tokio-native-tls"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbae76ab933c85776efabc971569dd6119c580d8f5d448769dec1764bf796ef2"
+dependencies = [
+ "native-tls",
+ "tokio",
 ]
 
 [[package]]

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -47,6 +47,7 @@ tauri-build = { version = "2", features = [], optional = true }
 # ── Core (always included) ───────────────────────────────────────────
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
+reqwest = { version = "0.13", default-features = false, features = ["blocking", "native-tls"] }
 sysinfo = "0.32"
 anyhow = "1.0"
 thiserror = "1.0"

--- a/src-tauri/src/blocking.rs
+++ b/src-tauri/src/blocking.rs
@@ -1,0 +1,137 @@
+//! Admission control before dispatching synchronous scans to the blocking pool.
+use std::sync::{Arc, LazyLock};
+use tokio::sync::Semaphore;
+
+pub(crate) static DISCOVERY: LazyLock<Arc<Semaphore>> =
+    LazyLock::new(|| Arc::new(Semaphore::new(1)));
+pub(crate) static SUBAGENTS: LazyLock<Arc<Semaphore>> =
+    LazyLock::new(|| Arc::new(Semaphore::new(1)));
+pub(crate) static SUBAGENT_TRANSCRIPT: LazyLock<Arc<Semaphore>> =
+    LazyLock::new(|| Arc::new(Semaphore::new(1)));
+
+pub(crate) async fn scan<T: Send + 'static>(
+    gate: &Arc<Semaphore>,
+    job: impl FnOnce() -> Result<T, String> + Send + 'static,
+) -> Result<T, String> {
+    // No unbounded queue of async waiters or already-spawned blocking jobs.
+    let permit = gate
+        .clone()
+        .try_acquire_owned()
+        .map_err(|_| "Scan already in progress; retry shortly")?;
+    tokio::task::spawn_blocking(move || {
+        let _permit = permit; // Remains held if the caller is cancelled.
+        job()
+    })
+    .await
+    .map_err(|error| format!("Scan failed: {error}"))?
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::time::Duration;
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn blocking_scan_keeps_timers_running_and_rejects_overlap_after_cancellation() {
+        let gate = Arc::new(Semaphore::new(1));
+        let job_gate = gate.clone();
+        let (started_tx, started_rx) = tokio::sync::oneshot::channel();
+        let (finish_tx, finish_rx) = std::sync::mpsc::channel();
+        let job = tokio::spawn(async move {
+            scan(&job_gate, move || {
+                started_tx.send(()).unwrap();
+                finish_rx.recv_timeout(Duration::from_secs(3)).unwrap();
+                Ok(())
+            })
+            .await
+        });
+        started_rx.await.unwrap();
+        tokio::time::timeout(
+            Duration::from_millis(100),
+            tokio::time::sleep(Duration::from_millis(5)),
+        )
+        .await
+        .unwrap();
+        assert!(scan(&gate, || Ok(()))
+            .await
+            .unwrap_err()
+            .contains("in progress"));
+        job.abort();
+        assert!(
+            scan(&gate, || Ok(())).await.is_err(),
+            "cancelled callers must not release a running scan"
+        );
+        finish_tx.send(()).unwrap();
+        tokio::time::timeout(Duration::from_secs(1), async {
+            while gate.available_permits() == 0 {
+                tokio::task::yield_now().await;
+            }
+        })
+        .await
+        .unwrap();
+        assert!(scan(&gate, || Ok(())).await.is_ok());
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    #[ignore = "explicit scheduler benchmark with a 40 MiB synthetic transcript"]
+    async fn benchmark_transcript_scheduler() {
+        use std::io::Write;
+        use std::sync::atomic::{AtomicBool, Ordering};
+        use std::time::Instant;
+        let mut file = tempfile::NamedTempFile::new().unwrap();
+        let text = "x".repeat(2048);
+        for i in 0..20_000 {
+            writeln!(
+                file,
+                "{}",
+                serde_json::json!({
+                    "type":"assistant","uuid":format!("message-{i}"),"sessionId":"perf",
+                "timestamp":"2026-09-12T00:00:00Z","message":{"id":format!("m-{i}"),"model":"fixture","role":"assistant",
+                    "content":[{"type":"tool_use","id":format!("task-{i}"),"name":"Agent",
+                    "input":{"description":text,"subagent_type":"fixture"}}]}
+                })
+            )
+            .unwrap();
+        }
+        file.flush().unwrap();
+        for inline in [true, false] {
+            let running = Arc::new(AtomicBool::new(true));
+            let running_in_timer = running.clone();
+            let timer = tokio::spawn(async move {
+                let mut previous = Instant::now();
+                let mut max_gap = 0.0f64;
+                let mut ticks = 0;
+                while running_in_timer.load(Ordering::Acquire) {
+                    tokio::time::sleep(Duration::from_millis(2)).await;
+                    max_gap = max_gap.max(previous.elapsed().as_secs_f64() * 1000.0);
+                    previous = Instant::now();
+                    ticks += 1;
+                }
+                (ticks, max_gap)
+            });
+            tokio::task::yield_now().await;
+            let path = file.path().to_path_buf();
+            let work = move || {
+                let entries = crate::session::parser::parse_all_entries(&path)?;
+                let subagents = crate::session::active_subagents_for_path("perf", &path);
+                Ok((entries.len(), subagents.len()))
+            };
+            let start = Instant::now();
+            let counts = if inline {
+                work().unwrap()
+            } else {
+                scan(&Arc::new(Semaphore::new(1)), work).await.unwrap()
+            };
+            let elapsed = start.elapsed().as_secs_f64() * 1000.0;
+            tokio::time::sleep(Duration::from_millis(5)).await;
+            running.store(false, Ordering::Release);
+            let (ticks, max_gap_ms) = timer.await.unwrap();
+            assert_eq!(counts, (20_000, 20_000));
+            println!(
+                "SCAN_PERF {}",
+                serde_json::json!({"mode":if inline {"inline_control"} else {"bounded_blocking"},
+                "file_bytes":file.as_file().metadata().unwrap().len(),"elapsed_ms":elapsed,"timer_ticks":ticks,"max_timer_gap_ms":max_gap_ms})
+            );
+        }
+    }
+}

--- a/src-tauri/src/cli/mod.rs
+++ b/src-tauri/src/cli/mod.rs
@@ -1734,6 +1734,13 @@ fn resolve_session_reference_lightweight_under(
         .map_or((None, reference), |(provider, raw_prefix)| {
             (Some(provider), raw_prefix)
         });
+    // Explicit full OpenCode IDs do not depend on the monitor's freshness window.
+    if provider_filter == Some(session::SessionProvider::Opencode)
+        && prefix.len() >= 30 && prefix.starts_with("ses_")
+        && prefix[4..].bytes().all(|b| b.is_ascii_alphanumeric())
+    {
+        return Ok((prefix.to_string(), provider_filter));
+    }
     let projects_dir = home_dir.join(".claude").join("projects");
 
     let mut matches: Vec<session::SessionIdentity> = Vec::new();
@@ -1783,6 +1790,14 @@ fn resolve_session_reference_lightweight_under(
             .map(|id| session::SessionIdentity::new(session::SessionProvider::Pi, id)),
     );
 
+    if provider_filter.is_none() || provider_filter == Some(session::SessionProvider::Opencode) {
+        matches.extend(
+            session::opencode::detect_once().into_iter()
+                .filter_map(|s| s.identity())
+                .filter(|s| s.session_id.starts_with(prefix)),
+        );
+    }
+
     if let Some(provider) = provider_filter {
         matches.retain(|identity| identity.provider == provider);
     }
@@ -1802,6 +1817,7 @@ fn parse_provider_scoped_reference(reference: &str) -> Option<(session::SessionP
         "codex" => session::SessionProvider::Codex,
         "cursor" => session::SessionProvider::Cursor,
         "pi" => session::SessionProvider::Pi,
+        "opencode" => session::SessionProvider::Opencode,
         _ => return None,
     };
     Some((provider, raw_prefix))
@@ -1845,6 +1861,15 @@ mod session_formatter_tests {
     use super::*;
     use crate::session::source::{AgentKind, SessionProvider, SessionSurface};
     use crate::session::SessionStatus;
+
+    #[test]
+    fn explicit_opencode_id_bypasses_recent_session_discovery() {
+        let home = tempfile::tempdir().unwrap();
+        let id = "ses_f835ea1f8ffelnS2uzHgkM9qUq";
+        let result = super::resolve_session_reference_lightweight_under(
+            &format!("opencode:{id}"), home.path()).unwrap();
+        assert_eq!(result, (id.to_string(), Some(SessionProvider::Opencode)));
+    }
 
     fn codex_subagent() -> session::enrichment::Session {
         session::enrichment::Session {

--- a/src-tauri/src/cli/mod.rs
+++ b/src-tauri/src/cli/mod.rs
@@ -1736,8 +1736,7 @@ fn resolve_session_reference_lightweight_under(
         });
     // Explicit full OpenCode IDs do not depend on the monitor's freshness window.
     if provider_filter == Some(session::SessionProvider::Opencode)
-        && prefix.len() >= 30 && prefix.starts_with("ses_")
-        && prefix[4..].bytes().all(|b| b.is_ascii_alphanumeric())
+        && session::opencode::is_full_session_reference(prefix)
     {
         return Ok((prefix.to_string(), provider_filter));
     }
@@ -1869,6 +1868,10 @@ mod session_formatter_tests {
         let result = super::resolve_session_reference_lightweight_under(
             &format!("opencode:{id}"), home.path()).unwrap();
         assert_eq!(result, (id.to_string(), Some(SessionProvider::Opencode)));
+        let scoped = format!("{id}?directory=%2Farchive%2F%E4%B8%AD%E6%96%87");
+        let result = super::resolve_session_reference_lightweight_under(
+            &format!("opencode:{scoped}"), home.path()).unwrap();
+        assert_eq!(result, (scoped, Some(SessionProvider::Opencode)));
     }
 
     fn codex_subagent() -> session::enrichment::Session {

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -16,6 +16,8 @@ pub mod notifications;
 #[cfg(all(not(mobile), feature = "gui"))]
 pub mod polling;
 #[cfg(all(not(mobile), feature = "gui"))]
+mod blocking;
+#[cfg(all(not(mobile), feature = "gui"))]
 pub mod web_server;
 #[cfg(all(not(mobile), feature = "gui"))]
 pub mod subscription_usage;
@@ -73,14 +75,18 @@ async fn get_subscription_usage() -> Vec<subscription_usage::SubscriptionUsage> 
 async fn get_sessions(
     detector: tauri::State<'_, Arc<Mutex<session::DetectorState>>>,
 ) -> Result<Vec<Session>, String> {
-    let detect_result = {
-        let mut state = detector
-            .lock()
-            .map_err(|e| format!("Detector lock poisoned: {}", e))?;
-        state.detect()
-    };
-    let (detected, diag) = detect_result.map_err(|e| format!("Detect failed: {}", e))?;
-    session::enrichment::enrich_detected_sessions(detected, diag).map(|(sessions, _)| sessions)
+    let detector = Arc::clone(detector.inner());
+    blocking::scan(&blocking::DISCOVERY, move || {
+        let detect_result = {
+            let mut state = detector
+                .lock()
+                .map_err(|e| format!("Detector lock poisoned: {}", e))?;
+            state.detect()
+        };
+        let (detected, diag) = detect_result.map_err(|e| format!("Detect failed: {}", e))?;
+        session::enrichment::enrich_detected_sessions(detected, diag).map(|(sessions, _)| sessions)
+    })
+    .await
 }
 
 #[cfg(all(not(mobile), feature = "gui"))]
@@ -159,13 +165,7 @@ async fn get_subagents(
     // Transcript scans perform blocking disk I/O and JSON parsing. Running them
     // directly on Tokio workers can starve subscription IPC, pipes and timers.
     // Hold the permit inside the blocking job so cancellation cannot overlap scans.
-    static SCAN_GATE: std::sync::OnceLock<Arc<tokio::sync::Semaphore>> = std::sync::OnceLock::new();
-    let permit = SCAN_GATE.get_or_init(|| Arc::new(tokio::sync::Semaphore::new(1)))
-        .clone().acquire_owned().await.map_err(|e| e.to_string())?;
-    tauri::async_runtime::spawn_blocking(move || {
-        let _permit = permit;
-        session::all_subagents_by_session()
-    }).await.map_err(|e| format!("Subagent scan failed: {e}"))
+    blocking::scan(&blocking::SUBAGENTS, || Ok(session::all_subagents_by_session())).await
 }
 
 /// Returns the prompt + final result (plus usage stats when available) for a
@@ -176,12 +176,15 @@ async fn get_subagent_transcript(
     parent_session_id: String,
     subagent_id: String,
 ) -> Result<session::SubagentTranscript, String> {
-    session::get_subagent_transcript(&parent_session_id, &subagent_id).ok_or_else(|| {
-        format!(
-            "subagent {} not found in session {}",
-            subagent_id, parent_session_id
-        )
+    blocking::scan(&blocking::SUBAGENT_TRANSCRIPT, move || {
+        session::get_subagent_transcript(&parent_session_id, &subagent_id).ok_or_else(|| {
+            format!(
+                "subagent {} not found in session {}",
+                subagent_id, parent_session_id
+            )
+        })
     })
+    .await
 }
 
 /// Returns the parsed TodoWrite tasks for a session, sorted by numeric `id`.
@@ -735,6 +738,7 @@ pub fn run() {
         .invoke_handler(tauri::generate_handler![
             session::opencode::opencode_connection_status,
             session::opencode::opencode_connect,
+            session::opencode::opencode_session_children,
             notifications::get_notification_preferences,
             notifications::save_notification_preferences,
             notifications::test_native_notification,

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -733,6 +733,8 @@ pub fn run() {
             Ok(())
         })
         .invoke_handler(tauri::generate_handler![
+            session::opencode::opencode_connection_status,
+            session::opencode::opencode_connect,
             notifications::get_notification_preferences,
             notifications::save_notification_preferences,
             notifications::test_native_notification,

--- a/src-tauri/src/notifications.rs
+++ b/src-tauri/src/notifications.rs
@@ -215,6 +215,7 @@ fn content(s: &Session, event: Event, detail: Detail) -> (String, String) {
         SessionProvider::Codex => "Codex",
         SessionProvider::Cursor => "Cursor",
         SessionProvider::Pi => "Pi",
+        SessionProvider::Opencode => "OpenCode",
     };
     let project = std::path::Path::new(&s.project_path)
         .file_name()

--- a/src-tauri/src/session/codex.rs
+++ b/src-tauri/src/session/codex.rs
@@ -636,6 +636,7 @@ impl CodexSessionSource {
                 codex_summary: Some(summary),
                 cursor_summary: None,
                 pi_summary: None,
+                opencode_summary: None,
             });
         }
         Ok((sessions, DetectionDiagnostics::default()))

--- a/src-tauri/src/session/conversation.rs
+++ b/src-tauri/src/session/conversation.rs
@@ -225,16 +225,24 @@ pub fn get_conversation_data_for_provider_with_progress(
         return load_for_provider(session_id, provider, include_tools, &mut report);
     }
 
+    probe_providerless_conversation(session_id, |provider| {
+        load_for_provider(session_id, provider, include_tools, &mut report)
+    })
+}
+
+fn probe_providerless_conversation(
+    session_id: &str,
+    mut load: impl FnMut(SessionProvider) -> Result<Conversation, String>,
+) -> Result<Conversation, String> {
     let mut matches = Vec::new();
     for provider in [
         SessionProvider::ClaudeCode,
         SessionProvider::Codex,
         SessionProvider::Cursor,
         SessionProvider::Pi,
+        SessionProvider::Opencode,
     ] {
-        if let Ok(conversation) =
-            load_for_provider(session_id, provider, include_tools, &mut report)
-        {
+        if let Ok(conversation) = load(provider) {
             matches.push((provider, conversation));
         }
     }
@@ -274,6 +282,27 @@ mod tests {
             provider: SessionProvider::ClaudeCode,
             messages: Vec::new(),
         }
+    }
+
+    #[test]
+    fn providerless_probe_finds_opencode_and_still_rejects_collisions() {
+        let load = |provider| {
+            if provider == SessionProvider::Opencode {
+                Ok(Conversation { provider, ..conversation("remote-id") })
+            } else {
+                Err("not found".into())
+            }
+        };
+        let result = probe_providerless_conversation("remote-id", load).unwrap();
+        assert_eq!(result.provider, SessionProvider::Opencode);
+        let error = probe_providerless_conversation("remote-id", |provider| {
+            if provider == SessionProvider::Pi {
+                Ok(Conversation { provider, ..conversation("remote-id") })
+            } else {
+                load(provider)
+            }
+        }).unwrap_err();
+        assert!(error.contains("ambiguous across providers"));
     }
 
     #[test]

--- a/src-tauri/src/session/conversation.rs
+++ b/src-tauri/src/session/conversation.rs
@@ -175,6 +175,7 @@ fn load_for_provider(
         SessionProvider::Codex => codex_conversation(session_id, include_tools, on_progress),
         SessionProvider::Cursor => cursor_conversation(session_id, include_tools, on_progress),
         SessionProvider::Pi => pi_conversation(session_id, include_tools, on_progress),
+        SessionProvider::Opencode => super::opencode::conversation(session_id, include_tools),
     }
 }
 

--- a/src-tauri/src/session/cursor.rs
+++ b/src-tauri/src/session/cursor.rs
@@ -282,6 +282,7 @@ impl CursorSessionSource {
                 codex_summary: None,
                 cursor_summary: Some(summary),
                 pi_summary: None,
+                opencode_summary: None,
             });
         }
         Ok((sessions, DetectionDiagnostics::default()))

--- a/src-tauri/src/session/detector_cli.rs
+++ b/src-tauri/src/session/detector_cli.rs
@@ -93,6 +93,7 @@ impl CliSessionSource {
             codex_summary: None,
             cursor_summary: None,
             pi_summary: None,
+            opencode_summary: None,
         }
     }
 }

--- a/src-tauri/src/session/enrichment.rs
+++ b/src-tauri/src/session/enrichment.rs
@@ -174,6 +174,7 @@ pub fn detect_and_enrich_sessions() -> Result<(Vec<Session>, DetectionDiagnostic
     let codex_result = owners.detect_codex();
     let cursor_result = owners.detect_cursor();
     let pi_result = owners.detect_pi();
+    let opencode_sessions = super::opencode::detect_once();
     match claude_result {
         Ok((mut detected, diagnostics)) => {
             if let Some((mut codex_sessions, _)) = codex_result {
@@ -185,10 +186,11 @@ pub fn detect_and_enrich_sessions() -> Result<(Vec<Session>, DetectionDiagnostic
             if let Some((mut pi_sessions, _)) = pi_result {
                 detected.append(&mut pi_sessions);
             }
+            detected.extend(opencode_sessions);
             enrich_detected_sessions(detected, diagnostics)
         }
         Err(error) => {
-            let mut fallback = Vec::new();
+            let mut fallback = opencode_sessions;
             let mut diagnostics = DetectionDiagnostics::default();
             if let Some((sessions, extra)) = codex_result {
                 fallback.extend(sessions);
@@ -383,6 +385,50 @@ pub fn enrich_detected_sessions(
                 status,
                 latest_message,
                 notification_preview,
+                pending_tool_name: None,
+                pending_tool_input: None,
+                worker_of: None,
+                official_name: detected.official_name.clone(),
+                started_at_ms: detected.started_at_ms,
+                provider: detected.provider,
+                surface: detected.surface,
+                agent_kind: detected.agent_kind,
+                parent_thread_id: detected.parent_thread_id.clone(),
+                root_session_id: detected.root_session_id.clone(),
+                agent_path: detected.agent_path.clone(),
+                agent_nickname: detected.agent_nickname.clone(),
+                agent_role: detected.agent_role.clone(),
+                internal_kind: detected.internal_kind.clone(),
+                can_open: detected.can_open,
+                can_stop: detected.can_stop,
+                can_rename: detected.can_rename,
+            });
+            continue;
+        }
+
+        if let Some(summary) = detected.opencode_summary.as_ref() {
+            let first_prompt = detected.official_name.clone().unwrap_or_default();
+            let latest_message = summary.diagnostic.clone();
+            let session_name = detected.project_name.clone();
+            let modified = summary.modified.clone();
+            let status = summary.status.clone();
+            sessions.push(Session {
+                id: session_id.clone(),
+                session_key: SessionIdentity::new(detected.provider, session_id.clone()).key(),
+                pid: detected.pid,
+                session_name,
+                custom_title: claude_custom_title(detected.provider, &custom_titles, &session_id),
+                codex_title: None,
+                cursor_title: None,
+                project_path: detected.cwd.to_string_lossy().to_string(),
+                git_branch: None,
+                first_prompt,
+                summary: None,
+                message_count: 0,
+                modified,
+                status,
+                latest_message,
+                notification_preview: None,
                 pending_tool_name: None,
                 pending_tool_input: None,
                 worker_of: None,
@@ -937,6 +983,7 @@ mod placeholder_tests {
             codex_summary: None,
             cursor_summary: None,
             pi_summary: None,
+            opencode_summary: None,
         };
         let (sessions, _) =
             enrich_detected_sessions(vec![detected], DetectionDiagnostics::default()).unwrap();

--- a/src-tauri/src/session/mod.rs
+++ b/src-tauri/src/session/mod.rs
@@ -6,6 +6,7 @@ pub mod detector;
 pub mod parser;
 pub mod permissions;
 pub mod pi;
+pub mod opencode;
 pub mod source;
 pub mod status;
 

--- a/src-tauri/src/session/opencode.rs
+++ b/src-tauri/src/session/opencode.rs
@@ -1,0 +1,754 @@
+//! Explicit OpenCode HTTP integration. No process, port or storage discovery.
+//!
+//! Configure C9WATCH_OPENCODE_URL to opt in. Detection only reads a background
+//! snapshot; a slow/offline server never blocks the other providers.
+use super::conversation::{Conversation, ConversationMessage};
+use super::{
+    AgentKind, DetectedSession, MessageType, SessionProvider, SessionStatus, SessionSurface,
+};
+use reqwest::blocking::Client;
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+use std::collections::{BTreeSet, HashMap, HashSet};
+use std::io::Read;
+use std::sync::{Arc, LazyLock, Mutex};
+use std::time::Duration;
+
+const MAX_RESPONSE: u64 = 8 * 1024 * 1024;
+const IDLE_FRESHNESS_MS: i64 = 30 * 60 * 1000;
+
+#[derive(Clone, Debug)]
+pub struct OpenCodeSummary {
+    pub modified: String,
+    pub status: SessionStatus,
+    pub diagnostic: String,
+}
+
+#[derive(Clone)]
+struct Connection {
+    url: reqwest::Url,
+    username: String,
+    password: Option<String>,
+}
+
+impl Connection {
+    fn from_env() -> Result<Option<Self>, String> {
+        let Ok(raw) = std::env::var("C9WATCH_OPENCODE_URL") else {
+            return Ok(None);
+        };
+        Self::parse(
+            &raw,
+            std::env::var("C9WATCH_OPENCODE_USERNAME").unwrap_or_else(|_| "opencode".into()),
+            std::env::var("C9WATCH_OPENCODE_PASSWORD").ok(),
+        )
+        .map(Some)
+    }
+
+    fn parse(raw: &str, username: String, password: Option<String>) -> Result<Self, String> {
+        let url = reqwest::Url::parse(raw).map_err(|_| "Invalid OpenCode URL")?;
+        if !matches!(url.scheme(), "http" | "https")
+            || url.host_str().is_none()
+            || !url.username().is_empty()
+            || url.password().is_some()
+            || url.query().is_some()
+            || url.fragment().is_some()
+        {
+            return Err(
+                "OpenCode URL must be HTTP(S), without credentials, query or fragment".into(),
+            );
+        }
+        Ok(Self {
+            url,
+            username,
+            password,
+        })
+    }
+
+    fn get<T: serde::de::DeserializeOwned>(
+        &self,
+        client: &Client,
+        segments: &[&str],
+    ) -> Result<T, String> {
+        self.get_page(client, segments, &[]).map(|(value, _)| value)
+    }
+
+    fn get_page<T: serde::de::DeserializeOwned>(
+        &self,
+        client: &Client,
+        segments: &[&str],
+        query: &[(&str, &str)],
+    ) -> Result<(T, Option<String>), String> {
+        let mut url = self.url.clone();
+        url.path_segments_mut()
+            .map_err(|_| "Invalid OpenCode URL")?
+            .pop_if_empty()
+            .extend(segments);
+        if !query.is_empty() {
+            url.query_pairs_mut().extend_pairs(query.iter().copied());
+        }
+        let mut request = client.get(url);
+        if let Some(password) = &self.password {
+            request = request.basic_auth(&self.username, Some(password));
+        }
+        let response = request
+            .send()
+            .map_err(|_| "OpenCode connection failed or timed out")?;
+        if !response.status().is_success() {
+            return Err(format!("OpenCode HTTP {}", response.status().as_u16()));
+        }
+        let next_cursor = response
+            .headers()
+            .get("x-next-cursor")
+            .map(|v| v.to_str().map(str::to_owned))
+            .transpose()
+            .map_err(|_| "Invalid OpenCode pagination cursor")?;
+        let mut bytes = Vec::new();
+        response
+            .take(MAX_RESPONSE + 1)
+            .read_to_end(&mut bytes)
+            .map_err(|_| "OpenCode response read failed")?;
+        if bytes.len() as u64 > MAX_RESPONSE {
+            return Err("OpenCode response exceeds 8 MiB".into());
+        }
+        serde_json::from_slice(&bytes)
+            .map(|value| (value, next_cursor))
+            .map_err(|_| "Malformed OpenCode response".into())
+    }
+}
+
+fn client() -> Result<Client, String> {
+    Client::builder()
+        .timeout(Duration::from_secs(3))
+        .redirect(reqwest::redirect::Policy::none())
+        .no_proxy()
+        .build()
+        .map_err(|_| "Could not initialize OpenCode HTTP client".into())
+}
+
+#[derive(Deserialize)]
+struct RemoteSession {
+    id: String,
+    directory: String,
+    title: String,
+    #[serde(rename = "parentID")]
+    parent_id: Option<String>,
+    time: RemoteTime,
+}
+
+#[derive(Deserialize)]
+struct RemoteTime {
+    created: i64,
+    updated: i64,
+    archived: Option<i64>,
+}
+
+#[derive(Deserialize)]
+struct RemoteStatus {
+    #[serde(rename = "type")]
+    kind: String,
+}
+
+fn timestamp(ms: i64) -> String {
+    chrono::DateTime::from_timestamp_millis(ms)
+        .map(|t| t.to_rfc3339())
+        .unwrap_or_default()
+}
+
+fn snapshot(connection: &Connection, client: &Client) -> Result<Vec<DetectedSession>, String> {
+    let sessions: Vec<RemoteSession> = connection.get(client, &["session"])?;
+    // Status is directory-scoped even though the session list spans the project.
+    let mut statuses_by_directory = HashMap::new();
+    for directory in sessions
+        .iter()
+        .filter(|s| s.time.archived.is_none())
+        .map(|s| s.directory.as_str())
+        .collect::<BTreeSet<_>>()
+    {
+        let (statuses, _): (HashMap<String, RemoteStatus>, _) =
+            connection.get_page(client, &["session", "status"], &[("directory", directory)])?;
+        statuses_by_directory.insert(directory.to_owned(), statuses);
+    }
+    Ok(sessions
+        .into_iter()
+        .filter(|s| s.time.archived.is_none())
+        .filter(|s| {
+            statuses_by_directory
+                .get(&s.directory)
+                .and_then(|statuses| statuses.get(&s.id))
+                .is_some_and(|status| status.kind != "idle")
+                || chrono::Utc::now()
+                    .timestamp_millis()
+                    .saturating_sub(s.time.updated)
+                    <= IDLE_FRESHNESS_MS
+        })
+        .map(|s| {
+            let mut detected = DetectedSession::with_legacy_defaults(
+                0,
+                s.directory.clone().into(),
+                s.directory.clone().into(),
+                Some(s.id.clone()),
+                s.title.clone(),
+            );
+            detected.provider = SessionProvider::Opencode;
+            detected.surface = SessionSurface::Integration;
+            detected.official_name = Some(s.title);
+            detected.started_at_ms = Some(s.time.created);
+            detected.agent_kind = if s.parent_id.is_some() {
+                AgentKind::Subagent
+            } else {
+                AgentKind::Root
+            };
+            detected.parent_thread_id = s.parent_id;
+            detected.can_open = false;
+            detected.can_stop = false;
+            detected.can_rename = false;
+            // Missing entries in the status map are idle; unknown future values
+            // are explicitly Connecting, never guessed to mean completion.
+            let kind = statuses_by_directory
+                .get(&s.directory)
+                .and_then(|statuses| statuses.get(&s.id))
+                .map(|s| s.kind.as_str())
+                .unwrap_or("idle");
+            detected.opencode_summary = Some(OpenCodeSummary {
+                modified: timestamp(s.time.updated),
+                status: match kind {
+                    "busy" => SessionStatus::Working,
+                    "idle" => SessionStatus::WaitingForInput,
+                    _ => SessionStatus::Connecting,
+                },
+                diagnostic: match kind {
+                    "retry" => "OpenCode is retrying".into(),
+                    "busy" | "idle" => String::new(),
+                    _ => "OpenCode reported an unrecognized status".into(),
+                },
+            });
+            detected
+        })
+        .collect())
+}
+
+struct Cache {
+    started: bool,
+    generation: u64,
+    connection: Option<Connection>,
+    sessions: Vec<DetectedSession>,
+    error: Option<String>,
+    connected: bool,
+}
+static CACHE: LazyLock<Arc<Mutex<Cache>>> = LazyLock::new(|| {
+    let result = Connection::from_env();
+    Arc::new(Mutex::new(Cache {
+        started: false,
+        generation: 0,
+        sessions: Vec::new(),
+        connected: false,
+        error: result.as_ref().err().cloned(),
+        connection: result.ok().flatten(),
+    }))
+});
+
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ConnectionStatus {
+    url: String,
+    connected: bool,
+    error: Option<String>,
+    session_count: usize,
+}
+
+#[cfg(feature = "gui")]
+#[tauri::command]
+pub fn opencode_connection_status() -> ConnectionStatus {
+    detect();
+    let cache = CACHE.lock().unwrap_or_else(|e| e.into_inner());
+    ConnectionStatus {
+        url: cache
+            .connection
+            .as_ref()
+            .map(|c| c.url.to_string())
+            .unwrap_or_default(),
+        connected: cache.connected,
+        error: cache.error.clone(),
+        session_count: cache.sessions.len(),
+    }
+}
+
+/// Credentials stay in process memory and are never returned to the UI or logged.
+#[cfg(feature = "gui")]
+#[tauri::command]
+pub fn opencode_connect(
+    url: String,
+    username: String,
+    password: Option<String>,
+) -> Result<(), String> {
+    let connection = if url.trim().is_empty() {
+        None
+    } else {
+        Some(Connection::parse(
+            url.trim(),
+            username,
+            password.filter(|p| !p.is_empty()),
+        )?)
+    };
+    {
+        let mut cache = CACHE.lock().unwrap_or_else(|e| e.into_inner());
+        cache.connection = connection;
+        cache.generation += 1;
+        cache.sessions.clear();
+        cache.error = None;
+        cache.connected = false;
+    }
+    detect();
+    Ok(())
+}
+
+pub(crate) fn detect() -> Vec<DetectedSession> {
+    let mut cache = CACHE.lock().unwrap_or_else(|e| e.into_inner());
+    if !cache.started {
+        cache.started = true;
+        let shared = Arc::clone(&CACHE);
+        std::thread::spawn(move || {
+            let client = match client() {
+                Ok(c) => c,
+                Err(e) => {
+                    shared.lock().unwrap_or_else(|e| e.into_inner()).error = Some(e);
+                    return;
+                }
+            };
+            loop {
+                let (connection, generation) = {
+                    let cache = shared.lock().unwrap_or_else(|e| e.into_inner());
+                    (cache.connection.clone(), cache.generation)
+                };
+                if let Some(connection) = connection {
+                    let result = snapshot(&connection, &client);
+                    let mut cache = shared.lock().unwrap_or_else(|e| e.into_inner());
+                    // A response from an old endpoint must never populate a new connection.
+                    if cache.generation == generation {
+                        apply_result(&mut cache, result);
+                    }
+                }
+                std::thread::sleep(Duration::from_secs(2));
+            }
+        });
+    }
+    cache.sessions.clone()
+}
+
+fn apply_result(cache: &mut Cache, result: Result<Vec<DetectedSession>, String>) {
+    match result {
+        Ok(sessions) => {
+            cache.sessions = sessions;
+            cache.connected = true;
+            cache.error = None;
+        }
+        Err(error) => {
+            cache.connected = false;
+            cache.error = Some(error.clone());
+            for session in &mut cache.sessions {
+                if let Some(summary) = &mut session.opencode_summary {
+                    summary.status = SessionStatus::Connecting;
+                    summary.diagnostic = error.clone();
+                }
+            }
+        }
+    }
+}
+
+pub(crate) fn detect_once() -> Vec<DetectedSession> {
+    let connection = CACHE
+        .lock()
+        .unwrap_or_else(|e| e.into_inner())
+        .connection
+        .clone();
+    let Some(connection) = connection else {
+        return Vec::new();
+    };
+    std::thread::spawn(move || client().and_then(|client| snapshot(&connection, &client)))
+        .join()
+        .ok()
+        .and_then(Result::ok)
+        .unwrap_or_default()
+}
+
+pub(crate) fn conversation(id: &str, include_tools: bool) -> Result<Conversation, String> {
+    let connection = CACHE
+        .lock()
+        .unwrap_or_else(|e| e.into_inner())
+        .connection
+        .clone()
+        .ok_or("OpenCode is not configured")?;
+    read_conversation(&connection, &client()?, id, include_tools)
+}
+
+fn read_conversation(
+    connection: &Connection,
+    client: &Client,
+    id: &str,
+    include_tools: bool,
+) -> Result<Conversation, String> {
+    let mut pages = Vec::new();
+    let mut before: Option<String> = None;
+    let mut cursors = HashSet::new();
+    let mut limit = 20usize;
+    let started = std::time::Instant::now();
+    loop {
+        if pages.len() >= 1000 || started.elapsed() > Duration::from_secs(60) {
+            return Err("OpenCode conversation is too large to load in one minute".into());
+        }
+        let limit_text = limit.to_string();
+        let mut query = vec![("limit", limit_text.as_str())];
+        if let Some(cursor) = &before {
+            query.push(("before", cursor.as_str()));
+        }
+        let result = connection.get_page::<Vec<Value>>(client, &["session", id, "message"], &query);
+        let (rows, next) = match result {
+            Err(error) if error == "OpenCode response exceeds 8 MiB" && limit > 1 => {
+                limit = (limit / 2).max(1);
+                continue;
+            }
+            other => other?,
+        };
+        pages.push(parse_conversation(id, rows, include_tools)?.messages);
+        match next {
+            Some(cursor) if !cursor.is_empty() && cursors.insert(cursor.clone()) => {
+                before = Some(cursor)
+            }
+            Some(_) => return Err("OpenCode returned a repeated or empty pagination cursor".into()),
+            None => break,
+        }
+    }
+    // OpenCode pages are individually chronological but are fetched newest first.
+    Ok(Conversation {
+        session_id: id.into(),
+        provider: SessionProvider::Opencode,
+        messages: pages.into_iter().rev().flatten().collect(),
+    })
+}
+
+fn parse_conversation(
+    id: &str,
+    rows: Vec<Value>,
+    include_tools: bool,
+) -> Result<Conversation, String> {
+    let mut messages = Vec::new();
+    for row in rows {
+        let role = row["info"]["role"]
+            .as_str()
+            .ok_or("Malformed OpenCode message role")?;
+        let time = timestamp(row["info"]["time"]["created"].as_i64().unwrap_or_default());
+        let parts = row["parts"]
+            .as_array()
+            .ok_or("Malformed OpenCode message parts")?;
+        for part in parts {
+            let (message_type, content) = match part["type"].as_str() {
+                Some("text") if role == "user" || role == "assistant" => (
+                    if role == "user" {
+                        MessageType::User
+                    } else {
+                        MessageType::Assistant
+                    },
+                    part["text"].as_str().unwrap_or_default().to_owned(),
+                ),
+                Some("tool") if include_tools => (
+                    MessageType::ToolResult,
+                    format!(
+                        "{}: {}",
+                        part["tool"].as_str().unwrap_or("tool"),
+                        part["state"]["output"]
+                            .as_str()
+                            .or(part["state"]["error"].as_str())
+                            .unwrap_or("(pending)")
+                    ),
+                ),
+                _ => continue,
+            };
+            messages.push(ConversationMessage {
+                timestamp: time.clone(),
+                message_type,
+                content,
+                images: Vec::new(),
+            });
+        }
+    }
+    Ok(Conversation {
+        session_id: id.into(),
+        provider: SessionProvider::Opencode,
+        messages,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+    use std::io::{BufRead, BufReader, Write};
+    use std::net::TcpListener;
+
+    fn server(responses: Vec<(&str, u16, String)>) -> (Connection, std::thread::JoinHandle<()>) {
+        server_with_headers(
+            responses
+                .into_iter()
+                .map(|(p, c, b)| (p, c, b, ""))
+                .collect(),
+        )
+    }
+
+    fn server_with_headers(
+        responses: Vec<(&str, u16, String, &str)>,
+    ) -> (Connection, std::thread::JoinHandle<()>) {
+        let listener = TcpListener::bind("127.0.0.1:0").unwrap();
+        let connection = Connection::parse(
+            &format!("http://{}", listener.local_addr().unwrap()),
+            "opencode".into(),
+            Some("test-secret".into()),
+        )
+        .unwrap();
+        let paths: Vec<_> = responses
+            .into_iter()
+            .map(|(p, s, b, h)| (p.to_owned(), s, b, h.to_owned()))
+            .collect();
+        let handle = std::thread::spawn(move || {
+            for (path, code, body, headers) in paths {
+                let (mut socket, _) = listener.accept().unwrap();
+                socket
+                    .set_read_timeout(Some(Duration::from_secs(5)))
+                    .unwrap();
+                let mut reader = BufReader::new(socket.try_clone().unwrap());
+                let mut line = String::new();
+                reader.read_line(&mut line).unwrap();
+                assert_eq!(line.trim(), format!("GET {path} HTTP/1.1"));
+                let mut auth = false;
+                loop {
+                    line.clear();
+                    reader.read_line(&mut line).unwrap();
+                    if line == "\r\n" {
+                        break;
+                    }
+                    if line.to_lowercase().starts_with("authorization: basic ") {
+                        auth = true;
+                    }
+                }
+                assert!(auth);
+                write!(
+                    socket,
+                    "HTTP/1.1 {code} Test\r\nContent-Length: {}\r\nConnection: close\r\n{headers}\r\n{body}",
+                    body.len()
+                )
+                .unwrap();
+            }
+        });
+        (connection, handle)
+    }
+
+    #[test]
+    fn http_snapshot_maps_lifecycle_hierarchy_and_capabilities() {
+        let rows: Vec<_> = ["busy", "idle", "retry", "future", "archived", "old"].into_iter().map(|id| json!({
+            "id": id, "directory": "/synthetic/project", "title": id,
+            "parentID": if id == "retry" { Some("busy") } else { None },
+            "time": {"created": 1000, "updated": if id == "old" { 0 } else { chrono::Utc::now().timestamp_millis() }, "archived": if id == "archived" { Some(3000) } else { None }}
+        })).collect();
+        let (connection, thread) = server(vec![
+            ("/session", 200, json!(rows).to_string()),
+            ("/session/status?directory=%2Fsynthetic%2Fproject", 200, json!({"busy":{"type":"busy"}, "retry":{"type":"retry"}, "future":{"type":"new-state"}}).to_string()),
+        ]);
+        let sessions = snapshot(&connection, &client().unwrap()).unwrap();
+        thread.join().unwrap();
+        assert_eq!(sessions.len(), 4);
+        assert_eq!(sessions[0].identity_key().as_deref(), Some("opencode:busy"));
+        assert_eq!(
+            sessions[0].opencode_summary.as_ref().unwrap().status,
+            SessionStatus::Working
+        );
+        assert_eq!(
+            sessions[1].opencode_summary.as_ref().unwrap().status,
+            SessionStatus::WaitingForInput
+        );
+        assert_eq!(
+            sessions[2].opencode_summary.as_ref().unwrap().status,
+            SessionStatus::Connecting
+        );
+        assert_eq!(
+            sessions[3].opencode_summary.as_ref().unwrap().status,
+            SessionStatus::Connecting
+        );
+        assert_eq!(sessions[2].parent_thread_id.as_deref(), Some("busy"));
+        assert!(sessions
+            .iter()
+            .all(|s| s.pid == 0 && !s.can_open && !s.can_stop && !s.can_rename));
+        let enriched = super::super::enrichment::enrich_detected_sessions(
+            sessions.clone(),
+            Default::default(),
+        )
+        .unwrap()
+        .0;
+        assert_eq!(enriched[0].provider, SessionProvider::Opencode);
+        assert_eq!(enriched[0].status, SessionStatus::Working);
+        let mut cache = Cache {
+            started: true,
+            generation: 0,
+            connection: None,
+            sessions,
+            error: None,
+            connected: true,
+        };
+        apply_result(&mut cache, Err("OpenCode HTTP 401".into()));
+        assert!(!cache.connected);
+        assert_eq!(cache.sessions.len(), 4);
+        assert!(cache
+            .sessions
+            .iter()
+            .all(|s| s.opencode_summary.as_ref().unwrap().status == SessionStatus::Connecting));
+        apply_result(&mut cache, Ok(Vec::new()));
+        assert!(cache.connected && cache.sessions.is_empty() && cache.error.is_none());
+    }
+
+    #[test]
+    fn malformed_and_auth_errors_are_explicit_without_response_body_or_secret() {
+        for (code, body, expected) in [
+            (401, "test-secret", "OpenCode HTTP 401"),
+            (200, "not json", "Malformed OpenCode response"),
+            (302, "redirect", "OpenCode HTTP 302"),
+        ] {
+            let (connection, thread) = server(vec![("/session", code, body.into())]);
+            let error = snapshot(&connection, &client().unwrap()).unwrap_err();
+            thread.join().unwrap();
+            assert_eq!(error, expected);
+            assert!(!error.contains("test-secret"));
+        }
+    }
+
+    #[test]
+    fn conversations_preserve_roles_unicode_and_tool_visibility() {
+        let rows = vec![
+            json!({"info":{"role":"user","time":{"created":1000}},"parts":[{"type":"text","text":"你好"}]}),
+            json!({"info":{"role":"assistant","time":{"created":2000}},"parts":[{"type":"text","text":"Hello"},
+                {"type":"tool","tool":"read","state":{"status":"completed","output":"fixture output"}},
+                {"type":"future-part","text":"ignored"}]}),
+        ];
+        let result = parse_conversation("same-id", rows.clone(), false).unwrap();
+        assert_eq!(result.provider, SessionProvider::Opencode);
+        assert_eq!(result.messages.len(), 2);
+        assert_eq!(result.messages[0].content, "你好");
+        assert!(matches!(result.messages[0].message_type, MessageType::User));
+        assert!(matches!(
+            result.messages[1].message_type,
+            MessageType::Assistant
+        ));
+        assert_eq!(
+            parse_conversation("same-id", rows, true)
+                .unwrap()
+                .messages
+                .len(),
+            3
+        );
+        assert!(parse_conversation("id", vec![json!({})], true).is_err());
+    }
+
+    #[test]
+    fn directory_statuses_do_not_turn_other_worktrees_idle() {
+        let now = chrono::Utc::now().timestamp_millis();
+        let rows = json!([
+            {"id":"idle","directory":"/a","title":"A","time":{"created":0,"updated":now}},
+            {"id":"busy","directory":"/b","title":"B","time":{"created":0,"updated":0}}
+        ]);
+        let (connection, thread) = server(vec![
+            ("/session", 200, rows.to_string()),
+            ("/session/status?directory=%2Fa", 200, "{}".into()),
+            (
+                "/session/status?directory=%2Fb",
+                200,
+                r#"{"busy":{"type":"busy"}}"#.into(),
+            ),
+        ]);
+        let sessions = snapshot(&connection, &client().unwrap()).unwrap();
+        thread.join().unwrap();
+        assert_eq!(sessions.len(), 2, "old busy worktree must not expire");
+        assert_eq!(
+            sessions[0].opencode_summary.as_ref().unwrap().status,
+            SessionStatus::WaitingForInput
+        );
+        assert_eq!(
+            sessions[1].opencode_summary.as_ref().unwrap().status,
+            SessionStatus::Working
+        );
+    }
+
+    #[test]
+    fn paginated_conversation_larger_than_response_cap_preserves_order() {
+        let page = |text: &str| {
+            json!([{
+                "info":{"role":"assistant","time":{"created":1000}},
+                "parts":[{"type":"text","text":text},
+                    {"type":"tool","tool":"read","state":{"output":"x".repeat(3 * 1024 * 1024)}}]
+            }])
+            .to_string()
+        };
+        let (connection, thread) = server_with_headers(vec![
+            (
+                "/session/ses_test/message?limit=20",
+                200,
+                page("newest"),
+                "X-Next-Cursor: c2\r\n",
+            ),
+            (
+                "/session/ses_test/message?limit=20&before=c2",
+                200,
+                page("middle"),
+                "X-Next-Cursor: c1\r\n",
+            ),
+            (
+                "/session/ses_test/message?limit=20&before=c1",
+                200,
+                page("oldest"),
+                "",
+            ),
+        ]);
+        let conversation =
+            read_conversation(&connection, &client().unwrap(), "ses_test", false).unwrap();
+        thread.join().unwrap();
+        assert_eq!(
+            conversation
+                .messages
+                .iter()
+                .map(|m| m.content.as_str())
+                .collect::<Vec<_>>(),
+            vec!["oldest", "middle", "newest"]
+        );
+    }
+
+    #[test]
+    fn repeated_pagination_cursor_returns_error_instead_of_looping() {
+        let (connection, thread) = server_with_headers(vec![
+            (
+                "/session/ses_test/message?limit=20",
+                200,
+                "[]".into(),
+                "X-Next-Cursor: same\r\n",
+            ),
+            (
+                "/session/ses_test/message?limit=20&before=same",
+                200,
+                "[]".into(),
+                "X-Next-Cursor: same\r\n",
+            ),
+        ]);
+        let error =
+            read_conversation(&connection, &client().unwrap(), "ses_test", false).unwrap_err();
+        thread.join().unwrap();
+        assert!(error.contains("repeated"));
+    }
+
+    #[test]
+    fn rejects_credential_urls_and_non_http_schemes() {
+        for raw in [
+            "file:///tmp/data",
+            "http://user:secret@localhost:4096",
+            "http://localhost/?secret=1",
+            "http://localhost/#fragment",
+        ] {
+            assert!(Connection::parse(raw, "opencode".into(), None).is_err());
+        }
+        assert!(Connection::parse("http://127.0.0.1:4096", "opencode".into(), None).is_ok());
+    }
+}

--- a/src-tauri/src/session/opencode.rs
+++ b/src-tauri/src/session/opencode.rs
@@ -11,11 +11,40 @@ use serde::{Deserialize, Serialize};
 use serde_json::Value;
 use std::collections::{BTreeSet, HashMap, HashSet};
 use std::io::Read;
+use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Arc, LazyLock, Mutex};
-use std::time::Duration;
+use std::time::{Duration, Instant};
 
 const MAX_RESPONSE: u64 = 8 * 1024 * 1024;
+const MAX_CONVERSATION_BYTES: u64 = 32 * 1024 * 1024;
+const MAX_CONVERSATION_MESSAGES: usize = 10_000;
+const MAX_PAGES: usize = 128;
+const MAX_SESSIONS: usize = 512;
+const MAX_DIRECTORIES: usize = 32;
 const IDLE_FRESHNESS_MS: i64 = 30 * 60 * 1000;
+
+/// Shared by every request in an operation, including oversized-page retries.
+struct Budget {
+    deadline: Instant,
+    remaining: u64,
+}
+
+impl Budget {
+    fn new(seconds: u64, bytes: u64) -> Self {
+        Self {
+            deadline: Instant::now() + Duration::from_secs(seconds),
+            remaining: bytes,
+        }
+    }
+
+    fn timeout(&self) -> Result<Duration, String> {
+        self.deadline
+            .checked_duration_since(Instant::now())
+            .filter(|duration| !duration.is_zero())
+            .map(|duration| duration.min(Duration::from_secs(3)))
+            .ok_or_else(|| "OpenCode operation timed out".into())
+    }
+}
 
 #[derive(Clone, Debug)]
 pub struct OpenCodeSummary {
@@ -29,6 +58,7 @@ struct Connection {
     url: reqwest::Url,
     username: String,
     password: Option<String>,
+    cancelled: Arc<AtomicBool>,
 }
 
 impl Connection {
@@ -61,23 +91,26 @@ impl Connection {
             url,
             username,
             password,
+            cancelled: Arc::new(AtomicBool::new(false)),
         })
     }
 
-    fn get<T: serde::de::DeserializeOwned>(
-        &self,
-        client: &Client,
-        segments: &[&str],
-    ) -> Result<T, String> {
-        self.get_page(client, segments, &[]).map(|(value, _)| value)
+    fn check_active(&self) -> Result<(), String> {
+        if self.cancelled.load(Ordering::Acquire) {
+            Err("OpenCode connection changed or disconnected".into())
+        } else {
+            Ok(())
+        }
     }
 
-    fn get_page<T: serde::de::DeserializeOwned>(
+    fn get_page_bounded<T: serde::de::DeserializeOwned>(
         &self,
         client: &Client,
         segments: &[&str],
         query: &[(&str, &str)],
+        budget: &mut Budget,
     ) -> Result<(T, Option<String>), String> {
+        self.check_active()?;
         let mut url = self.url.clone();
         url.path_segments_mut()
             .map_err(|_| "Invalid OpenCode URL")?
@@ -86,13 +119,14 @@ impl Connection {
         if !query.is_empty() {
             url.query_pairs_mut().extend_pairs(query.iter().copied());
         }
-        let mut request = client.get(url);
+        let mut request = client.get(url).timeout(budget.timeout()?);
         if let Some(password) = &self.password {
             request = request.basic_auth(&self.username, Some(password));
         }
         let response = request
             .send()
             .map_err(|_| "OpenCode connection failed or timed out")?;
+        self.check_active()?;
         if !response.status().is_success() {
             return Err(format!("OpenCode HTTP {}", response.status().as_u16()));
         }
@@ -102,11 +136,24 @@ impl Connection {
             .map(|v| v.to_str().map(str::to_owned))
             .transpose()
             .map_err(|_| "Invalid OpenCode pagination cursor")?;
+        if next_cursor
+            .as_ref()
+            .is_some_and(|cursor| cursor.len() > 4096)
+        {
+            return Err("OpenCode pagination cursor exceeds 4096 bytes".into());
+        }
         let mut bytes = Vec::new();
+        let allowed = MAX_RESPONSE.min(budget.remaining);
         response
-            .take(MAX_RESPONSE + 1)
+            .take(allowed + 1)
             .read_to_end(&mut bytes)
             .map_err(|_| "OpenCode response read failed")?;
+        self.check_active()?;
+        budget.timeout()?;
+        if bytes.len() as u64 > budget.remaining {
+            return Err("OpenCode operation exceeds total response byte limit".into());
+        }
+        budget.remaining -= bytes.len() as u64;
         if bytes.len() as u64 > MAX_RESPONSE {
             return Err("OpenCode response exceeds 8 MiB".into());
         }
@@ -120,12 +167,14 @@ fn client() -> Result<Client, String> {
     Client::builder()
         .timeout(Duration::from_secs(3))
         .redirect(reqwest::redirect::Policy::none())
+        .pool_max_idle_per_host(1)
+        .pool_idle_timeout(Duration::from_secs(5))
         .no_proxy()
         .build()
         .map_err(|_| "Could not initialize OpenCode HTTP client".into())
 }
 
-#[derive(Deserialize)]
+#[derive(Clone, Deserialize)]
 struct RemoteSession {
     id: String,
     directory: String,
@@ -135,7 +184,7 @@ struct RemoteSession {
     time: RemoteTime,
 }
 
-#[derive(Deserialize)]
+#[derive(Clone, Deserialize)]
 struct RemoteTime {
     created: i64,
     updated: i64,
@@ -154,8 +203,61 @@ fn timestamp(ms: i64) -> String {
         .unwrap_or_default()
 }
 
+// Keep the shared provider identity opaque. Directory is encoded in OpenCode's
+// local ID only; HTTP paths always use the original remote ID.
+fn scoped_id(id: &str, directory: &str) -> String {
+    let mut url = reqwest::Url::parse("http://identity/").unwrap();
+    url.query_pairs_mut().append_pair("directory", directory);
+    format!("{}?{}", id, url.query().unwrap())
+}
+
+fn split_id(id: &str) -> Result<(&str, Option<String>), String> {
+    let Some((raw, query)) = id.split_once('?') else {
+        return Ok((id, None));
+    };
+    let url = reqwest::Url::parse(&format!("http://identity/?{query}"))
+        .map_err(|_| "Invalid OpenCode session identity")?;
+    let pairs: Vec<_> = url.query_pairs().collect();
+    if raw.is_empty() || pairs.len() != 1 || pairs[0].0 != "directory" || pairs[0].1.is_empty() {
+        return Err("Invalid OpenCode session identity".into());
+    }
+    Ok((raw, Some(pairs[0].1.to_string())))
+}
+
+pub(crate) fn is_full_session_reference(id: &str) -> bool {
+    split_id(id).is_ok_and(|(raw, _)| {
+        raw.len() >= 30
+            && raw.starts_with("ses_")
+            && raw[4..].bytes().all(|b| b.is_ascii_alphanumeric())
+    })
+}
+
+pub(crate) fn matches_session_reference(scoped: &str, requested: &str) -> bool {
+    scoped == requested
+        || (split_id(requested).is_ok_and(|(_, directory)| directory.is_none())
+            && split_id(scoped).is_ok_and(|(raw, _)| raw == requested))
+}
+
+#[derive(Deserialize)]
+struct Health {
+    healthy: bool,
+    version: String,
+}
+
 fn snapshot(connection: &Connection, client: &Client) -> Result<Vec<DetectedSession>, String> {
-    let sessions: Vec<RemoteSession> = connection.get(client, &["session"])?;
+    let mut budget = Budget::new(10, 16 * 1024 * 1024);
+    let (health, _): (Health, _) =
+        connection.get_page_bounded(client, &["global", "health"], &[], &mut budget)?;
+    if !health.healthy || health.version.is_empty() {
+        return Err("OpenCode server is unhealthy".into());
+    }
+    // Ask for one beyond the bound so a server-side cap cannot silently look complete.
+    let limit = (MAX_SESSIONS + 1).to_string();
+    let (sessions, _): (Vec<RemoteSession>, _) =
+        connection.get_page_bounded(client, &["session"], &[("limit", &limit)], &mut budget)?;
+    if sessions.len() > MAX_SESSIONS {
+        return Err("OpenCode discovery exceeds 512 sessions".into());
+    }
     // Status is directory-scoped even though the session list spans the project.
     let mut statuses_by_directory = HashMap::new();
     for directory in sessions
@@ -164,8 +266,15 @@ fn snapshot(connection: &Connection, client: &Client) -> Result<Vec<DetectedSess
         .map(|s| s.directory.as_str())
         .collect::<BTreeSet<_>>()
     {
-        let (statuses, _): (HashMap<String, RemoteStatus>, _) =
-            connection.get_page(client, &["session", "status"], &[("directory", directory)])?;
+        if statuses_by_directory.len() >= MAX_DIRECTORIES {
+            return Err("OpenCode discovery exceeds 32 directories".into());
+        }
+        let (statuses, _): (HashMap<String, RemoteStatus>, _) = connection.get_page_bounded(
+            client,
+            &["session", "status"],
+            &[("directory", directory)],
+            &mut budget,
+        )?;
         statuses_by_directory.insert(directory.to_owned(), statuses);
     }
     Ok(sessions
@@ -186,7 +295,7 @@ fn snapshot(connection: &Connection, client: &Client) -> Result<Vec<DetectedSess
                 0,
                 s.directory.clone().into(),
                 s.directory.clone().into(),
-                Some(s.id.clone()),
+                Some(scoped_id(&s.id, &s.directory)),
                 s.title.clone(),
             );
             detected.provider = SessionProvider::Opencode;
@@ -198,7 +307,7 @@ fn snapshot(connection: &Connection, client: &Client) -> Result<Vec<DetectedSess
             } else {
                 AgentKind::Root
             };
-            detected.parent_thread_id = s.parent_id;
+            detected.parent_thread_id = s.parent_id.map(|id| scoped_id(&id, &s.directory));
             detected.can_open = false;
             detected.can_stop = false;
             detected.can_rename = false;
@@ -292,11 +401,18 @@ pub fn opencode_connect(
     };
     {
         let mut cache = CACHE.lock().unwrap_or_else(|e| e.into_inner());
+        if let Some(old) = &cache.connection {
+            old.cancelled.store(true, Ordering::Release);
+        }
         cache.connection = connection;
         cache.generation += 1;
         cache.sessions.clear();
         cache.error = None;
         cache.connected = false;
+    }
+    // Never wait for an old load while handling disconnect on the UI thread.
+    if let Ok(mut reader) = CONVERSATION_READER.try_lock() {
+        reader.cached = None;
     }
     detect();
     Ok(())
@@ -324,15 +440,23 @@ pub(crate) fn detect() -> Vec<DetectedSession> {
                     let result = snapshot(&connection, &client);
                     let mut cache = shared.lock().unwrap_or_else(|e| e.into_inner());
                     // A response from an old endpoint must never populate a new connection.
-                    if cache.generation == generation {
-                        apply_result(&mut cache, result);
-                    }
+                    apply_generation_result(&mut cache, generation, result);
                 }
                 std::thread::sleep(Duration::from_secs(2));
             }
         });
     }
     cache.sessions.clone()
+}
+
+fn apply_generation_result(
+    cache: &mut Cache,
+    generation: u64,
+    result: Result<Vec<DetectedSession>, String>,
+) {
+    if cache.generation == generation {
+        apply_result(cache, result);
+    }
 }
 
 fn apply_result(cache: &mut Cache, result: Result<Vec<DetectedSession>, String>) {
@@ -372,36 +496,228 @@ pub(crate) fn detect_once() -> Vec<DetectedSession> {
 }
 
 pub(crate) fn conversation(id: &str, include_tools: bool) -> Result<Conversation, String> {
-    let connection = CACHE
-        .lock()
-        .unwrap_or_else(|e| e.into_inner())
-        .connection
-        .clone()
-        .ok_or("OpenCode is not configured")?;
-    read_conversation(&connection, &client()?, id, include_tools)
+    let connection = {
+        let cache = CACHE.lock().unwrap_or_else(|e| e.into_inner());
+        if split_id(id)?.1.is_none() {
+            let matches = cache
+                .sessions
+                .iter()
+                .filter(|s| {
+                    s.session_id
+                        .as_deref()
+                        .is_some_and(|key| matches_session_reference(key, id))
+                })
+                .count();
+            if matches > 1 {
+                return Err(
+                    "OpenCode session ID is ambiguous across directories; use the scoped ID".into(),
+                );
+            }
+        }
+        cache
+            .connection
+            .clone()
+            .ok_or("OpenCode is not configured")?
+    };
+    // Fail fast instead of queueing blocking threads during retries/window churn.
+    let mut reader = CONVERSATION_READER
+        .try_lock()
+        .map_err(|_| "OpenCode conversation load already in progress; retry shortly")?;
+    reader.load(&connection, id, include_tools)
 }
 
+#[derive(Default)]
+struct ConversationReader {
+    client: Option<Client>,
+    cached: Option<CachedConversation>,
+}
+
+struct CachedConversation {
+    connection: Arc<AtomicBool>,
+    include_tools: bool,
+    loaded: Instant,
+    value: Conversation,
+}
+
+static CONVERSATION_READER: LazyLock<Mutex<ConversationReader>> =
+    LazyLock::new(|| Mutex::new(ConversationReader::default()));
+
+impl ConversationReader {
+    fn load(
+        &mut self,
+        connection: &Connection,
+        id: &str,
+        include_tools: bool,
+    ) -> Result<Conversation, String> {
+        connection.check_active()?;
+        if let Some(cached) = &self.cached {
+            if Arc::ptr_eq(&cached.connection, &connection.cancelled)
+                && cached.value.session_id == id
+                && cached.include_tools == include_tools
+                && cached.loaded.elapsed() < Duration::from_secs(1)
+            {
+                return Ok(cached.value.clone());
+            }
+        }
+        self.cached = None;
+        if self.client.is_none() {
+            self.client = Some(client()?);
+        }
+        let client = self.client.as_ref().unwrap();
+        let mut budget = Budget::new(60, MAX_CONVERSATION_BYTES);
+        let detail = session_detail(connection, client, id, &mut budget)?;
+        let address = scoped_id(&detail.id, &detail.directory);
+        let mut value =
+            read_conversation_bounded(connection, client, &address, include_tools, &mut budget)?;
+        value.session_id = id.into();
+        connection.check_active()?;
+        self.cached = Some(CachedConversation {
+            connection: Arc::clone(&connection.cancelled),
+            include_tools,
+            loaded: Instant::now(),
+            value: value.clone(),
+        });
+        Ok(value)
+    }
+}
+
+fn session_detail(
+    connection: &Connection,
+    client: &Client,
+    id: &str,
+    budget: &mut Budget,
+) -> Result<RemoteSession, String> {
+    let (raw, directory) = split_id(id)?;
+    let query: Vec<_> = directory
+        .as_deref()
+        .map(|dir| ("directory", dir))
+        .into_iter()
+        .collect();
+    let (detail, _): (RemoteSession, _) =
+        connection.get_page_bounded(client, &["session", raw], &query, budget)?;
+    if detail.id != raw
+        || directory
+            .as_ref()
+            .is_some_and(|dir| dir != &detail.directory)
+    {
+        return Err("OpenCode session detail does not match requested identity".into());
+    }
+    if detail.time.archived.is_some() {
+        return Err("OpenCode session is archived".into());
+    }
+    Ok(detail)
+}
+
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct OpenCodeChild {
+    session_id: String,
+    parent_thread_id: String,
+    directory: String,
+    title: String,
+}
+
+/// On-demand hierarchy reads share the same fail-fast HTTP gate as conversations.
+#[cfg(feature = "gui")]
+#[tauri::command]
+pub async fn opencode_session_children(session_id: String) -> Result<Vec<OpenCodeChild>, String> {
+    tauri::async_runtime::spawn_blocking(move || {
+        let connection = CACHE
+            .lock()
+            .unwrap_or_else(|e| e.into_inner())
+            .connection
+            .clone()
+            .ok_or("OpenCode is not configured")?;
+        let _guard = CONVERSATION_READER
+            .try_lock()
+            .map_err(|_| "OpenCode load already in progress; retry shortly")?;
+        read_children(&connection, &client()?, &session_id)
+    })
+    .await
+    .map_err(|e| e.to_string())?
+}
+
+#[cfg(any(feature = "gui", test))]
+fn read_children(
+    connection: &Connection,
+    client: &Client,
+    id: &str,
+) -> Result<Vec<OpenCodeChild>, String> {
+    let mut budget = Budget::new(10, MAX_RESPONSE);
+    let parent = session_detail(connection, client, id, &mut budget)?;
+    let (children, _): (Vec<RemoteSession>, _) = connection.get_page_bounded(
+        client,
+        &["session", &parent.id, "children"],
+        &[("directory", &parent.directory)],
+        &mut budget,
+    )?;
+    if children.len() > MAX_SESSIONS {
+        return Err("OpenCode children exceed 512 sessions".into());
+    }
+    children
+        .into_iter()
+        .map(|child| {
+            if child.directory != parent.directory || child.parent_id.as_deref() != Some(&parent.id)
+            {
+                return Err("OpenCode child does not match requested parent/directory".into());
+            }
+            Ok(OpenCodeChild {
+                session_id: scoped_id(&child.id, &child.directory),
+                parent_thread_id: scoped_id(&parent.id, &parent.directory),
+                directory: child.directory,
+                title: child.title,
+            })
+        })
+        .collect()
+}
+
+#[cfg(test)]
 fn read_conversation(
     connection: &Connection,
     client: &Client,
     id: &str,
     include_tools: bool,
 ) -> Result<Conversation, String> {
+    read_conversation_bounded(
+        connection,
+        client,
+        id,
+        include_tools,
+        &mut Budget::new(60, MAX_CONVERSATION_BYTES),
+    )
+}
+
+fn read_conversation_bounded(
+    connection: &Connection,
+    client: &Client,
+    id: &str,
+    include_tools: bool,
+    budget: &mut Budget,
+) -> Result<Conversation, String> {
+    let (raw, directory) = split_id(id)?;
     let mut pages = Vec::new();
     let mut before: Option<String> = None;
     let mut cursors = HashSet::new();
     let mut limit = 20usize;
-    let started = std::time::Instant::now();
+    let mut message_count = 0;
     loop {
-        if pages.len() >= 1000 || started.elapsed() > Duration::from_secs(60) {
-            return Err("OpenCode conversation is too large to load in one minute".into());
+        if pages.len() >= MAX_PAGES {
+            return Err("OpenCode conversation exceeds 128 pages".into());
         }
         let limit_text = limit.to_string();
         let mut query = vec![("limit", limit_text.as_str())];
         if let Some(cursor) = &before {
             query.push(("before", cursor.as_str()));
         }
-        let result = connection.get_page::<Vec<Value>>(client, &["session", id, "message"], &query);
+        if let Some(directory) = &directory {
+            query.push(("directory", directory.as_str()));
+        }
+        let result = connection.get_page_bounded::<Vec<Value>>(
+            client,
+            &["session", raw, "message"],
+            &query,
+            budget,
+        );
         let (rows, next) = match result {
             Err(error) if error == "OpenCode response exceeds 8 MiB" && limit > 1 => {
                 limit = (limit / 2).max(1);
@@ -409,7 +725,15 @@ fn read_conversation(
             }
             other => other?,
         };
-        pages.push(parse_conversation(id, rows, include_tools)?.messages);
+        if rows.len() > limit {
+            return Err("OpenCode server ignored message page limit".into());
+        }
+        let messages = parse_conversation(id, rows, include_tools)?.messages;
+        message_count += messages.len();
+        if message_count > MAX_CONVERSATION_MESSAGES {
+            return Err("OpenCode conversation exceeds 10000 rendered messages".into());
+        }
+        pages.push(messages);
         match next {
             Some(cursor) if !cursor.is_empty() && cursors.insert(cursor.clone()) => {
                 before = Some(cursor)
@@ -436,7 +760,14 @@ fn parse_conversation(
         let role = row["info"]["role"]
             .as_str()
             .ok_or("Malformed OpenCode message role")?;
-        let time = timestamp(row["info"]["time"]["created"].as_i64().unwrap_or_default());
+        if !matches!(role, "user" | "assistant") {
+            return Err("Malformed OpenCode message role".into());
+        }
+        let time = timestamp(
+            row["info"]["time"]["created"]
+                .as_i64()
+                .ok_or("Malformed OpenCode message timestamp")?,
+        );
         let parts = row["parts"]
             .as_array()
             .ok_or("Malformed OpenCode message parts")?;
@@ -448,7 +779,10 @@ fn parse_conversation(
                     } else {
                         MessageType::Assistant
                     },
-                    part["text"].as_str().unwrap_or_default().to_owned(),
+                    part["text"]
+                        .as_str()
+                        .ok_or("Malformed OpenCode message text")?
+                        .to_owned(),
                 ),
                 Some("tool") if include_tools => (
                     MessageType::ToolResult,
@@ -479,6 +813,14 @@ fn parse_conversation(
 }
 
 #[cfg(test)]
+#[path = "opencode_regression.rs"]
+mod regression;
+
+#[cfg(test)]
+#[path = "opencode_perf.rs"]
+mod perf;
+
+#[cfg(test)]
 mod tests {
     use super::*;
     use serde_json::json;
@@ -495,8 +837,23 @@ mod tests {
     }
 
     fn server_with_headers(
-        responses: Vec<(&str, u16, String, &str)>,
+        mut responses: Vec<(&str, u16, String, &str)>,
     ) -> (Connection, std::thread::JoinHandle<()>) {
+        if responses
+            .first()
+            .is_some_and(|(path, _, _, _)| *path == "/session")
+        {
+            responses[0].0 = "/session?limit=513";
+            responses.insert(
+                0,
+                (
+                    "/global/health",
+                    200,
+                    r#"{"healthy":true,"version":"fixture"}"#.into(),
+                    "",
+                ),
+            );
+        }
         let listener = TcpListener::bind("127.0.0.1:0").unwrap();
         let connection = Connection::parse(
             &format!("http://{}", listener.local_addr().unwrap()),
@@ -555,7 +912,10 @@ mod tests {
         let sessions = snapshot(&connection, &client().unwrap()).unwrap();
         thread.join().unwrap();
         assert_eq!(sessions.len(), 4);
-        assert_eq!(sessions[0].identity_key().as_deref(), Some("opencode:busy"));
+        assert_eq!(
+            sessions[0].identity_key().as_deref(),
+            Some("opencode:busy?directory=%2Fsynthetic%2Fproject")
+        );
         assert_eq!(
             sessions[0].opencode_summary.as_ref().unwrap().status,
             SessionStatus::Working
@@ -572,7 +932,10 @@ mod tests {
             sessions[3].opencode_summary.as_ref().unwrap().status,
             SessionStatus::Connecting
         );
-        assert_eq!(sessions[2].parent_thread_id.as_deref(), Some("busy"));
+        assert_eq!(
+            sessions[2].parent_thread_id.as_deref(),
+            Some("busy?directory=%2Fsynthetic%2Fproject")
+        );
         assert!(sessions
             .iter()
             .all(|s| s.pid == 0 && !s.can_open && !s.can_stop && !s.can_rename));

--- a/src-tauri/src/session/opencode_perf.rs
+++ b/src-tauri/src/session/opencode_perf.rs
@@ -1,0 +1,105 @@
+//! Identical harness can be added to the PR baseline without changing its loader.
+use super::*;
+use std::io::{BufRead, BufReader, Write};
+use std::net::TcpListener;
+use std::time::Instant;
+
+#[test]
+#[ignore = "explicit loopback performance run; reports measurements, not a CI timing gate"]
+fn benchmark_opencode_conversation() {
+    for (name, count, text_bytes) in [("small", 24usize, 128usize), ("large", 1200, 8192)] {
+        let rows: Vec<_> = (0..count)
+            .map(|i| {
+                serde_json::json!({
+                    "info":{"role":"assistant","time":{"created":i as i64 + 1}},
+                    "parts":[{"type":"text","text":format!("{i:05} {}", "x".repeat(text_bytes))}]
+                })
+            })
+            .collect();
+        let pages: Vec<String> = rows
+            .chunks(20)
+            .rev()
+            .map(|chunk| serde_json::to_string(chunk).unwrap())
+            .collect();
+        let page_count = pages.len();
+        let wire_bytes: usize = pages.iter().map(String::len).sum();
+        let listener = TcpListener::bind("127.0.0.1:0").unwrap();
+        let connection = Connection::parse(
+            &format!("http://{}", listener.local_addr().unwrap()),
+            "opencode".into(),
+            None,
+        )
+        .unwrap();
+        let iterations = 11;
+        let server = std::thread::spawn(move || {
+            for _ in 0..iterations {
+                for (index, body) in pages.iter().enumerate() {
+                    let (mut socket, _) = listener.accept().unwrap();
+                    socket
+                        .set_read_timeout(Some(Duration::from_secs(5)))
+                        .unwrap();
+                    socket
+                        .set_write_timeout(Some(Duration::from_secs(5)))
+                        .unwrap();
+                    let mut reader = BufReader::new(socket.try_clone().unwrap());
+                    loop {
+                        let mut line = String::new();
+                        reader.read_line(&mut line).unwrap();
+                        if line == "\r\n" {
+                            break;
+                        }
+                    }
+                    let cursor = if index + 1 < pages.len() {
+                        format!("X-Next-Cursor: page{}\r\n", index + 1)
+                    } else {
+                        String::new()
+                    };
+                    write!(
+                        socket,
+                        "HTTP/1.1 200 OK\r\nContent-Length: {}\r\nConnection: close\r\n{}\r\n{}",
+                        body.len(),
+                        cursor,
+                        body
+                    )
+                    .unwrap();
+                }
+            }
+        });
+        let cold_start = Instant::now();
+        let client = client().unwrap();
+        let mut times = Vec::new();
+        let mut serialized_bytes = 0;
+        for i in 0..iterations {
+            let start = if i == 0 { cold_start } else { Instant::now() };
+            let conversation = read_conversation(&connection, &client, "perf", false).unwrap();
+            assert_eq!(conversation.messages.len(), count);
+            assert!(conversation
+                .messages
+                .first()
+                .unwrap()
+                .content
+                .starts_with("00000"));
+            assert!(conversation
+                .messages
+                .last()
+                .unwrap()
+                .content
+                .starts_with(&format!("{:05}", count - 1)));
+            // Include serialization because GUI/WS transfer the full response.
+            serialized_bytes = serde_json::to_vec(&conversation).unwrap().len();
+            times.push(start.elapsed().as_secs_f64() * 1000.0);
+        }
+        server.join().unwrap();
+        let cold = times.remove(0);
+        times.sort_by(f64::total_cmp);
+        println!(
+            "OPENCODE_PERF {}",
+            serde_json::json!({
+                "case":name,"messages":count,"pages":page_count,"wire_bytes":wire_bytes,
+                "serialized_bytes":serialized_bytes,"cold_ms":cold,"repeat_median_ms":times[times.len()/2],
+                "repeat_p95_ms":times[times.len()-1],"repeats":times.len(),"http_requests":page_count * iterations,
+                "cache":"bypassed; every repeat rereads every HTTP page"
+            })
+        );
+    }
+}

--- a/src-tauri/src/session/opencode_regression.rs
+++ b/src-tauri/src/session/opencode_regression.rs
@@ -1,0 +1,606 @@
+//! Real loopback HTTP fixtures; no user transcripts or external endpoints.
+use super::*;
+use serde_json::json;
+use std::io::{BufRead, BufReader, Write};
+use std::net::TcpListener;
+use std::sync::atomic::AtomicUsize;
+use std::thread;
+
+struct Reply {
+    code: u16,
+    body: String,
+    headers: String,
+    delay: Duration,
+    chunked: bool,
+}
+
+impl Reply {
+    fn json(value: Value) -> Self {
+        Self::body(value.to_string())
+    }
+    fn body(body: String) -> Self {
+        Self {
+            code: 200,
+            body,
+            headers: String::new(),
+            delay: Duration::ZERO,
+            chunked: false,
+        }
+    }
+}
+
+struct Fixture {
+    connection: Connection,
+    requests: Arc<Mutex<Vec<String>>>,
+    active: Arc<AtomicUsize>,
+    peak: Arc<AtomicUsize>,
+    stop: Arc<AtomicBool>,
+    server: Option<thread::JoinHandle<()>>,
+}
+
+impl Fixture {
+    fn new(handler: impl Fn(&str) -> Reply + Send + Sync + 'static) -> Self {
+        let listener = TcpListener::bind("127.0.0.1:0").unwrap();
+        listener.set_nonblocking(true).unwrap();
+        let connection = Connection::parse(
+            &format!("http://{}", listener.local_addr().unwrap()),
+            "opencode".into(),
+            None,
+        )
+        .unwrap();
+        let stop = Arc::new(AtomicBool::new(false));
+        let requests = Arc::new(Mutex::new(Vec::new()));
+        let active = Arc::new(AtomicUsize::new(0));
+        let peak = Arc::new(AtomicUsize::new(0));
+        let (server_stop, seen, count, maximum) =
+            (stop.clone(), requests.clone(), active.clone(), peak.clone());
+        let handler = Arc::new(handler);
+        let server = thread::spawn(move || {
+            let mut jobs = Vec::new();
+            while !server_stop.load(Ordering::Acquire) {
+                let Ok((mut socket, _)) = listener.accept() else {
+                    thread::sleep(Duration::from_millis(1));
+                    continue;
+                };
+                let (seen, handler, count, maximum) = (
+                    seen.clone(),
+                    handler.clone(),
+                    count.clone(),
+                    maximum.clone(),
+                );
+                jobs.push(thread::spawn(move || {
+                    socket.set_nonblocking(false).unwrap();
+                    socket.set_read_timeout(Some(Duration::from_secs(2))).unwrap();
+                    socket.set_write_timeout(Some(Duration::from_secs(2))).unwrap();
+                    let mut reader = BufReader::new(socket.try_clone().unwrap());
+                    let mut line = String::new();
+                    if reader.read_line(&mut line).unwrap_or(0) == 0 { return; }
+                    let path = line.split_whitespace().nth(1).unwrap().to_string();
+                    loop {
+                        line.clear();
+                        if reader.read_line(&mut line).unwrap_or(0) == 0 || line == "\r\n" { break; }
+                    }
+                    seen.lock().unwrap().push(path.clone());
+                    let n = count.fetch_add(1, Ordering::AcqRel) + 1;
+                    maximum.fetch_max(n, Ordering::AcqRel);
+                    let reply = handler(&path);
+                    thread::sleep(reply.delay);
+                    if reply.chunked {
+                        let _ = write!(socket, "HTTP/1.1 {} Test\r\nTransfer-Encoding: chunked\r\nConnection: close\r\n{}\r\n{:X}\r\n{}\r\n0\r\n\r\n", reply.code, reply.headers, reply.body.len(), reply.body);
+                    } else {
+                        let _ = write!(socket, "HTTP/1.1 {} Test\r\nContent-Length: {}\r\nConnection: close\r\n{}\r\n{}", reply.code, reply.body.len(), reply.headers, reply.body);
+                    }
+                    count.fetch_sub(1, Ordering::AcqRel);
+                }));
+            }
+            for job in jobs {
+                job.join().unwrap();
+            }
+        });
+        Self {
+            connection,
+            requests,
+            active,
+            peak,
+            stop,
+            server: Some(server),
+        }
+    }
+}
+
+impl Drop for Fixture {
+    fn drop(&mut self) {
+        self.stop.store(true, Ordering::Release);
+        self.server.take().unwrap().join().unwrap();
+        assert_eq!(self.active.load(Ordering::Acquire), 0);
+    }
+}
+
+fn remote(id: &str, directory: &str) -> Value {
+    json!({"id":id,"directory":directory,"title":id,"time":{"created":1,"updated":chrono::Utc::now().timestamp_millis()}})
+}
+
+fn message(text: &str, created: i64) -> Value {
+    json!({"info":{"role":"assistant","time":{"created":created}},"parts":[{"type":"text","text":text}]})
+}
+
+#[test]
+fn identical_remote_ids_in_two_directories_survive_enrichment_and_reads_are_scoped() {
+    let fixture = Fixture::new(|path| match path {
+        "/global/health" => Reply::json(json!({"healthy":true,"version":"fixture"})),
+        "/session?limit=513" => Reply::json(json!([remote("same", "/a"), remote("same", "/中文")])),
+        "/session/status?directory=%2Fa" => Reply::json(json!({"same":{"type":"busy"}})),
+        "/session/status?directory=%2F%E4%B8%AD%E6%96%87" => Reply::json(json!({})),
+        "/session/same?directory=%2Fa" => Reply::json(remote("same", "/a")),
+        "/session/same/message?limit=20&directory=%2Fa" => {
+            Reply::json(json!([message("English A", 1)]))
+        }
+        "/session/same?directory=%2F%E4%B8%AD%E6%96%87" => Reply::json(remote("same", "/中文")),
+        "/session/same/message?limit=20&directory=%2F%E4%B8%AD%E6%96%87" => {
+            Reply::json(json!([message("中文 B", 2)]))
+        }
+        _ => panic!("unexpected {path}"),
+    });
+    let detected = snapshot(&fixture.connection, &client().unwrap()).unwrap();
+    let sessions = super::super::enrichment::enrich_detected_sessions(detected, Default::default())
+        .unwrap()
+        .0;
+    assert_eq!(sessions.len(), 2);
+    assert_ne!(sessions[0].session_key, sessions[1].session_key);
+    assert_eq!(sessions[0].status, SessionStatus::Working);
+    assert_eq!(sessions[1].status, SessionStatus::WaitingForInput);
+    let mut reader = ConversationReader::default();
+    for (s, text) in sessions.iter().zip(["English A", "中文 B"]) {
+        let conv = reader.load(&fixture.connection, &s.id, false).unwrap();
+        assert_eq!(conv.session_id, s.id);
+        assert_eq!(conv.messages[0].content, text);
+    }
+}
+
+#[test]
+fn detail_children_deleted_archived_and_wrong_directory_are_validated() {
+    let fixture = Fixture::new(|path| {
+        if path == "/session/root/children?directory=%2Fa" {
+            let mut child = remote("child", "/a");
+            child["parentID"] = json!("root");
+            return Reply::json(json!([child]));
+        }
+        if path.contains("missing") {
+            let mut reply = Reply::body("private body".into());
+            reply.code = 404;
+            return reply;
+        }
+        let mut detail = remote(
+            if path.contains("archived") {
+                "archived"
+            } else {
+                "root"
+            },
+            "/a",
+        );
+        if path.contains("archived") {
+            detail["time"]["archived"] = json!(123);
+        }
+        Reply::json(detail)
+    });
+    let children = read_children(
+        &fixture.connection,
+        &client().unwrap(),
+        &scoped_id("root", "/a"),
+    )
+    .unwrap();
+    assert_eq!(children[0].parent_thread_id, scoped_id("root", "/a"));
+    assert_eq!(children[0].session_id, scoped_id("child", "/a"));
+    let mut reader = ConversationReader::default();
+    for (id, expected) in [
+        ("missing", "404"),
+        ("archived", "archived"),
+        ("root?directory=%2Fb", "identity"),
+    ] {
+        assert!(reader
+            .load(&fixture.connection, id, false)
+            .unwrap_err()
+            .contains(expected));
+    }
+}
+
+#[test]
+fn health_auth_server_malformed_and_recovery_replace_or_retain_snapshot() {
+    let mode = Arc::new(AtomicUsize::new(0));
+    let state = mode.clone();
+    let fixture = Fixture::new(move |path| {
+        if path == "/global/health" {
+            let mode = state.load(Ordering::Acquire);
+            if mode == 6 {
+                return Reply::body("not json".into());
+            }
+            if mode == 7 {
+                return Reply::json(json!({"healthy":false,"version":"fixture"}));
+            }
+            if mode > 0 && mode < 6 {
+                let mut r = Reply::body("secret diagnostics".into());
+                r.code = [0, 401, 403, 404, 500, 503][mode];
+                return r;
+            }
+            return Reply::json(json!({"healthy":true,"version":"fixture"}));
+        }
+        if path == "/session?limit=513" {
+            return Reply::json(json!([remote("root", "/a")]));
+        }
+        Reply::json(json!({}))
+    });
+    let client = client().unwrap();
+    let mut cache = Cache {
+        started: true,
+        generation: 1,
+        connection: None,
+        sessions: vec![],
+        error: None,
+        connected: false,
+    };
+    apply_result(&mut cache, snapshot(&fixture.connection, &client));
+    assert_eq!(cache.sessions.len(), 1);
+    for mode_value in 1..=7 {
+        mode.store(mode_value, Ordering::Release);
+        apply_result(&mut cache, snapshot(&fixture.connection, &client));
+        assert!(!cache.connected);
+        assert_eq!(cache.sessions.len(), 1);
+        assert_eq!(
+            cache.sessions[0].opencode_summary.as_ref().unwrap().status,
+            SessionStatus::Connecting
+        );
+        assert!(!cache.error.as_ref().unwrap().contains("secret"));
+        mode.store(0, Ordering::Release);
+        apply_result(&mut cache, snapshot(&fixture.connection, &client));
+        assert!(cache.connected && cache.error.is_none());
+    }
+    apply_generation_result(&mut cache, 0, Ok(vec![]));
+    assert_eq!(
+        cache.sessions.len(),
+        1,
+        "late generation cannot clear replacement snapshot"
+    );
+    apply_generation_result(&mut cache, 1, Ok(vec![]));
+    assert!(
+        cache.sessions.is_empty(),
+        "deletion/expiry removes prior snapshot"
+    );
+}
+
+#[test]
+fn bounded_pages_bytes_messages_and_malformed_parts_do_not_silently_truncate() {
+    let fixture = Fixture::new(|_| Reply::json(json!([message(&"a".repeat(256), 1)])));
+    let mut budget = Budget::new(2, 128);
+    assert!(read_conversation_bounded(
+        &fixture.connection,
+        &client().unwrap(),
+        "root",
+        false,
+        &mut budget
+    )
+    .unwrap_err()
+    .contains("total response"));
+    let fixture = Fixture::new(|_| {
+        let mut r = Reply::json(json!([]));
+        r.headers = format!("X-Next-Cursor: {}\r\n", uuid::Uuid::new_v4());
+        r
+    });
+    assert!(
+        read_conversation(&fixture.connection, &client().unwrap(), "root", false)
+            .unwrap_err()
+            .contains("128 pages")
+    );
+    assert_eq!(fixture.requests.lock().unwrap().len(), 128);
+    let fixture =
+        Fixture::new(|_| Reply::json(json!((0..21).map(|_| message("x", 1)).collect::<Vec<_>>())));
+    assert!(
+        read_conversation(&fixture.connection, &client().unwrap(), "root", false)
+            .unwrap_err()
+            .contains("ignored message page limit")
+    );
+    let fixture = Fixture::new(|_| {
+        let mut row = message("x", 1);
+        row["parts"] = json!((0..10_001)
+            .map(|_| json!({"type":"text","text":"x"}))
+            .collect::<Vec<_>>());
+        Reply::json(json!([row]))
+    });
+    assert!(
+        read_conversation(&fixture.connection, &client().unwrap(), "root", false)
+            .unwrap_err()
+            .contains("10000")
+    );
+    assert!(parse_conversation("x", vec![json!({"info":{"role":"assistant","time":{"created":1}},"parts":[{"type":"text","text":123}]})], false).is_err());
+}
+
+#[test]
+fn chunked_oversized_page_shrinks_and_cursor_cycles_are_detected() {
+    let fixture = Fixture::new(|path| {
+        let mut reply = if path.contains("limit=20") {
+            Reply::body(" ".repeat(MAX_RESPONSE as usize + 1))
+        } else {
+            Reply::json(json!([message("small page", 1)]))
+        };
+        reply.chunked = true;
+        reply
+    });
+    let conv = read_conversation(&fixture.connection, &client().unwrap(), "root", false).unwrap();
+    assert_eq!(conv.messages[0].content, "small page");
+    assert_eq!(fixture.requests.lock().unwrap().len(), 2);
+    let fixture = Fixture::new(|path| {
+        let mut reply = Reply::json(json!([]));
+        reply.headers = format!(
+            "X-Next-Cursor: {}\r\n",
+            if path.contains("before=a") { "b" } else { "a" }
+        );
+        reply
+    });
+    assert!(
+        read_conversation(&fixture.connection, &client().unwrap(), "root", false)
+            .unwrap_err()
+            .contains("repeated")
+    );
+    assert_eq!(fixture.requests.lock().unwrap().len(), 3);
+}
+
+#[test]
+fn deadline_and_disconnect_bound_http_work_and_discard_late_data() {
+    let fixture = Fixture::new(|_| {
+        let mut r = Reply::json(json!([]));
+        r.delay = Duration::from_millis(150);
+        r
+    });
+    let start = Instant::now();
+    let mut budget = Budget {
+        deadline: Instant::now() + Duration::from_millis(40),
+        remaining: MAX_RESPONSE,
+    };
+    assert!(read_conversation_bounded(
+        &fixture.connection,
+        &client().unwrap(),
+        "root",
+        false,
+        &mut budget
+    )
+    .is_err());
+    assert!(start.elapsed() < Duration::from_millis(500));
+    let connection = fixture.connection.clone();
+    let job =
+        thread::spawn(move || read_conversation(&connection, &client().unwrap(), "root", false));
+    let wait_start = Instant::now();
+    while fixture.requests.lock().unwrap().len() < 2 {
+        assert!(wait_start.elapsed() < Duration::from_secs(2));
+        thread::sleep(Duration::from_millis(1));
+    }
+    fixture.connection.cancelled.store(true, Ordering::Release);
+    assert!(job.join().unwrap().unwrap_err().contains("disconnected"));
+    let n = fixture.requests.lock().unwrap().len();
+    assert!(read_conversation(&fixture.connection, &client().unwrap(), "root", false).is_err());
+    assert_eq!(
+        fixture.requests.lock().unwrap().len(),
+        n,
+        "disconnect must not start another HTTP request"
+    );
+}
+
+#[test]
+fn cache_is_one_entry_short_lived_connection_scoped_and_fail_fast() {
+    let fixture = Fixture::new(|path| {
+        if path.contains("/message?") {
+            Reply::json(json!([message("cached", 1)]))
+        } else {
+            Reply::json(remote("root", "/a"))
+        }
+    });
+    let reader = Arc::new(Mutex::new(ConversationReader::default()));
+    let mut guard = reader.lock().unwrap();
+    let value = guard.load(&fixture.connection, "root", false).unwrap();
+    for _ in 0..100 {
+        assert_eq!(
+            guard
+                .load(&fixture.connection, "root", false)
+                .unwrap()
+                .messages
+                .len(),
+            value.messages.len()
+        );
+    }
+    assert_eq!(fixture.requests.lock().unwrap().len(), 2);
+    let other = reader.clone();
+    assert!(thread::spawn(move || other.try_lock().is_err())
+        .join()
+        .unwrap());
+    guard.cached.as_mut().unwrap().loaded -= Duration::from_secs(2);
+    guard.load(&fixture.connection, "root", false).unwrap();
+    assert_eq!(fixture.requests.lock().unwrap().len(), 4);
+    fixture.connection.cancelled.store(true, Ordering::Release);
+    assert!(guard.load(&fixture.connection, "root", false).is_err());
+    assert_eq!(fixture.peak.load(Ordering::Acquire), 1);
+}
+
+#[test]
+fn actual_32_mib_total_cap_and_single_8_mib_page_cap_are_enforced() {
+    let page = json!([message(&"x".repeat(5 * 1024 * 1024), 1)]).to_string();
+    let fixture = Fixture::new(move |_| {
+        let mut reply = Reply::body(page.clone());
+        reply.headers = format!("X-Next-Cursor: {}\r\n", uuid::Uuid::new_v4());
+        reply
+    });
+    assert!(
+        read_conversation(&fixture.connection, &client().unwrap(), "root", false)
+            .unwrap_err()
+            .contains("total response")
+    );
+    assert_eq!(fixture.requests.lock().unwrap().len(), 7);
+    let fixture = Fixture::new(|_| Reply::body("x".repeat(MAX_RESPONSE as usize + 1)));
+    let mut budget = Budget::new(3, MAX_RESPONSE + 2);
+    let error = fixture
+        .connection
+        .get_page_bounded::<Value>(
+            &client().unwrap(),
+            &["session", "root", "message"],
+            &[("limit", "1")],
+            &mut budget,
+        )
+        .unwrap_err();
+    assert!(error.contains("exceeds 8 MiB"));
+    assert_eq!(fixture.requests.lock().unwrap().len(), 1);
+}
+
+#[test]
+fn discovery_size_and_directory_fanout_are_bounded() {
+    for directories in [false, true] {
+        let fixture = Fixture::new(move |path| {
+            if path == "/global/health" {
+                return Reply::json(json!({"healthy":true,"version":"fixture"}));
+            }
+            if path == "/session?limit=513" {
+                return Reply::json(json!((0..if directories { 33 } else { 513 })
+                    .map(|i| remote(
+                        &format!("id{i}"),
+                        &format!("/dir{}", if directories { i } else { 0 })
+                    ))
+                    .collect::<Vec<_>>()));
+            }
+            Reply::json(json!({}))
+        });
+        let error = snapshot(&fixture.connection, &client().unwrap()).unwrap_err();
+        assert!(error.contains(if directories {
+            "32 directories"
+        } else {
+            "512 sessions"
+        }));
+        assert!(fixture.requests.lock().unwrap().len() <= 34);
+    }
+}
+
+#[test]
+fn scoped_ids_keep_legacy_collision_guards_and_direct_cli_references() {
+    let id = "ses_f835ea1f8ffelnS2uzHgkM9qUq";
+    let scoped = scoped_id(id, "/中文?folder&space value");
+    assert!(is_full_session_reference(&scoped));
+    assert!(matches_session_reference(&scoped, id));
+    assert!(matches_session_reference(&scoped, &scoped));
+    assert!(!matches_session_reference(
+        &scoped,
+        &scoped_id(id, "/other")
+    ));
+    assert!(!matches_session_reference(&scoped, "unrelated"));
+    assert!(!is_full_session_reference(&format!("{id}?directory=")));
+    assert_eq!(
+        split_id(&scoped).unwrap(),
+        (id, Some("/中文?folder&space value".into()))
+    );
+}
+
+#[test]
+#[ignore = "explicit production reader benchmark including detail and cache copies"]
+fn benchmark_opencode_reader_cache_and_refresh() {
+    for (name, count, width) in [("small", 24usize, 128usize), ("large", 1200, 8192)] {
+        let rows: Vec<_> = (0..count)
+            .map(|i| message(&format!("{i:05} {}", "x".repeat(width)), i as i64 + 1))
+            .collect();
+        let fixture = Fixture::new(move |path| {
+            if !path.contains("/message?") {
+                return Reply::json(remote("root", "/a"));
+            }
+            let url = reqwest::Url::parse(&format!("http://fixture{path}")).unwrap();
+            let before = url
+                .query_pairs()
+                .find(|(key, _)| key == "before")
+                .map(|(_, value)| value.parse::<usize>().unwrap())
+                .unwrap_or(count);
+            let start = before.saturating_sub(20);
+            let mut reply = Reply::json(json!(rows[start..before]));
+            if start > 0 {
+                reply.headers = format!("X-Next-Cursor: {start}\r\n");
+            }
+            reply
+        });
+        let mut reader = ConversationReader::default();
+        let mut times = Vec::new();
+        let mut cached_times = Vec::new();
+        for _ in 0..11 {
+            if let Some(cached) = &mut reader.cached {
+                cached.loaded -= Duration::from_secs(2);
+            }
+            let start = Instant::now();
+            let value = reader.load(&fixture.connection, "root", false).unwrap();
+            assert_eq!(value.messages.len(), count);
+            let _serialized = serde_json::to_vec(&value).unwrap();
+            times.push(start.elapsed().as_secs_f64() * 1000.0);
+            let requests = fixture.requests.lock().unwrap().len();
+            let start = Instant::now();
+            let cached = reader.load(&fixture.connection, "root", false).unwrap();
+            let _serialized = serde_json::to_vec(&cached).unwrap();
+            cached_times.push(start.elapsed().as_secs_f64() * 1000.0);
+            assert_eq!(fixture.requests.lock().unwrap().len(), requests);
+        }
+        let cold = times.remove(0);
+        times.sort_by(f64::total_cmp);
+        cached_times.sort_by(f64::total_cmp);
+        assert_eq!(
+            fixture.requests.lock().unwrap().len(),
+            11 * (1 + count.div_ceil(20))
+        );
+        println!(
+            "OPENCODE_READER_PERF {}",
+            json!({
+                "case":name,"messages":count,"cold_ms":cold,
+                "refresh_median_ms":times[5],"refresh_p95_ms":times[9],
+                "cache_hit_median_ms":cached_times[5],"cache_hit_http_requests":0,
+                "total_http_requests":fixture.requests.lock().unwrap().len(),
+                "includes":"session detail, page reads, cache copy, response serialization"
+            })
+        );
+    }
+}
+
+#[test]
+#[ignore = "isolated global service stress; run explicitly with --test-threads=1"]
+fn concurrent_conversation_entry_has_one_http_load_and_recovers_after_disconnect() {
+    let fixture = Fixture::new(|path| {
+        if path.contains("/message?") {
+            let mut reply = Reply::json(json!([message("one load", 1)]));
+            reply.delay = Duration::from_millis(250);
+            reply
+        } else {
+            Reply::json(remote("root", "/a"))
+        }
+    });
+    CACHE.lock().unwrap().connection = Some(fixture.connection.clone());
+    let barrier = Arc::new(std::sync::Barrier::new(17));
+    let jobs: Vec<_> = (0..16)
+        .map(|_| {
+            let barrier = barrier.clone();
+            thread::spawn(move || {
+                barrier.wait();
+                conversation("root", false)
+            })
+        })
+        .collect();
+    barrier.wait();
+    let results: Vec<_> = jobs.into_iter().map(|job| job.join().unwrap()).collect();
+    assert_eq!(results.iter().filter(|r| r.is_ok()).count(), 1);
+    assert!(results
+        .iter()
+        .filter_map(|r| r.as_ref().err())
+        .all(|e| e.contains("already in progress")));
+    assert_eq!(fixture.requests.lock().unwrap().len(), 2);
+    assert_eq!(fixture.peak.load(Ordering::Acquire), 1);
+    fixture.connection.cancelled.store(true, Ordering::Release);
+    assert!(conversation("root", false)
+        .unwrap_err()
+        .contains("disconnected"));
+    let replacement =
+        Connection::parse(fixture.connection.url.as_str(), "opencode".into(), None).unwrap();
+    CACHE.lock().unwrap().connection = Some(replacement);
+    assert_eq!(
+        conversation("root", false).unwrap().messages[0].content,
+        "one load"
+    );
+    assert_eq!(fixture.requests.lock().unwrap().len(), 4);
+    CACHE.lock().unwrap().connection = None;
+    *CONVERSATION_READER.lock().unwrap() = ConversationReader::default();
+    println!("OPENCODE_CONCURRENCY callers=16 accepted=1 rejected=15 peak_http=1 recovery=ok");
+}

--- a/src-tauri/src/session/owners.rs
+++ b/src-tauri/src/session/owners.rs
@@ -67,8 +67,17 @@ impl ProviderSourceOwners {
         guard.as_mut()?.detect().ok()
     }
 
+    pub(crate) fn detect_opencode(&self) -> Vec<DetectedSession> {
+        if !self.initialize_defaults {
+            return Vec::new();
+        }
+        super::opencode::detect()
+    }
+
     pub(crate) fn has_non_claude_session(&self, session_id: &str) -> bool {
-        if self.has_pi_session(session_id) {
+        if self.detect_opencode().iter().any(|s| s.session_id.as_deref() == Some(session_id))
+            || self.has_pi_session(session_id)
+        {
             return true;
         }
         let codex = {

--- a/src-tauri/src/session/owners.rs
+++ b/src-tauri/src/session/owners.rs
@@ -75,7 +75,8 @@ impl ProviderSourceOwners {
     }
 
     pub(crate) fn has_non_claude_session(&self, session_id: &str) -> bool {
-        if self.detect_opencode().iter().any(|s| s.session_id.as_deref() == Some(session_id))
+        if self.detect_opencode().iter().any(|s| s.session_id.as_deref()
+            .is_some_and(|id| super::opencode::matches_session_reference(id, session_id)))
             || self.has_pi_session(session_id)
         {
             return true;

--- a/src-tauri/src/session/pi.rs
+++ b/src-tauri/src/session/pi.rs
@@ -270,6 +270,7 @@ impl SessionSource for PiSessionSource {
                     codex_summary: None,
                     cursor_summary: None,
                     pi_summary: Some(summary),
+                    opencode_summary: None,
                 });
             }
         }

--- a/src-tauri/src/session/source.rs
+++ b/src-tauri/src/session/source.rs
@@ -45,6 +45,7 @@ pub enum SessionProvider {
     Codex,
     Cursor,
     Pi,
+    Opencode,
 }
 
 #[derive(Debug, Clone, Copy, Serialize, Deserialize, Default, PartialEq, Eq, Hash)]
@@ -102,6 +103,7 @@ fn provider_key(provider: SessionProvider) -> &'static str {
         SessionProvider::Codex => "codex",
         SessionProvider::Cursor => "cursor",
         SessionProvider::Pi => "pi",
+        SessionProvider::Opencode => "opencode",
     }
 }
 
@@ -155,6 +157,8 @@ pub struct DetectedSession {
     pub cursor_summary: Option<CursorTranscriptSummary>,
     #[serde(skip)]
     pub pi_summary: Option<PiTranscriptSummary>,
+    #[serde(skip)]
+    pub opencode_summary: Option<super::opencode::OpenCodeSummary>,
 }
 
 fn default_true() -> bool {
@@ -205,6 +209,7 @@ impl DetectedSession {
             codex_summary: None,
             cursor_summary: None,
             pi_summary: None,
+            opencode_summary: None,
         }
     }
 }

--- a/src-tauri/src/session/state.rs
+++ b/src-tauri/src/session/state.rs
@@ -34,6 +34,7 @@ impl DetectorState {
         let codex_result = self.provider_sources.detect_codex();
         let cursor_result = self.provider_sources.detect_cursor();
         let pi_result = self.provider_sources.detect_pi();
+        let opencode_sessions = self.provider_sources.detect_opencode();
         match claude_result {
             Ok((mut sessions, diagnostics)) => {
                 self.consecutive_failures = 0;
@@ -46,6 +47,7 @@ impl DetectorState {
                 if let Some((mut extra, _)) = pi_result {
                     sessions.append(&mut extra);
                 }
+                sessions.extend(opencode_sessions);
                 Ok((sessions, diagnostics))
             }
             Err(e) => {
@@ -53,7 +55,7 @@ impl DetectorState {
                 if self.should_downgrade() {
                     self.downgrade_to_legacy();
                 }
-                let mut fallback = Vec::new();
+                let mut fallback = opencode_sessions;
                 let mut diagnostics = DetectionDiagnostics::default();
                 if let Some((sessions, extra)) = codex_result {
                     fallback.extend(sessions);

--- a/src-tauri/src/web_server.rs
+++ b/src-tauri/src/web_server.rs
@@ -390,7 +390,7 @@ async fn handle_message_with_owners(
         ClientMsg::GetSubscriptionUsage => ServerMsg::SubscriptionUsage {
             data: serde_json::to_value(crate::subscription_usage::get_subscription_usage().await).unwrap_or_default(),
         },
-        ClientMsg::GetSessions => match crate::polling::detect_and_enrich_sessions() {
+        ClientMsg::GetSessions => match crate::blocking::scan(&crate::blocking::DISCOVERY, crate::polling::detect_and_enrich_sessions).await {
             Ok(sessions) => ServerMsg::Sessions {
                 data: serde_json::to_value(&sessions).unwrap_or_default(),
             },

--- a/src/lib/components/DebugConsole.svelte
+++ b/src/lib/components/DebugConsole.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-	import { slide } from 'svelte/transition';
+	import { slide } from '$lib/transitions';
 	import { getDebugLogs } from '$lib/api';
 	import type { LogEntry } from '$lib/types';
 

--- a/src/lib/components/ExpandedCardOverlay.svelte
+++ b/src/lib/components/ExpandedCardOverlay.svelte
@@ -31,8 +31,8 @@
 </script>
 
 <script lang="ts">
-	import { onDestroy, onMount, tick } from 'svelte';
-	import { fade } from 'svelte/transition';
+	import { onDestroy, onMount, tick, untrack } from 'svelte';
+	import { fade } from '$lib/transitions';
 	import { flyIn, flyInX, fadeIn } from '$lib/transitions';
 	import { invoke } from '@tauri-apps/api/core';
 	import type { Session, Conversation } from '$lib/types';
@@ -66,12 +66,14 @@
 	interface Props {
 		session: Session;
 		conversation: Conversation | null;
+		loadError?: string | null;
+		onretry?: () => void;
 		onclose?: () => void;
 		onstop?: () => void;
 		onopen?: () => void;
 	}
 
-	let { session, conversation, onclose, onstop, onopen }: Props = $props();
+	let { session, conversation, loadError = null, onretry, onclose, onstop, onopen }: Props = $props();
 
 	let messagesContainer = $state<HTMLDivElement>(undefined!);
 	let isInitialLoad = $state(true);
@@ -284,6 +286,7 @@
 				const isAtBottom =
 					messagesContainer.scrollHeight - messagesContainer.scrollTop - messagesContainer.clientHeight < 150;
 				if (isAtBottom) {
+					untrack(() => sw.followLatest(conversation.messages.length));
 					tick().then(() => {
 						messagesContainer.scrollTop = messagesContainer.scrollHeight;
 					});
@@ -330,7 +333,7 @@
 			sessionId: child.id,
 			provider: providerOf(child),
 			agentType: child.agentRole || child.agentNickname || 'subagent',
-				description: child.agentNickname || child.codexTitle || child.cursorTitle || child.summary || child.firstPrompt || child.agentRole || (providerOf(child) === 'cursor' ? 'Cursor subagent' : providerOf(child) === 'pi' ? 'Pi subagent' : 'Codex subagent'),
+				description: child.agentNickname || child.codexTitle || child.cursorTitle || child.summary || child.firstPrompt || child.agentRole || (providerOf(child) === 'cursor' ? 'Cursor subagent' : providerOf(child) === 'pi' ? 'Pi subagent' : providerOf(child) === 'opencode' ? 'OpenCode subagent' : 'Codex subagent'),
 			startedAt: child.startedAtMs ? new Date(child.startedAtMs).toISOString() : child.modified,
 			completedAt: child.status === SessionStatus.Working ? null : child.modified,
 			parentSessionId: session.id,
@@ -363,7 +366,7 @@
 	let previewError = $derived(previewState.error);
 
 	async function openSubagentPreview(sa: SubagentInfo) {
-		if ((sa.provider === 'codex' || sa.provider === 'cursor' || sa.provider === 'pi') && sa.sessionId) {
+		if ((sa.provider === 'codex' || sa.provider === 'cursor' || sa.provider === 'pi' || sa.provider === 'opencode') && sa.sessionId) {
 			expandedSessionId.set(providerSessionKey(sa.provider, sa.sessionId));
 			return;
 		}
@@ -668,6 +671,12 @@
 							</div>
 						{/if}
 					</div>
+				{:else if !conversation && loadError}
+					<div class="loading-state" role="alert">
+						<p>Could not load conversation</p>
+						<p>{loadError}</p>
+						<button class="retry-conversation" onclick={onretry}>RETRY</button>
+					</div>
 				{:else if !conversation}
 					<div class="loading-state">
 
@@ -859,6 +868,8 @@
 </div>
 
 <style>
+	.retry-conversation { padding: 8px 12px; border: 1px solid var(--border-default); border-radius: var(--radius-sm); background: var(--bg-elevated); color: var(--text-primary); font: 11px var(--font-mono); cursor: pointer; }
+
 	.overlay-backdrop {
 		position: fixed;
 		inset: 0;

--- a/src/lib/components/HistoryCardOverlay.svelte
+++ b/src/lib/components/HistoryCardOverlay.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
 	import { onDestroy, onMount, tick } from 'svelte';
-	import { fade, scale } from 'svelte/transition';
+	import { fade, scale } from '$lib/transitions';
 	import { quintOut } from 'svelte/easing';
 	import type { HistoryEntry, Conversation } from '$lib/types';
 	import MessageBubble from './MessageBubble.svelte';

--- a/src/lib/components/IntegrationSettings.svelte
+++ b/src/lib/components/IntegrationSettings.svelte
@@ -1,0 +1,103 @@
+<script lang="ts">
+	import ProviderBadge from './ProviderBadge.svelte';
+	import OpenCodeConnection from './OpenCodeConnection.svelte';
+	import type { SessionProvider } from '$lib/types';
+
+	type LocalIntegration = {
+		provider: SessionProvider;
+		name: string;
+		description: string;
+		detail: string;
+	};
+
+	const localIntegrations: LocalIntegration[] = [
+		{
+			provider: 'claudeCode',
+			name: 'Claude Code',
+			description: 'Local Claude Code sessions are detected automatically.',
+			detail: 'No endpoint or token is required. Full Disk Access may be needed to read every session.'
+		},
+		{
+			provider: 'codex',
+			name: 'Codex',
+			description: 'Local Codex sessions are detected automatically.',
+			detail: 'c9watch reads the local Codex session archive; there is no separate connection to configure.'
+		},
+		{
+			provider: 'cursor',
+			name: 'Cursor',
+			description: 'Local Cursor Agent sessions are detected automatically.',
+			detail: 'c9watch reads the local Cursor Agent store; there is no separate connection to configure.'
+		},
+		{
+			provider: 'pi',
+			name: 'Pi',
+			description: 'Local Pi sessions are detected automatically.',
+			detail: 'c9watch reads the local Pi session files; there is no separate connection to configure.'
+		}
+	];
+</script>
+
+<section class="integration-settings" aria-labelledby="integration-settings-title">
+	<header>
+		<div>
+			<h2 id="integration-settings-title">Integrations</h2>
+			<p>Connect c9watch to the agent sessions you want to monitor.</p>
+		</div>
+		<span class="scope">SESSION SOURCES</span>
+	</header>
+
+	<div class="section-block" aria-labelledby="local-integrations-title">
+		<div class="section-heading">
+			<h3 id="local-integrations-title">Local integrations</h3>
+			<span>Automatic detection</span>
+		</div>
+		<div class="integration-grid">
+			{#each localIntegrations as integration}
+				<article class="integration-card">
+					<div class="card-topline">
+						<ProviderBadge provider={integration.provider} noun="integration" />
+						<span class="state"><span class="state-marker"></span>AUTO</span>
+					</div>
+					<h4>{integration.name}</h4>
+					<p>{integration.description}</p>
+					<span class="detail">{integration.detail}</span>
+				</article>
+			{/each}
+		</div>
+	</div>
+
+	<div class="section-block remote-block" aria-labelledby="remote-integrations-title">
+		<div class="section-heading">
+			<h3 id="remote-integrations-title">Remote integrations</h3>
+			<span>Explicit connection</span>
+		</div>
+		<OpenCodeConnection />
+	</div>
+</section>
+
+<style>
+	.integration-settings { width: 100%; color: var(--text-primary); font: 14px/1.5 var(--font-sans); }
+	header { display: flex; align-items: baseline; justify-content: space-between; gap: var(--space-lg); margin-bottom: var(--space-2xl); }
+	h2, h3 { margin: 0 0 var(--space-sm); font: 600 13px/1.5 var(--font-pixel); text-transform: uppercase; letter-spacing: .1em; }
+	h4 { margin: var(--space-md) 0 var(--space-xs); font: 600 15px/1.35 var(--font-sans); }
+	p { margin: 0; }
+	header p, .detail, .scope, .section-heading span { color: var(--text-secondary); font-size: 13px; line-height: 1.55; }
+	.scope { flex-shrink: 0; border: 1px solid var(--border-default); padding: 4px 8px; font: 11px/1.4 var(--font-mono); letter-spacing: .06em; }
+	.section-block { border-top: 1px solid var(--border-default); padding-top: var(--space-xl); }
+	.remote-block { margin-top: var(--space-2xl); }
+	.section-heading { display: flex; align-items: baseline; justify-content: space-between; gap: var(--space-lg); margin-bottom: var(--space-lg); }
+	.section-heading h3 { margin: 0; }
+	.integration-grid { display: grid; grid-template-columns: repeat(2, minmax(0, 1fr)); gap: var(--space-md); }
+	.integration-card { min-width: 0; padding: var(--space-lg); border: 1px solid var(--border-default); background: var(--bg-card); }
+	.card-topline { display: flex; align-items: center; justify-content: space-between; gap: var(--space-md); }
+	.state { display: inline-flex; align-items: center; gap: 5px; color: var(--accent-green); font: 700 8px/1 var(--font-mono); letter-spacing: .08em; }
+	.state-marker { width: 5px; height: 5px; background: var(--accent-green); border: 1px solid var(--accent-green); }
+	.integration-card p { color: var(--text-primary); font-size: 13px; line-height: 1.55; }
+	.detail { display: block; margin-top: var(--space-md); }
+	@media (max-width: 720px) {
+		header, .section-heading { align-items: flex-start; flex-direction: column; gap: var(--space-sm); }
+		.integration-grid { grid-template-columns: 1fr; }
+	}
+	@media (prefers-reduced-motion: reduce) { .integration-card { transition: none; } }
+</style>

--- a/src/lib/components/MemoryViewer.svelte
+++ b/src/lib/components/MemoryViewer.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
 	import { onMount, tick } from 'svelte';
-	import { slide } from 'svelte/transition';
+	import { slide } from '$lib/transitions';
 	import { cubicOut } from 'svelte/easing';
 	import { marked } from 'marked';
 	import DOMPurify from 'dompurify';

--- a/src/lib/components/MessageBubble.svelte
+++ b/src/lib/components/MessageBubble.svelte
@@ -136,7 +136,8 @@
 		max-width: 100%;
 		border-left: 1px solid var(--border-default);
 		transition: background var(--transition-fast);
-		animation: fade-in 0.3s ease-out backwards;
+		/* The overlay owns entry motion through the visibility-safe transitions.
+		   A second CSS fade could freeze this bubble at opacity 0 in WebKit. */
 	}
 
 	.message-bubble:hover {

--- a/src/lib/components/OpenCodeConnection.svelte
+++ b/src/lib/components/OpenCodeConnection.svelte
@@ -8,31 +8,38 @@
 	let status = $state<ConnectionStatus | null>(null);
 	let error = $state('');
 	let busy = $state(false);
+	let generation = 0;
 	onMount(() => {
 		let disposed = false;
 		let first = true;
+		let timer: ReturnType<typeof setTimeout>;
 		async function refresh() {
+			const requestGeneration = generation;
 			try {
+				if (busy) return;
 				const next = await invoke<ConnectionStatus>('opencode_connection_status');
-				if (disposed) return;
+				if (disposed || requestGeneration !== generation) return;
 				status = next;
 				if (first && next.url) url = next.url;
 				first = false;
-			} catch (e) { if (!disposed) error = String(e); }
+			} catch (e) { if (!disposed && requestGeneration === generation) error = String(e); }
+			finally { if (!disposed) timer = setTimeout(refresh, 2000); }
 		}
 		void refresh();
-		const timer = setInterval(refresh, 2000);
-		return () => { disposed = true; clearInterval(timer); };
+		return () => { disposed = true; generation++; clearTimeout(timer); };
 	});
 	async function connect(disconnect = false) {
+		if (busy) return;
+		const requestGeneration = ++generation;
 		busy = true;
 		error = '';
 		try {
 			await invoke('opencode_connect', { url: disconnect ? '' : url, username, password: password || null });
 			password = '';
-			status = await invoke<ConnectionStatus>('opencode_connection_status');
-		} catch (e) { error = String(e); }
-		finally { busy = false; }
+			const next = await invoke<ConnectionStatus>('opencode_connection_status');
+			if (requestGeneration === generation) status = next;
+		} catch (e) { if (requestGeneration === generation) error = String(e); }
+		finally { if (requestGeneration === generation) busy = false; }
 	}
 </script>
 

--- a/src/lib/components/OpenCodeConnection.svelte
+++ b/src/lib/components/OpenCodeConnection.svelte
@@ -1,0 +1,71 @@
+<script lang="ts">
+	import { onMount } from 'svelte';
+	import { invoke } from '@tauri-apps/api/core';
+	type ConnectionStatus = { url: string; connected: boolean; error: string | null; sessionCount: number };
+	let url = $state('http://127.0.0.1:4096');
+	let username = $state('opencode');
+	let password = $state('');
+	let status = $state<ConnectionStatus | null>(null);
+	let error = $state('');
+	let busy = $state(false);
+	onMount(() => {
+		let disposed = false;
+		let first = true;
+		async function refresh() {
+			try {
+				const next = await invoke<ConnectionStatus>('opencode_connection_status');
+				if (disposed) return;
+				status = next;
+				if (first && next.url) url = next.url;
+				first = false;
+			} catch (e) { if (!disposed) error = String(e); }
+		}
+		void refresh();
+		const timer = setInterval(refresh, 2000);
+		return () => { disposed = true; clearInterval(timer); };
+	});
+	async function connect(disconnect = false) {
+		busy = true;
+		error = '';
+		try {
+			await invoke('opencode_connect', { url: disconnect ? '' : url, username, password: password || null });
+			password = '';
+			status = await invoke<ConnectionStatus>('opencode_connection_status');
+		} catch (e) { error = String(e); }
+		finally { busy = false; }
+	}
+</script>
+
+<section aria-labelledby="opencode-heading">
+	<h3 id="opencode-heading">OpenCode <span>PREVIEW</span></h3>
+	<p>Connect to the server used by your OpenCode session. For a terminal session, start it with <code>opencode --port 4096</code>.</p>
+	<form onsubmit={(event) => { event.preventDefault(); void connect(); }}>
+		<label>Server URL <input bind:value={url} type="url" required placeholder="http://127.0.0.1:4096" disabled={busy} /></label>
+		<div class="credentials">
+			<label>Username <input bind:value={username} autocomplete="off" disabled={busy} /></label>
+			<label>Password (if required) <input bind:value={password} type="password" autocomplete="off" disabled={busy} /></label>
+		</div>
+		<div class="actions">
+			<button type="submit" disabled={busy}>{busy ? 'CONNECTING…' : 'CONNECT'}</button>
+			{#if status?.url}<button type="button" disabled={busy} onclick={() => connect(true)}>DISCONNECT</button>{/if}
+		</div>
+	</form>
+	<p class="status" role="status">{error || status?.error || (status?.connected ? `Connected · ${status.sessionCount} sessions` : status?.url ? 'Connecting…' : 'Not connected')}</p>
+	<p class="hint">Connection settings apply until c9watch quits. Sessions refresh every two seconds. OpenCode controls and usage totals are not included in this preview.</p>
+</section>
+
+<style>
+	section { border: 1px solid var(--border-default); background: var(--bg-card); padding: 16px; border-radius: var(--radius-sm); }
+	h3 { margin: 0 0 8px; font-size: 14px; color: var(--text-primary); }
+	h3 span { margin-left: 6px; font: 9px var(--font-mono); color: var(--text-muted); }
+	p { margin: 8px 0; color: var(--text-secondary); font-size: 12px; line-height: 1.5; }
+	code { font-size: 11px; }
+	label { display: block; font-size: 11px; color: var(--text-secondary); }
+	input { box-sizing: border-box; width: 100%; margin: 5px 0 10px; padding: 8px; background: var(--bg-elevated); color: var(--text-primary); border: 1px solid var(--border-default); border-radius: var(--radius-sm); font: 12px var(--font-mono); }
+	.credentials { display: grid; grid-template-columns: 1fr 1fr; gap: 12px; }
+	.actions { display: flex; gap: 8px; }
+	button { padding: 8px 12px; border: 1px solid var(--border-default); border-radius: var(--radius-sm); background: var(--bg-elevated); color: var(--text-primary); font: 11px var(--font-mono); cursor: pointer; }
+	button:disabled { opacity: .5; cursor: default; }
+	.status { color: var(--text-primary); }
+	.hint { color: var(--text-muted); font-size: 11px; }
+</style>

--- a/src/lib/components/ProviderBadge.svelte
+++ b/src/lib/components/ProviderBadge.svelte
@@ -15,7 +15,7 @@
 </script>
 
 <span class="provider-stack" class:compact aria-label={`${providerLabel(normalized)} ${noun}${surfaceText ? `, ${surfaceText}` : ''}`}>
-	<span class="provider-badge" class:codex={normalized === 'codex'} class:cursor={normalized === 'cursor'} class:pi={normalized === 'pi'}>{providerLabel(normalized)}</span>
+	<span class="provider-badge" class:codex={normalized === 'codex'} class:cursor={normalized === 'cursor'} class:pi={normalized === 'pi'} class:opencode={normalized === 'opencode'}>{providerLabel(normalized)}</span>
 	{#if surfaceText}<span class="surface-badge">{surfaceText}</span>{/if}
 </span>
 
@@ -32,6 +32,7 @@
 	.provider-badge.codex { color: var(--accent-blue); border-color: color-mix(in srgb, var(--accent-blue) 55%, var(--border-default)); }
 	.provider-badge.cursor { color: var(--accent-purple); border-color: color-mix(in srgb, var(--accent-purple) 55%, var(--border-default)); }
 	.provider-badge.pi { color: var(--accent-green); border-color: color-mix(in srgb, var(--accent-green) 55%, var(--border-default)); }
+	.provider-badge.opencode { color: var(--accent-pink); border-color: color-mix(in srgb, var(--accent-pink) 55%, var(--border-default)); }
 	.surface-badge { height: 16px; padding: 0 4px; border-color: var(--border-default); border-style: dashed; font-size: 7px; color: var(--text-secondary); }
 	.compact .provider-badge { height: 16px; font-size: 7px; }
 	.compact .surface-badge { display: none; }

--- a/src/lib/components/ProviderFilter.svelte
+++ b/src/lib/components/ProviderFilter.svelte
@@ -13,7 +13,8 @@
 		{ value: 'claudeCode', label: 'Claude Code', short: 'CLAUDE CODE' },
 		{ value: 'codex', label: 'Codex', short: 'CODEX' },
 		{ value: 'cursor', label: 'Cursor', short: 'CURSOR' },
-		{ value: 'pi', label: 'Pi', short: 'PI' }
+		{ value: 'pi', label: 'Pi', short: 'PI' },
+		{ value: 'opencode', label: 'OpenCode', short: 'OPENCODE' }
 	];
 	let dropdownOpen = $state(false);
 	let activeIndex = $state(0);
@@ -204,6 +205,7 @@
 	.option-marker.codex { border-color: var(--accent-blue); background: var(--accent-blue); }
 	.option-marker.cursor { border-color: var(--accent-purple); background: var(--accent-purple); }
 	.option-marker.pi { border-color: var(--accent-green); background: var(--accent-green); }
+	.option-marker.opencode { border-color: var(--accent-pink); background: var(--accent-pink); }
 	.option-check { color: var(--text-secondary); text-align: right; }
 	.provider-select.compact { gap: 5px; }
 	.compact .select-label { font-size: 7px; }

--- a/src/lib/components/SettingsTab.svelte
+++ b/src/lib/components/SettingsTab.svelte
@@ -522,7 +522,7 @@
 		50% { opacity: 1; }
 	}
 
-    .settings-body { width: 100%; max-width: 960px; margin: 0; display: flex; flex-direction: column; gap: var(--space-xl); padding: 0 var(--space-lg) var(--space-2xl); box-sizing: border-box;  }
+    .settings-body { width: 100%; max-width: none; margin: 0; display: flex; flex-direction: column; gap: var(--space-xl); padding: 0 0 var(--space-2xl) var(--space-lg); box-sizing: border-box;  }
     .group { border-top: 1px solid var(--border-default); padding-top: var(--space-xl); }
     .group-title, .group-title--lg { font-family: var(--font-pixel); font-size: 13px; letter-spacing: .1em; text-transform: uppercase; border: 0; color: var(--text-primary); }
     .mono, .status-text, .version-diff, .notes-state, .state-line, .progress-label { font-size: 13px; text-transform: none; letter-spacing: normal; }

--- a/src/lib/components/SettingsTab.svelte
+++ b/src/lib/components/SettingsTab.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
 	import { onMount } from 'svelte';
+	import OpenCodeConnection from './OpenCodeConnection.svelte';
 	import NotificationSettings from './NotificationSettings.svelte';
 	import UsageSettings from './UsageSettings.svelte';
 	import { marked } from 'marked';
@@ -20,7 +21,7 @@
 	} from '$lib/stores/updater';
 
 	let checking = $state(false);
-	let activeSection = $state<'notifications' | 'usage' | 'about'>('notifications');
+	let activeSection = $state<'notifications' | 'usage' | 'opencode' | 'about'>('notifications');
 	let nativeNotifications = $state(false);
 	let justChecked = $state(false);
 
@@ -98,11 +99,13 @@
         <nav class="settings-nav" aria-label="Settings sections">
             {#if nativeNotifications}<button class:active={activeSection === 'notifications'} aria-current={activeSection === 'notifications' ? 'page' : undefined} onclick={() => activeSection = 'notifications'}>Notifications</button>{/if}
             <button class:active={activeSection === 'usage'} aria-current={activeSection === 'usage' ? 'page' : undefined} onclick={() => activeSection = 'usage'}>Usage</button>
+            {#if isTauri()}<button class:active={activeSection === 'opencode'} aria-current={activeSection === 'opencode' ? 'page' : undefined} onclick={() => activeSection = 'opencode'}>OpenCode</button>{/if}
             <button class:active={activeSection === 'about'} aria-current={activeSection === 'about' ? 'page' : undefined} onclick={() => activeSection = 'about'}>About &amp; updates</button>
         </nav>
         <div class="content"><div class="settings-body">
         {#if nativeNotifications}<div hidden={activeSection !== 'notifications'}><NotificationSettings /></div>{/if}
         <div hidden={activeSection !== 'usage'}><UsageSettings /></div>
+        {#if isTauri()}<div hidden={activeSection !== 'opencode'}><OpenCodeConnection /></div>{/if}
         <div class="about-panel" hidden={activeSection !== 'about'}>
 		<div class="group" >
 			<div class="group-title group-title--lg">Version</div>

--- a/src/lib/components/SettingsTab.svelte
+++ b/src/lib/components/SettingsTab.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
 	import { onMount } from 'svelte';
-	import OpenCodeConnection from './OpenCodeConnection.svelte';
+	import IntegrationSettings from './IntegrationSettings.svelte';
 	import NotificationSettings from './NotificationSettings.svelte';
 	import UsageSettings from './UsageSettings.svelte';
 	import { marked } from 'marked';
@@ -21,7 +21,7 @@
 	} from '$lib/stores/updater';
 
 	let checking = $state(false);
-	let activeSection = $state<'notifications' | 'usage' | 'opencode' | 'about'>('notifications');
+	let activeSection = $state<'notifications' | 'usage' | 'integration' | 'about'>('notifications');
 	let nativeNotifications = $state(false);
 	let justChecked = $state(false);
 
@@ -99,13 +99,13 @@
         <nav class="settings-nav" aria-label="Settings sections">
             {#if nativeNotifications}<button class:active={activeSection === 'notifications'} aria-current={activeSection === 'notifications' ? 'page' : undefined} onclick={() => activeSection = 'notifications'}>Notifications</button>{/if}
             <button class:active={activeSection === 'usage'} aria-current={activeSection === 'usage' ? 'page' : undefined} onclick={() => activeSection = 'usage'}>Usage</button>
-            {#if isTauri()}<button class:active={activeSection === 'opencode'} aria-current={activeSection === 'opencode' ? 'page' : undefined} onclick={() => activeSection = 'opencode'}>OpenCode</button>{/if}
+            {#if isTauri()}<button class:active={activeSection === 'integration'} aria-current={activeSection === 'integration' ? 'page' : undefined} onclick={() => activeSection = 'integration'}>Integration</button>{/if}
             <button class:active={activeSection === 'about'} aria-current={activeSection === 'about' ? 'page' : undefined} onclick={() => activeSection = 'about'}>About &amp; updates</button>
         </nav>
         <div class="content"><div class="settings-body">
         {#if nativeNotifications}<div hidden={activeSection !== 'notifications'}><NotificationSettings /></div>{/if}
         <div hidden={activeSection !== 'usage'}><UsageSettings /></div>
-        {#if isTauri()}<div hidden={activeSection !== 'opencode'}><OpenCodeConnection /></div>{/if}
+        {#if isTauri()}<div hidden={activeSection !== 'integration'}><IntegrationSettings /></div>{/if}
         <div class="about-panel" hidden={activeSection !== 'about'}>
 		<div class="group" >
 			<div class="group-title group-title--lg">Version</div>

--- a/src/lib/provider.ts
+++ b/src/lib/provider.ts
@@ -4,7 +4,7 @@ export type ProviderFilter = 'all' | SessionProvider;
 export type SessionAction = 'open' | 'stop' | 'rename' | 'conversation';
 type ProviderRecord = { provider?: SessionProvider | null };
 
-const KNOWN_PROVIDERS: SessionProvider[] = ['claudeCode', 'codex', 'cursor', 'pi'];
+const KNOWN_PROVIDERS: SessionProvider[] = ['claudeCode', 'codex', 'cursor', 'pi', 'opencode'];
 
 export function providerOf(record: ProviderRecord): SessionProvider {
 	return record.provider && KNOWN_PROVIDERS.includes(record.provider)
@@ -29,6 +29,7 @@ export function providerLabel(provider: SessionProvider): string {
 	if (provider === 'codex') return 'CODEX';
 	if (provider === 'cursor') return 'CURSOR';
 	if (provider === 'pi') return 'PI';
+	if (provider === 'opencode') return 'OPENCODE';
 	return 'CLAUDE CODE';
 }
 
@@ -48,6 +49,7 @@ export function providerFilterLabel(filter: ProviderFilter): string {
 	if (filter === 'claudeCode') return 'Claude Code';
 	if (filter === 'cursor') return 'Cursor';
 	if (filter === 'pi') return 'Pi';
+	if (filter === 'opencode') return 'OpenCode';
 	return 'All providers';
 }
 
@@ -60,7 +62,7 @@ export function isHiddenInternalSession(session: Session): boolean {
 
 export function isCodexSubagent(session: Session): boolean {
 	const provider = providerOf(session);
-	return (provider === 'codex' || provider === 'cursor') && session.agentKind === 'subagent' && !isHiddenInternalSession(session);
+	return (provider === 'codex' || provider === 'cursor' || provider === 'opencode') && session.agentKind === 'subagent' && !isHiddenInternalSession(session);
 }
 
 export interface CodexHierarchy {

--- a/src/lib/slidingWindow.svelte.ts
+++ b/src/lib/slidingWindow.svelte.ts
@@ -23,6 +23,11 @@ export function createSlidingWindow() {
 		startIndex = initialStart ?? Math.max(0, totalMessages - BATCH_SIZE);
 	}
 
+	function followLatest(totalMessages: number) {
+		endIndex = totalMessages;
+		startIndex = Math.max(0, Math.min(startIndex, totalMessages), totalMessages - MAX_VISIBLE);
+	}
+
 	function sliceMessages(messages: Message[]): Message[] {
 		return messages.slice(startIndex, endIndex);
 	}
@@ -108,6 +113,7 @@ export function createSlidingWindow() {
 		get loading() { return loading; },
 		reset,
 		sliceMessages,
+		followLatest,
 		loadOlder,
 		loadNewer,
 		handleScroll,

--- a/src/lib/stores/provider-filter.ts
+++ b/src/lib/stores/provider-filter.ts
@@ -5,7 +5,7 @@ import type { ProviderFilter } from '$lib/provider';
 const STORAGE_KEY = 'c9watch.providerFilter';
 
 function sanitize(value: string | null): ProviderFilter {
-	return value === 'claudeCode' || value === 'codex' || value === 'cursor' || value === 'pi' ? value : 'all';
+	return value === 'claudeCode' || value === 'codex' || value === 'cursor' || value === 'pi' || value === 'opencode' ? value : 'all';
 }
 
 export const providerFilter = writable<ProviderFilter>(

--- a/src/lib/stores/subagents.ts
+++ b/src/lib/stores/subagents.ts
@@ -22,7 +22,7 @@ export interface SubagentInfo {
 	completedAt: string | null;
 	parentSessionId: string;
 	status: SubagentStatus;
-	provider?: 'claudeCode' | 'codex' | 'cursor' | 'pi';
+	provider?: 'claudeCode' | 'codex' | 'cursor' | 'pi' | 'opencode';
 	sessionId?: string;
 }
 

--- a/src/lib/transitions.ts
+++ b/src/lib/transitions.ts
@@ -1,5 +1,25 @@
-import { fly, fade, type FlyParams, type FadeParams } from 'svelte/transition';
+import { fly, fade as svelteFade, scale as svelteScale, slide as svelteSlide, type FlyParams, type FadeParams, type ScaleParams, type SlideParams } from 'svelte/transition';
 import { cubicOut } from 'svelte/easing';
+import { isTauri } from './ws';
+
+// Native WebKit can suspend its animation timeline even after an intro starts,
+// while DOM/AX updates continue. Native content must not depend on a transition
+// finishing to become visible. Browser transitions remain animated when visible.
+function skipMotion(node: Element): boolean {
+	return isTauri() || node.ownerDocument.visibilityState === 'hidden' || prefersReducedMotion();
+}
+
+export function fade(node: Element, params: FadeParams = {}) {
+	return skipMotion(node) ? { duration: 0, delay: 0 } : svelteFade(node, params);
+}
+
+export function scale(node: Element, params: ScaleParams = {}) {
+	return skipMotion(node) ? { duration: 0, delay: 0 } : svelteScale(node, params);
+}
+
+export function slide(node: Element, params: SlideParams = {}) {
+	return skipMotion(node) ? { duration: 0, delay: 0 } : svelteSlide(node, params);
+}
 
 function prefersReducedMotion(): boolean {
 	if (typeof window === 'undefined' || !window.matchMedia) return false;
@@ -18,12 +38,12 @@ export function flyIn(
 	node: Element,
 	params: { index?: number; y?: number; duration?: number; stride?: number; base?: number } = {}
 ) {
-	if (prefersReducedMotion()) {
-		return fade(node, { duration: 0 });
+	if (skipMotion(node)) {
+		return { duration: 0, delay: 0 };
 	}
 	const { index = 0, y = 8, duration = 400, stride = 60, base = 0 } = params;
 	if (index > CASCADE_CAP) {
-		return fade(node, { duration: 0 });
+		return { duration: 0, delay: 0 };
 	}
 	return fly(node, {
 		y,
@@ -36,8 +56,8 @@ export function flyIn(
 
 // Plain fade that respects reduced motion.
 export function fadeIn(node: Element, params: FadeParams = {}) {
-	if (prefersReducedMotion()) {
-		return fade(node, { duration: 0 });
+	if (skipMotion(node)) {
+		return { duration: 0, delay: 0 };
 	}
 	return fade(node, { duration: 320, easing: cubicOut, ...params });
 }
@@ -48,12 +68,12 @@ export function flyInX(
 	node: Element,
 	params: { index?: number; x?: number; duration?: number; stride?: number; base?: number } = {}
 ) {
-	if (prefersReducedMotion()) {
-		return fade(node, { duration: 0 });
+	if (skipMotion(node)) {
+		return { duration: 0, delay: 0 };
 	}
 	const { index = 0, x = 12, duration = 400, stride = 60, base = 0 } = params;
 	if (index > CASCADE_CAP) {
-		return fade(node, { duration: 0 });
+		return { duration: 0, delay: 0 };
 	}
 	return fly(node, {
 		x,

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -12,7 +12,7 @@ export enum SessionStatus {
   Connecting = 'Connecting'            // Session starting up
 }
 
-export type SessionProvider = 'claudeCode' | 'codex' | 'cursor' | 'pi';
+export type SessionProvider = 'claudeCode' | 'codex' | 'cursor' | 'pi' | 'opencode';
 export type SessionSurface = 'claudeCode' | 'app' | 'cli' | 'exec' | 'integration' | 'cursor' | 'unknown';
 export type AgentKind = 'root' | 'subagent' | 'internal';
 

--- a/src/routes/(app)/+page.svelte
+++ b/src/routes/(app)/+page.svelte
@@ -361,7 +361,8 @@
 					console.error('Failed to fetch conversation:', error);
 					// Keep the last successful preview during transient refresh failures.
 				} finally {
-					if (!cancelled && requestId === conversationRequestId) {
+					// Local providers parse transcripts in full; only OpenCode needs HTTP polling.
+					if (providerOf(selected!) === 'opencode' && !cancelled && requestId === conversationRequestId) {
 						timer = setTimeout(() => void refresh(false), 2000);
 					}
 				}

--- a/src/routes/(app)/+page.svelte
+++ b/src/routes/(app)/+page.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-	import { fade } from 'svelte/transition';
+	import { fade } from '$lib/transitions';
 	import { flip } from 'svelte/animate';
 	import { fadeIn, flyIn } from '$lib/transitions';
 	import { onMount, untrack } from 'svelte';
@@ -329,28 +329,46 @@
 	// should clear/reload the conversation. Read the current object untracked.
 	let conversationTarget = $derived(expandedSession ? sessionKeyOf(expandedSession) : null);
 	let conversationRequestId = 0;
+	let conversationError = $state<string | null>(null);
+	let conversationRetry = $state(0);
+	function retryConversation() { conversationRetry += 1; }
 	$effect(() => {
 		const sessionId = conversationTarget;
+		conversationRetry;
+		conversationError = null;
 		const requestId = ++conversationRequestId;
 		currentConversation.set(null);
 		const selected = untrack(() => expandedSession);
+		let cancelled = false;
+		let timer: ReturnType<typeof setTimeout>;
 		if (sessionId && selected) {
 			const selectedKey = sessionKeyOf(selected);
 			toolsLoadedFor.set(null);
-			withConversationLoader(selected.id, selected.provider, 'conversation', () =>
-				getConversation(selected.id, selected.provider, false)
-			)
-				.then((conv) => {
-					if (requestId !== conversationRequestId) return;
-					if (get(toolsLoadedFor) === selectedKey) return;
-					if (providerSessionKey(conv.provider ?? providerOf(selected), conv.sessionId) !== selectedKey) return;
+			async function refresh(initial: boolean) {
+				const includeTools = get(toolsLoadedFor) === selectedKey;
+				try {
+					const task = () => getConversation(selected!.id, selected!.provider, includeTools);
+					const conv = await (initial
+						? withConversationLoader(selected!.id, selected!.provider, 'conversation', task)
+						: task());
+					if (cancelled || requestId !== conversationRequestId) return;
+					if (includeTools !== (get(toolsLoadedFor) === selectedKey)) return;
+					if (providerSessionKey(conv.provider ?? providerOf(selected!), conv.sessionId) !== selectedKey) return;
+					conversationError = null;
 					currentConversation.set(conv);
-				})
-				.catch((error) => {
+				} catch (error) {
+					if (!cancelled && requestId === conversationRequestId) conversationError = String(error);
 					console.error('Failed to fetch conversation:', error);
-					if (requestId === conversationRequestId) currentConversation.set(null);
-				});
+					// Keep the last successful preview during transient refresh failures.
+				} finally {
+					if (!cancelled && requestId === conversationRequestId) {
+						timer = setTimeout(() => void refresh(false), 2000);
+					}
+				}
+			}
+			void refresh(true);
 		}
+		return () => { cancelled = true; clearTimeout(timer); };
 	});
 
 	function handleExpand(session: Session) {
@@ -792,6 +810,8 @@
 		<ExpandedCardOverlay
 			session={expandedSession}
 			{conversation}
+			loadError={conversationError}
+			onretry={retryConversation}
 			onclose={handleClose}
 			onstop={() => handleStop(expandedSession.pid)}
 			onopen={() => handleOpen(expandedSession.pid, expandedSession.projectPath)}

--- a/src/routes/(app)/+page.svelte
+++ b/src/routes/(app)/+page.svelte
@@ -510,7 +510,7 @@
 		<MemoryViewer />
 	</main>
 	{:else if activeTab === 'settings'}
-	<main class="grid-container history-main" in:fadeIn>
+	<main class="grid-container history-main settings-main" in:fadeIn>
 		<SettingsTab />
 	</main>
 	{:else}
@@ -957,6 +957,10 @@
 		overflow: hidden;
 		display: flex;
 		flex-direction: column;
+	}
+
+	.history-main.settings-main {
+		padding-right: 0;
 	}
 
 	.sections-container {

--- a/src/routes/(app)/+page.svelte
+++ b/src/routes/(app)/+page.svelte
@@ -960,7 +960,7 @@
 	}
 
 	.history-main.settings-main {
-		padding-right: 0;
+		padding-right: var(--space-md);
 	}
 
 	.sections-container {


### PR DESCRIPTION
## Summary

Connect c9watch to agent sessions from Settings → Integration. Claude Code, Codex, Cursor and Pi remain local integrations with automatic detection; OpenCode is an explicitly configured HTTP server. Preserve full-width Settings content and its aligned right inset. OpenCode has pink provider badges/filter, parent/child grouping and read-only chronological conversation previews. Connection settings and optional Basic-auth credentials stay in process memory until quit.

Session identity is provider- and directory-qualified. Health/discovery/status/detail/children reads validate scope, retain old-but-busy sessions, expire old idle/archived/deleted sessions and preserve metadata as Connecting during outages. Full scoped CLI references can resolve sessions outside recent discovery.

Conversation loading is single-flight with a one-entry, one-second cache, cancellation/generation guards and explicit Retry errors. Limits: 8 MiB/page, 32 MiB/load, 128 pages, 10,000 rendered parts, 400-message DOM window; discovery: 512 sessions, 32 directories, 16 MiB/10 seconds. HTTP requests have a three-second timeout, bounded by operation deadline. Disconnect prevents stale publication and further paging; no unbounded retry queue. Synchronous discovery/enrichment and subagent scans run behind bounded blocking-pool admission rather than on Tokio async workers.

Native transitions complete immediately to prevent hidden-window WebKit animation suspension at opacity zero. Browser transitions retain motion when visible; message bubbles no longer add a duplicate opacity animation.

## Current verification — candidate 900cd7d

Implementation: `0f9509e`; final native acceptance record: `900cd7d`. Rechecked against main `d3fe23e`. The prior September 8 validation text is superseded by this dated evidence.

- Default Rust: **443 unit + 3 integration passed**, 9 unit / 1 integration ignored. CLI: **409 unit + 3 integration passed**, 6 unit / 1 integration ignored. Doc tests completed.
- Svelte check: **0 errors / 0 warnings**; frontend production build and native Debug bundle build passed.
- **22 frontend regressions** plus subagent/subscription/usage polling checks passed; `git diff --check` passed. Added HTTP failure, directory collision, total/page bounds, cancellation and cache regressions. Explicit ignored performance/stress tests were run separately.
- Comparative large-conversation fixture: 1,200 messages / 60 pages / 9.94 MB, full uncached reads plus serialization. Median of repeat medians **226.602 → 236.084 ms (+4.2%)**; maximum RSS **+0.38%**. Cold-load/repeat variance and all alternating baseline/candidate runs are documented, not hidden. No sustained substantial regression observed on this shared debug Mac.
- Real 46.5 MB transcript/subagent scan on a single-thread Tokio runtime: maximum heartbeat gap approximately **1,232 → 3.78 ms** using bounded blocking dispatch. **16 concurrent conversation callers → 1 admitted HTTP load, 15 fail-fast rejections**, followed by successful reconnect recovery.
- Exact native QA binary SHA-256: `1924e61eefe2245d8bce486e0cf01512f10e2db9e04d44a3b21ca9e0cb2ba886`. Observed full-size screenshots and AX for Integration connection, OpenCode-only filter, cross-directory Working/Ready, English/Chinese rendering, 24→26 message live refresh, Hide/Raise, disconnect to empty monitor with stopped HTTP requests, reconnect with fresh revision, global HTTP 503/Retry/Connecting and recovery to revision 3. Test servers were stopped after acceptance.
- Current isolated **OpenCode 1.18.20** compatibility checks: health/version, empty discovery, directory status and `/doc` endpoint schemas. Nonempty conversations/failures use the committed fixture. No real model request was made in this audit; old 1.18.29/model-response claims are not reused as current evidence.

Full commands, comparative numbers, failure matrix, native evidence and limitations: [acceptance record at 900cd7d](https://github.com/minchenlee/c9watch/blob/900cd7d9f558a6b4e15724ba4e0b00599d6b1f70/docs/opencode-preview-acceptance-2026-09-12.md).

Candidate accepted as merge-ready for the development-preview scope. Fresh GitHub [CI run 34702074445](https://github.com/minchenlee/c9watch/actions/runs/34702074445) on pushed head `900cd7d9f558a6b4e15724ba4e0b00599d6b1f70` **passed** (check job: 2m46s), including frontend checks/regressions/build, Rust check/full tests and CLI-only check/tests. The runner emitted a non-failing Node.js 20 deprecation annotation for existing checkout/setup-node actions; this is not a test failure. No merge performed.

## Scope and limits

HTTP polling only. No automatic endpoint discovery, prompt sending, stop, rename, terminal opening, permission/question lifecycle, usage totals, history search or other unspecified capabilities. Unsupported action flags stay false. No Codex/Claude messaging-worker or widget changes were imported. This is development/ad-hoc QA, not distribution signing, notarization or deployment. Benchmarks are debug loopback fixtures, not a production SLA; screenshots are retained inline in the task, with tooling limitations distinguished from data evidence.

User authorized the candidate push and this PR evidence update. **Do not auto-merge; merge remains the user's decision.**
