### PR TITLE
feat: refine mobile web UI layout and responsiveness

### DIFF
--- a/src/app.css
+++ b/src/app.css
@@ -137,6 +137,13 @@
 	--transition-normal: 150ms linear;
 	--transition-slow: 250ms linear;
 	--transition-spring: 200ms linear;
+
+	/* Touch / safe area (used on mobile web; no-ops on desktop) */
+	--touch-min: 44px;
+	--safe-top: env(safe-area-inset-top, 0px);
+	--safe-right: env(safe-area-inset-right, 0px);
+	--safe-bottom: env(safe-area-inset-bottom, 0px);
+	--safe-left: env(safe-area-inset-left, 0px);
 }
 
 /* CSS Reset */
@@ -165,6 +172,9 @@ body {
 	background-color: var(--bg-base);
 	-webkit-font-smoothing: antialiased;
 	-moz-osx-font-smoothing: grayscale;
+	-webkit-text-size-adjust: 100%;
+	text-size-adjust: 100%;
+	-webkit-tap-highlight-color: transparent;
 }
 
 
@@ -350,13 +360,14 @@ input, textarea, select {
 /* ── Mobile Responsive ─────────────────────────────────────────────── */
 @media (max-width: 768px) {
 	body {
-		font-size: 13px;
+		font-size: 14px;
+		line-height: 1.45;
 	}
+}
 
-	/* Larger touch targets */
+@media (hover: none) {
 	button,
 	[role="button"] {
-		min-height: 36px;
-		min-width: 36px;
+		-webkit-tap-highlight-color: transparent;
 	}
 }

--- a/src/app.css
+++ b/src/app.css
@@ -358,7 +358,7 @@ input, textarea, select {
 }
 
 /* ── Mobile Responsive ─────────────────────────────────────────────── */
-@media (max-width: 768px) {
+@media (max-width: 768px), (orientation: landscape) and (max-height: 500px) {
 	body {
 		font-size: 14px;
 		line-height: 1.45;

--- a/src/app.html
+++ b/src/app.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="utf-8" />
     <link rel="icon" href="%sveltekit.assets%/favicon.png" />
-    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover" />
     <title>c9watch</title>
     %sveltekit.head%
   </head>

--- a/src/lib/components/ConnectionScreen.svelte
+++ b/src/lib/components/ConnectionScreen.svelte
@@ -428,7 +428,7 @@
 		text-align: center;
 	}
 
-	@media (max-width: 768px) {
+	@media (max-width: 768px), (orientation: landscape) and (max-height: 500px) {
 		.connection-screen {
 			padding: var(--space-lg);
 			padding-top: max(var(--space-lg), var(--safe-top));
@@ -449,7 +449,7 @@
 		}
 	}
 
-	@media (max-width: 768px) and (orientation: landscape) {
+	@media (orientation: landscape) and (max-height: 500px) {
 		.connection-screen {
 			align-items: flex-start;
 			overflow-y: auto;

--- a/src/lib/components/ConnectionScreen.svelte
+++ b/src/lib/components/ConnectionScreen.svelte
@@ -184,9 +184,14 @@
 		align-items: center;
 		justify-content: center;
 		height: 100vh;
+		height: 100dvh;
 		width: 100vw;
 		background: var(--bg-base);
 		padding: var(--space-xl);
+		padding-top: max(var(--space-xl), var(--safe-top));
+		padding-right: max(var(--space-xl), var(--safe-right));
+		padding-bottom: max(var(--space-xl), var(--safe-bottom));
+		padding-left: max(var(--space-xl), var(--safe-left));
 	}
 
 	.content {
@@ -426,6 +431,45 @@
 	@media (max-width: 768px) {
 		.connection-screen {
 			padding: var(--space-lg);
+			padding-top: max(var(--space-lg), var(--safe-top));
+			padding-right: max(var(--space-lg), var(--safe-right));
+			padding-bottom: max(var(--space-lg), var(--safe-bottom));
+			padding-left: max(var(--space-lg), var(--safe-left));
+		}
+
+		.option-btn,
+		.back-btn,
+		.connect-btn {
+			min-height: var(--touch-min);
+		}
+
+		.url-input {
+			min-height: var(--touch-min);
+			font-size: 16px; /* avoid iOS zoom on focus */
+		}
+	}
+
+	@media (max-width: 768px) and (orientation: landscape) {
+		.connection-screen {
+			align-items: flex-start;
+			overflow-y: auto;
+			padding: var(--space-md);
+			padding-top: max(var(--space-md), var(--safe-top));
+		}
+
+		.content {
+			gap: var(--space-lg);
+			max-width: 480px;
+		}
+
+		.logo-box {
+			width: 40px;
+			height: 40px;
+			margin-bottom: 0;
+		}
+
+		.title {
+			font-size: 18px;
 		}
 	}
 </style>

--- a/src/lib/components/ExpandedCardOverlay.svelte
+++ b/src/lib/components/ExpandedCardOverlay.svelte
@@ -481,6 +481,7 @@
 							<h2
 								id="overlay-title"
 								class="project-name"
+								title={session.customTitle || session.officialName || session.codexTitle || session.cursorTitle || session.summary || session.firstPrompt || 'New Session'}
 								onmouseenter={() => tipEnter(session.id)}
 								onmouseleave={tipLeave}
 								onmousemove={tipMove}
@@ -523,7 +524,7 @@
 						<div class="header-meta">
 							<span class="status-label" style="color: {getSessionStatusColor(session.status)}">{getSessionStatusLabel(session.status, session.pendingToolName)}</span>
 							<span class="separator">·</span>
-							<span class="session-name-badge">{session.sessionName}</span>
+							<span class="session-name-badge" title={session.sessionName}>{session.sessionName}</span>
 							<span class="separator">·</span>
 							<span class="message-count">{#if conversation && conversation.messages.length > BATCH_SIZE}{sw.startIndex + 1}–{sw.endIndex} / {/if}{conversation?.messages.length ?? 0} messages</span>
 							{#if loadLabel}
@@ -1097,6 +1098,7 @@
 		display: flex;
 		align-items: center;
 		gap: var(--space-sm);
+		min-width: 0;
 	}
 
 	.copy-id-btn {
@@ -1155,6 +1157,7 @@
 		text-overflow: ellipsis;
 		white-space: nowrap;
 		max-width: 500px;
+		min-width: 0;
 	}
 
 	.session-name-badge {
@@ -1167,6 +1170,10 @@
 		border: 1px solid var(--border-default);
 		text-transform: uppercase;
 		letter-spacing: 0.1em;
+		overflow: hidden;
+		text-overflow: ellipsis;
+		white-space: nowrap;
+		max-width: 180px;
 	}
 
 	.cost-breakdown {
@@ -1446,7 +1453,8 @@
 		overflow: hidden;
 		text-overflow: ellipsis;
 		white-space: nowrap;
-		max-width: 200px;
+		max-width: min(280px, 40vw);
+		min-width: 0;
 	}
 
 	.header-meta {
@@ -1638,7 +1646,7 @@
 		}
 
 		.project-name {
-			font-size: 13px;
+			font-size: 14px;
 			max-width: none;
 		}
 
@@ -1646,6 +1654,11 @@
 			flex-wrap: wrap;
 			font-size: 11px;
 			gap: var(--space-xs);
+		}
+
+		.session-name-badge,
+		.branch-name {
+			max-width: 100%;
 		}
 
 		.header-actions {
@@ -1657,18 +1670,24 @@
 		}
 
 		.header-button {
-			width: 28px;
-			height: 28px;
+			width: var(--touch-min);
+			height: var(--touch-min);
 		}
 
 		.close-button {
-			width: 28px;
-			height: 28px;
+			width: var(--touch-min);
+			height: var(--touch-min);
+		}
+
+		.copy-id-btn {
+			opacity: 0.55;
+			width: 32px;
+			height: 32px;
 		}
 
 		.conversation-area {
 			padding: var(--space-md);
-			padding-bottom: 72px; /* Space for FAB */
+			padding-bottom: calc(72px + var(--safe-bottom));
 		}
 
 		/* ── FAB (Floating Action Button) ────────────── */
@@ -1677,8 +1696,8 @@
 			align-items: center;
 			justify-content: center;
 			position: fixed;
-			bottom: 20px;
-			right: 20px;
+			bottom: max(20px, var(--safe-bottom));
+			right: max(20px, var(--safe-right));
 			width: 48px;
 			height: 48px;
 			background: var(--bg-card);
@@ -1726,6 +1745,7 @@
 			right: 0;
 			bottom: 0;
 			height: 55vh;
+			padding-bottom: var(--safe-bottom);
 			background: var(--bg-card);
 			border-top: 1px solid var(--border-default);
 			z-index: 1030;

--- a/src/lib/components/ExpandedCardOverlay.svelte
+++ b/src/lib/components/ExpandedCardOverlay.svelte
@@ -1612,7 +1612,7 @@
 	}
 
 	/* ── Mobile Responsive ─────────────────────────────────────── */
-	@media (max-width: 768px) {
+	@media (max-width: 768px), (orientation: landscape) and (max-height: 500px) {
 		.side-resizer { display: none; }
 		.overlay-backdrop {
 			padding: 0;

--- a/src/lib/components/HistoryCardOverlay.svelte
+++ b/src/lib/components/HistoryCardOverlay.svelte
@@ -692,7 +692,7 @@
 	}
 
 	/* ── Mobile Responsive ─────────────────────────────────────── */
-	@media (max-width: 768px) {
+	@media (max-width: 768px), (orientation: landscape) and (max-height: 500px) {
 		.overlay-backdrop {
 			padding: 0;
 		}

--- a/src/lib/components/HistoryCardOverlay.svelte
+++ b/src/lib/components/HistoryCardOverlay.svelte
@@ -225,7 +225,7 @@
 					<div class="header-info">
 						<div class="header-title">
 							<ProviderBadge provider={entry.provider} surface={entry.surface} />
-							<h2 id="overlay-title" class="project-name">{entry.customTitle || entry.codexTitle || entry.cursorTitle || entry.projectName}</h2>
+							<h2 id="overlay-title" class="project-name" title={entry.customTitle || entry.codexTitle || entry.cursorTitle || entry.projectName}>{entry.customTitle || entry.codexTitle || entry.cursorTitle || entry.projectName}</h2>
 						</div>
 						<div class="header-meta">
 							<span class="message-count">{#if conversation && conversation.messages.length > BATCH_SIZE}{sw.startIndex + 1}–{sw.endIndex} / {/if}{conversation?.messages.length ?? 0} messages</span>
@@ -448,6 +448,7 @@
 		display: flex;
 		align-items: center;
 		gap: var(--space-md);
+		min-width: 0;
 	}
 
 	.project-name {
@@ -461,6 +462,7 @@
 		text-overflow: ellipsis;
 		white-space: nowrap;
 		max-width: 300px;
+		min-width: 0;
 	}
 
 	.header-meta {
@@ -722,7 +724,7 @@
 		}
 
 		.project-name {
-			font-size: 13px;
+			font-size: 14px;
 			max-width: none;
 		}
 
@@ -747,18 +749,18 @@
 		}
 
 		.header-button {
-			width: 28px;
-			height: 28px;
+			width: var(--touch-min);
+			height: var(--touch-min);
 		}
 
 		.close-button {
-			width: 28px;
-			height: 28px;
+			width: var(--touch-min);
+			height: var(--touch-min);
 		}
 
 		.conversation-area {
 			padding: var(--space-md);
-			padding-bottom: 72px; /* Space for FAB */
+			padding-bottom: calc(72px + var(--safe-bottom));
 		}
 
 		/* ── FAB (Floating Action Button) ────────────── */
@@ -767,8 +769,8 @@
 			align-items: center;
 			justify-content: center;
 			position: fixed;
-			bottom: 20px;
-			right: 20px;
+			bottom: max(20px, var(--safe-bottom));
+			right: max(20px, var(--safe-right));
 			width: 48px;
 			height: 48px;
 			background: var(--bg-card);
@@ -816,6 +818,7 @@
 			right: 0;
 			bottom: 0;
 			height: 55vh;
+			padding-bottom: var(--safe-bottom);
 			background: var(--bg-card);
 			border-top: 1px solid var(--border-default);
 			z-index: 1030;

--- a/src/lib/components/SessionCard.svelte
+++ b/src/lib/components/SessionCard.svelte
@@ -194,6 +194,7 @@
 			<!-- svelte-ignore a11y_no_static_element_interactions -->
 			<h3
 				class="card-main-title"
+				title={cardTitle}
 				onmouseenter={() => tipEnter(session.id)}
 				onmouseleave={tipLeave}
 				onmousemove={tipMove}
@@ -228,7 +229,7 @@
 			<div class="stats-row">
 				<div class="badge-group">
 					<ProviderBadge provider={session.provider} surface={session.surface} {compact} />
-					<span class="session-name-badge">{session.sessionName}</span>
+					<span class="session-name-badge" title={session.sessionName}>{session.sessionName}</span>
 				{#if PM_ORCHESTRATION_ENABLED && session.workerOf && !workersView}
 					<!-- svelte-ignore a11y_no_static_element_interactions -->
 					<span
@@ -286,7 +287,7 @@
 						<circle cx="6" cy="18" r="3" />
 						<path d="M18 9a9 9 0 0 1-9 9" />
 					</svg>
-					<span class="branch-name">{session.gitBranch}</span>
+					<span class="branch-name" title={session.gitBranch}>{session.gitBranch}</span>
 				</div>
 			{/if}
 
@@ -385,6 +386,7 @@
 		display: flex;
 		align-items: center;
 		gap: var(--space-sm);
+		min-width: 0;
 	}
 
 	.card-main-title {
@@ -401,6 +403,8 @@
 		line-clamp: 2;
 		-webkit-box-orient: vertical;
 		cursor: default;
+		min-width: 0;
+		flex: 1;
 	}
 
 	.copy-id-btn {
@@ -548,7 +552,7 @@
 		white-space: nowrap;
 		text-overflow: ellipsis;
 		min-width: 0;
-		max-width: 200px;
+		max-width: min(280px, 100%);
 	}
 
 	.time-badge {
@@ -747,39 +751,136 @@
 		border-radius: 4px;
 	}
 
+	/* Coarse pointers (phones): keep the copy control visible without hover */
+	@media (hover: none) {
+		.copy-id-btn {
+			opacity: 0.55;
+			width: 32px;
+			height: 32px;
+		}
+	}
+
 	/* ── Mobile Responsive ─────────────────────────────────────── */
 	@media (max-width: 768px) {
 		.session-card {
 			height: auto;
-			min-height: auto;
-			padding: var(--space-md);
+			min-height: 0;
+			padding: 14px;
+			gap: var(--space-md);
+		}
+
+		.card-body {
+			gap: 10px;
 		}
 
 		.card-main-title {
-			font-size: 13px;
+			font-size: 15px;
+			letter-spacing: 0.02em;
+			line-height: 1.35;
 		}
 
 		.stats-row {
+			flex-direction: column;
+			align-items: stretch;
+			flex-wrap: nowrap;
+			gap: 8px;
+		}
+
+		.badge-group {
 			flex-wrap: wrap;
-			gap: var(--space-xs);
+			max-width: 100%;
 		}
 
 		.session-name-badge {
-			max-width: 60%;
+			max-width: 100%;
+		}
+
+		.stats-group {
+			flex-wrap: wrap;
+			justify-content: flex-start;
+			gap: var(--space-sm) var(--space-md);
+		}
+
+		.git-branch {
+			width: 100%;
 		}
 
 		.branch-name {
-			max-width: 150px;
+			max-width: none;
+			flex: 1;
+		}
+
+		.status-label {
+			font-size: 12px;
 		}
 
 		.task-preview {
 			font-size: 13px;
-			-webkit-line-clamp: 2;
-			line-clamp: 2;
+			line-height: 1.45;
+			-webkit-line-clamp: 3;
+			line-clamp: 3;
+			margin: 0;
+		}
+
+		.card-actions-container {
+			justify-content: stretch;
+			padding-top: var(--space-md);
 		}
 
 		.card-actions {
-			flex-wrap: wrap;
+			width: 100%;
+			flex-wrap: nowrap;
+			gap: var(--space-sm);
+		}
+
+		.action-btn {
+			flex: 1;
+			min-height: var(--touch-min);
+			min-width: 0;
+			justify-content: center;
+			padding: 10px 12px;
+			font-size: 11px;
+			gap: 8px;
+		}
+
+		.session-card.compact {
+			padding: 12px 14px;
+		}
+
+		.session-card.compact .card-body {
+			padding-right: 48px;
+		}
+
+		.compact-actions .action-btn {
+			min-width: var(--touch-min);
+			min-height: var(--touch-min);
+			width: var(--touch-min);
+			height: var(--touch-min);
+		}
+	}
+
+	/* Landscape phones: keep cards shorter so more sessions fit */
+	@media (max-width: 768px) and (orientation: landscape) {
+		.session-card {
+			padding: 10px 12px;
+		}
+
+		.card-body {
+			gap: 6px;
+		}
+
+		.task-preview {
+			-webkit-line-clamp: 1;
+			line-clamp: 1;
+		}
+
+		.card-actions-container {
+			padding-top: var(--space-sm);
+		}
+
+		.action-btn {
+			min-height: 40px;
+			padding: 8px 10px;
 		}
 	}
 

--- a/src/lib/components/SessionCard.svelte
+++ b/src/lib/components/SessionCard.svelte
@@ -761,7 +761,7 @@
 	}
 
 	/* ── Mobile Responsive ─────────────────────────────────────── */
-	@media (max-width: 768px) {
+	@media (max-width: 768px), (orientation: landscape) and (max-height: 500px) {
 		.session-card {
 			height: auto;
 			min-height: 0;
@@ -860,7 +860,7 @@
 	}
 
 	/* Landscape phones: keep cards shorter so more sessions fit */
-	@media (max-width: 768px) and (orientation: landscape) {
+	@media (orientation: landscape) and (max-height: 500px) {
 		.session-card {
 			padding: 10px 12px;
 		}

--- a/src/lib/components/StatusBar.svelte
+++ b/src/lib/components/StatusBar.svelte
@@ -255,7 +255,7 @@
 	}
 
 	/* ── Mobile Responsive ─────────────────────────────────────── */
-	@media (max-width: 768px) {
+	@media (max-width: 768px), (orientation: landscape) and (max-height: 500px) {
 		.system-status-bar {
 			padding: var(--space-md);
 			gap: var(--space-sm);
@@ -279,7 +279,7 @@
 		}
 	}
 
-	@media (max-width: 768px) and (orientation: landscape) {
+	@media (orientation: landscape) and (max-height: 500px) {
 		.system-status-bar {
 			padding: var(--space-sm) var(--space-md);
 			gap: 6px;

--- a/src/lib/components/StatusBar.svelte
+++ b/src/lib/components/StatusBar.svelte
@@ -258,10 +258,16 @@
 	@media (max-width: 768px) {
 		.system-status-bar {
 			padding: var(--space-md);
+			gap: var(--space-sm);
 		}
 
 		.legend {
-			gap: var(--space-md);
+			flex-wrap: wrap;
+			gap: var(--space-sm) var(--space-lg);
+		}
+
+		.legend-item {
+			gap: 6px;
 		}
 
 		.legend-item .label {
@@ -270,6 +276,17 @@
 
 		.legend-item .count {
 			font-size: 13px;
+		}
+	}
+
+	@media (max-width: 768px) and (orientation: landscape) {
+		.system-status-bar {
+			padding: var(--space-sm) var(--space-md);
+			gap: 6px;
+		}
+
+		.progress-track {
+			height: 12px;
 		}
 	}
 

--- a/src/lib/demo/data.ts
+++ b/src/lib/demo/data.ts
@@ -78,7 +78,7 @@ export function getDemoSessions(): Session[] {
 			sessionName: 'web-app',
 			customTitle: null,
 			projectPath: '/Users/demo/projects/web-app',
-			gitBranch: 'feat/auth-flow',
+			gitBranch: 'feat/oauth2-google-github-provider-callback-handler',
 			firstPrompt: 'Add OAuth2 login with Google and GitHub providers',
 			summary: 'Implementing OAuth2 authentication flow with multiple providers',
 			messageCount: 34,

--- a/src/routes/(app)/+page.svelte
+++ b/src/routes/(app)/+page.svelte
@@ -1333,7 +1333,7 @@
 	}
 
 	/* ── Mobile Responsive ─────────────────────────────────────── */
-	@media (max-width: 768px) {
+	@media (max-width: 768px), (orientation: landscape) and (max-height: 500px) {
 		.tab-bar {
 			height: 48px;
 			overflow-x: auto;
@@ -1454,7 +1454,7 @@
 	}
 
 	/* Landscape phones: use the extra width for cards / status columns */
-	@media (max-width: 768px) and (orientation: landscape) {
+	@media (orientation: landscape) and (max-height: 500px) {
 		.tab-bar {
 			height: 40px;
 		}
@@ -1482,12 +1482,13 @@
 
 		.status-groups {
 			flex-direction: row;
-			overflow-x: auto;
+			overflow-x: visible;
 			padding-bottom: var(--space-sm);
 		}
 
 		.status-group {
-			min-width: 260px;
+			min-width: 0;
+			flex: 1 1 0;
 			max-width: none;
 		}
 

--- a/src/routes/(app)/+page.svelte
+++ b/src/routes/(app)/+page.svelte
@@ -15,6 +15,7 @@
 	import { toolsLoadedFor, withConversationLoader } from '$lib/stores/conversation-loader';
 	import { get } from 'svelte/store';
 	import { isDemoMode, toggleDemoMode } from '$lib/demo';
+	import { isPersistedDemoMode } from '$lib/demo/mode';
 	import { PM_ORCHESTRATION_ENABLED } from '$lib/feature-flags';
 	import { isTauri } from '$lib/ws';
 	import StatusBar from '$lib/components/StatusBar.svelte';
@@ -69,6 +70,15 @@
 
 	onMount(() => {
 		if (browser) {
+			if (!isTauri()) {
+				const wantDemo =
+					new URLSearchParams(window.location.search).get('demo') === '1' ||
+					isPersistedDemoMode();
+				if (wantDemo) {
+					needsConnection = false;
+					if (!get(isDemoMode)) toggleDemoMode();
+				}
+			}
 			const saved = localStorage.getItem('sessionViewMode');
 			if (saved === 'project' || saved === 'all') {
 				viewMode = saved;
@@ -440,7 +450,7 @@
 {#if needsConnection}
 	<ConnectionScreen onconnected={() => (needsConnection = false)} />
 {:else}
-<div class="dashboard">
+<div class="dashboard" class:runtime-web={!isTauri()}>
 	<FdaBanner {fdaLikelyNeeded} />
 	<div class="tab-bar" class:fullscreen={isFullscreen} data-tauri-drag-region>
 		<button
@@ -679,7 +689,7 @@
 						{@const baseIdx = projectOffsets[gi] ?? 0}
 						<section class="project-section" in:flyIn|global={{ index: baseIdx }} animate:flip={{ duration: 400 }}>
 							<div class="project-header">
-								<span class="project-name">{group.displayName}</span>
+								<span class="project-name" title={group.path}>{group.displayName}</span>
 								<span class="project-count">
 									{group.attention.length + group.idle.length + group.working.length}
 								</span>
@@ -994,6 +1004,10 @@
 		text-transform: uppercase;
 		letter-spacing: 0.1em;
 		line-height: 1;
+		min-width: 0;
+		overflow: hidden;
+		text-overflow: ellipsis;
+		white-space: nowrap;
 	}
 
 	.project-count {
@@ -1321,15 +1335,54 @@
 	/* ── Mobile Responsive ─────────────────────────────────────── */
 	@media (max-width: 768px) {
 		.tab-bar {
-			height: 28px;
+			height: 48px;
+			overflow-x: auto;
+			overflow-y: hidden;
+			-webkit-overflow-scrolling: touch;
+			scrollbar-width: none;
+			padding-left: var(--space-md);
+			padding-right: var(--space-md);
+		}
+
+		.tab-bar.fullscreen {
+			padding-left: var(--space-md);
 		}
 
 		.tab-btn {
+			display: flex;
+			flex-shrink: 0;
+			min-height: var(--touch-min);
+			padding: 0 10px;
+		}
+
+		.tab-label {
+			font-size: 9px;
+		}
+
+		.tab-drag-region {
+			flex: 0 0 0;
+			min-width: 0;
+			overflow: hidden;
+		}
+
+		.drag-dots {
+			display: none;
+		}
+
+		.runtime-web .tab-bar {
+			padding-top: var(--safe-top);
+			padding-left: max(var(--space-sm), var(--safe-left));
+			padding-right: max(var(--space-sm), var(--safe-right));
+			height: calc(48px + var(--safe-top));
+		}
+
+		.runtime-web .tab-drag-region {
 			display: none;
 		}
 
 		.grid-container {
 			padding: var(--space-md);
+			padding-bottom: max(var(--space-md), var(--safe-bottom));
 		}
 
 		.sections-container {
@@ -1339,17 +1392,19 @@
 		.project-header {
 			flex-wrap: wrap;
 			gap: var(--space-sm);
+			row-gap: 10px;
 		}
 
 		.project-name {
 			font-size: 16px;
+			max-width: 100%;
 		}
 
 		.project-count {
 			font-size: 14px;
 		}
 
-		/* Stack status groups vertically on mobile */
+		/* Stack status groups vertically in portrait */
 		.status-groups {
 			flex-direction: column;
 			overflow-x: visible;
@@ -1375,12 +1430,77 @@
 		}
 
 		.toggle-btn {
-			width: 32px;
-			height: 32px;
+			width: var(--touch-min);
+			height: var(--touch-min);
+			min-width: var(--touch-min);
+			min-height: var(--touch-min);
 		}
 
-		.demo-toggle {
-			padding: 0 var(--space-xs);
+		.demo-toggle,
+		.mobile-connect-btn {
+			padding: 0 var(--space-sm);
+			min-width: 0;
+		}
+
+		.rename-hint-modal {
+			max-width: calc(100vw - 32px);
+			margin: var(--space-md);
+		}
+
+		.rename-hint-close {
+			min-height: var(--touch-min);
+			padding: 10px 24px;
+		}
+	}
+
+	/* Landscape phones: use the extra width for cards / status columns */
+	@media (max-width: 768px) and (orientation: landscape) {
+		.tab-bar {
+			height: 40px;
+		}
+
+		.runtime-web .tab-bar {
+			height: calc(40px + var(--safe-top));
+		}
+
+		.tab-btn {
+			min-height: 36px;
+		}
+
+		.grid-container {
+			padding: var(--space-sm) var(--space-md);
+		}
+
+		.sections-container {
+			gap: var(--space-lg);
+		}
+
+		.project-header {
+			padding-bottom: var(--space-sm);
+			margin-bottom: var(--space-sm);
+		}
+
+		.status-groups {
+			flex-direction: row;
+			overflow-x: auto;
+			padding-bottom: var(--space-sm);
+		}
+
+		.status-group {
+			min-width: 260px;
+			max-width: none;
+		}
+
+		.all-sessions-grid,
+		.all-sessions-grid.compact {
+			grid-template-columns: repeat(2, minmax(0, 1fr));
+		}
+
+		.toggle-btn {
+			width: 36px;
+			height: 36px;
+			min-width: 36px;
+			min-height: 36px;
 		}
 	}
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Description

Incremental CSS/layout polish for the mobile web client from PR #6. Addresses the main pain points in #15 without rewriting the Svelte/web architecture or changing the desktop Tauri layout.

**Cards (narrow screens)**
- Auto-height cards with stacked stats: badges on one row, message/cost/time on the next
- Long titles, session names, and git branches ellipsize against the card width (no more 150px cap)
- Full path available via `title` on project headers
- Copy-session-id stays visible on coarse pointers (no hover required)

**Touch targets**
- Card actions stretch to full width with 44px min height
- Overlay close/action buttons and compact-view icons match

**Chrome**
- Tab bar is usable again on mobile (it was `display: none` below 768px) and scrolls horizontally
- Web runtime drops the 80px macOS traffic-light padding and drag handle
- Safe-area insets + `viewport-fit=cover` for notched phones
- Status legend wraps; connection screen inputs stay 16px to avoid iOS zoom

**Portrait vs landscape**
- Portrait (`max-width: 768px`): single-column cards, stacked status groups, scrollable tabs
- Landscape phones (`max-height: 500px`): compact cards, two-column “all sessions” grid, shared-width status columns
- Landscape uses `max-height` rather than `max-width: 768px`, because a typical phone landscape viewport is ~844×390

Desktop (`min-width: 769px` and tall windows) is unchanged aside from slightly more generous branch ellipsis (`min(280px, 100%)`).

Web preview without a desktop WS: `/?demo=1`

## Type of Change

- [x] New feature (non-breaking change that adds functionality)
- [x] Other (please describe): mobile CSS/UX refinement

## Motivation and Context

Fixes #15

PR #6 shipped a working mobile web client with basic `flex-wrap` / `max-width` rules. Cards still felt cramped: stats collided, actions were 4×8px, long branches truncated at 150px, and the tab bar disappeared entirely under 768px.

## How Has This Been Tested?

- [x] Tested in development mode (`npm run dev` + `/?demo=1`, Chrome device mode 390×844 and 844×390)
- [ ] Tested in development mode (`npm run tauri dev`)
- [ ] Tested production build (`npm run tauri build`)
- [ ] Tested on macOS (version: )
- [x] Tested on Linux (distro: cloud agent / Chromium)
- [ ] Tested on Windows (version: )
- [x] `npx svelte-check` — 0 errors

## Screenshots

**After — portrait (390×844):** stacked card stats, truncated long branch, full-width 44px actions, tab bar visible again.

[Mobile portrait session cards](https://cursor.com/agents/bc-ffe35eff-8a18-4f70-8e02-044ad3ef9ec7/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fmobile_portrait_session_cards.webp)

**After — conversation overlay on phone:** full-bleed overlay, truncated title/branch, no desktop sidebar.

[Mobile conversation overlay](https://cursor.com/agents/bc-ffe35eff-8a18-4f70-8e02-044ad3ef9ec7/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fmobile_portrait_conversation_overlay.webp)

**After — landscape (844×390):** compact chrome; Show All uses two card columns.

[Mobile landscape two-column grid](https://cursor.com/agents/bc-ffe35eff-8a18-4f70-8e02-044ad3ef9ec7/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fmobile_landscape_two_column_grid.webp)

**Desktop unchanged (1280×800):** three-column status board, compact action buttons (not full-width).

[Desktop three-column layout](https://cursor.com/agents/bc-ffe35eff-8a18-4f70-8e02-044ad3ef9ec7/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fdesktop_three_column_unchanged.webp)

### Before (PR #6 baseline, for comparison)

- Stats + badges wrapped onto one cramped row
- Branch names hard-capped at `max-width: 150px`
- Action buttons `4px 8px` / 10px type
- All `.tab-btn { display: none }` under 768px
- Landscape phones (~844px wide) still used the desktop card height and 3–4 column grid

## Checklist

- [x] My code follows the project's style guidelines
- [ ] I have run `cargo fmt` and `cargo clippy` on Rust code
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings
- [x] My commit messages follow the [Conventional Commits](https://www.conventionalcommits.org/) format

## Additional Notes

No Rust changes. Scope is existing Svelte components + `app.css` / `app.html`.


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-ffe35eff-8a18-4f70-8e02-044ad3ef9ec7?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ffe35eff-8a18-4f70-8e02-044ad3ef9ec7&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

